### PR TITLE
feat: #49 Handle redeemers as map in Conway era

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/Redeemer.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/Redeemer.java
@@ -7,6 +7,7 @@ import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.plutus.spec.ExUnits;
 import com.bloxbean.cardano.client.plutus.spec.RedeemerTag;
+import com.bloxbean.cardano.yaci.core.exception.CborRuntimeException;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import lombok.*;
@@ -25,7 +26,7 @@ public class Redeemer {
     private ExUnits exUnits;
     private String cbor;
 
-    public static Redeemer deserialize(Array redeemerDI)
+    public static Redeemer deserializePreConway(Array redeemerDI)
             throws CborDeserializationException, CborException {
         List<DataItem> redeemerDIList = redeemerDI.getDataItems();
         if (redeemerDIList == null || redeemerDIList.size() != 4) {
@@ -38,10 +39,47 @@ public class Redeemer {
         DataItem dataDI = redeemerDIList.get(2);
         DataItem exUnitDI = redeemerDIList.get(3);
 
+        return getRedeemer(redeemerDI, (UnsignedInteger) tagDI, (UnsignedInteger) indexDI, dataDI, (Array) exUnitDI);
+    }
+
+    @SneakyThrows
+    public static Redeemer deserialize(Array keyDI, Array valueDI) { //Conway era
+        List<DataItem> keyDIList = keyDI.getDataItems();
+        List<DataItem> valueDIList = valueDI.getDataItems();
+
+        if (keyDIList == null || keyDIList.size() != 2) {
+            throw new CborRuntimeException(
+                    "Redeemer deserialization error. Invalid no of DataItems in key");
+        }
+
+        if (valueDIList == null || valueDIList.size() != 2) {
+            throw new CborRuntimeException(
+                    "Redeemer deserialization error. Invalid no of DataItems in value");
+        }
+
+        DataItem tagDI = keyDIList.get(0);
+        DataItem indexDI = keyDIList.get(1);
+        DataItem dataDI = valueDIList.get(0);
+        DataItem exUnitDI = valueDIList.get(1);
+
+        //TODO -- Cbor hex is a hack. It creates an array with all fields and then serializes it.
+        //This is added to make it work with the existing code in client applications. Need to fix this.
+        Array redeemerDI = new Array();
+        redeemerDI.add(tagDI);
+        redeemerDI.add(indexDI);
+        redeemerDI.add(dataDI);
+        redeemerDI.add(exUnitDI);
+
+        return getRedeemer(redeemerDI, (UnsignedInteger) tagDI, (UnsignedInteger) indexDI, dataDI, (Array) exUnitDI);
+
+    }
+
+    private static Redeemer getRedeemer(Array redeemerDI, UnsignedInteger tagDI, UnsignedInteger indexDI,
+                                        DataItem dataDI, Array exUnitDI) throws CborDeserializationException, CborException {
         Redeemer redeemer = new Redeemer();
 
         // Tag
-        int tagValue = ((UnsignedInteger) tagDI).getValue().intValue();
+        int tagValue = tagDI.getValue().intValue();
         if (tagValue == 0) {
             redeemer.setTag(RedeemerTag.Spend);
         } else if (tagValue == 1) {
@@ -53,17 +91,16 @@ public class Redeemer {
         }
 
         // Index
-        redeemer.setIndex(((UnsignedInteger) indexDI).getValue().intValue());
+        redeemer.setIndex(indexDI.getValue().intValue());
 
         // Redeemer data
         redeemer.setData(Datum.from(dataDI));
 
         // Redeemer resource usage (ExUnits)
-        redeemer.setExUnits(ExUnits.deserialize((Array) exUnitDI));
+        redeemer.setExUnits(ExUnits.deserialize(exUnitDI));
 
         //cbor
         redeemer.setCbor(HexUtil.encodeHexString(CborSerializationUtil.serialize(redeemerDI, false)));
-
         return redeemer;
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/serializers/util/WitnessUtil.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/serializers/util/WitnessUtil.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.AdditionalInformation;
 import co.nstant.in.cbor.model.Special;
 import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.util.Tuple;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
@@ -85,6 +86,37 @@ public final class WitnessUtil {
         }
 
         return witnessMap;
+    }
+
+    //Conway era
+    public static List<Tuple<byte[], byte[]>> getRedeemerMapBytes(byte[] redeemerBytes)
+            throws CborException {
+        var redeemerList = new ArrayList<Tuple<byte[], byte[]>>();
+
+        ByteArrayInputStream stream = new ByteArrayInputStream(redeemerBytes);
+        CborDecoder decoder = new CborDecoder(stream);
+
+        stream.read();
+
+        while (stream.available() > 0) {
+            int keyStartFrom = redeemerBytes.length - stream.available();
+            int previousAvailable = stream.available();
+            var keyDI = decoder.decodeNext();
+            int currentAvailable = stream.available();
+            final byte[] keyBytes = new byte[previousAvailable - currentAvailable];
+            System.arraycopy(redeemerBytes, keyStartFrom, keyBytes, 0, keyBytes.length);
+
+            int valueStartFrom = redeemerBytes.length - stream.available();
+            previousAvailable = stream.available();
+            var valueDI = decoder.decodeNext();
+            currentAvailable = stream.available();
+            final byte[] valueBytes = new byte[previousAvailable - currentAvailable];
+            System.arraycopy(redeemerBytes, valueStartFrom, valueBytes, 0, valueBytes.length);
+
+            redeemerList.add(new Tuple<>(keyBytes, valueBytes));
+        }
+
+        return redeemerList;
     }
 
     /**

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/model/serializers/WitnessUtilTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/model/serializers/WitnessUtilTest.java
@@ -1,0 +1,151 @@
+package com.bloxbean.cardano.yaci.core.model.serializers;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.client.plutus.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ExUnits;
+import com.bloxbean.cardano.client.plutus.spec.RedeemerTag;
+import com.bloxbean.cardano.yaci.core.model.Redeemer;
+import com.bloxbean.cardano.yaci.core.model.serializers.util.WitnessUtil;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yaci.core.util.Tuple;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WitnessUtilTest {
+
+    @Test
+    void getRedeemerMapBytes() throws Exception {
+
+        var redeemerTuple1 = createRedeemerKeyValue(2, 1, new BigIntPlutusData(BigInteger.valueOf(777000)),
+                BigInteger.valueOf(22000), BigInteger.valueOf(33000));
+        var redeemerTuple2 = createRedeemerKeyValue(3, 0, new BigIntPlutusData(BigInteger.valueOf(1000)),
+                BigInteger.valueOf(2000), BigInteger.valueOf(3000));
+
+        co.nstant.in.cbor.model.Map redeemerMap = new co.nstant.in.cbor.model.Map();
+        redeemerMap.put(redeemerTuple1._1, redeemerTuple1._2);
+        redeemerMap.put(redeemerTuple2._1, redeemerTuple2._2);
+
+        var redeemerBytes = CborSerializationUtil.serialize(redeemerMap);
+        System.out.println("Redeemer bytes: " + HexUtil.encodeHexString(redeemerBytes));
+
+        List<Tuple<byte[], byte[]>> deRedeemerList = WitnessUtil.getRedeemerMapBytes(redeemerBytes);
+
+        List<Redeemer> redeemers = new ArrayList<>();
+        for (var redeemerTuple : deRedeemerList) {
+            var keyArrayDI = (Array) CborSerializationUtil.deserializeOne(redeemerTuple._1);
+            var valueArrayDI = (Array) CborSerializationUtil.deserializeOne(redeemerTuple._2);
+
+            Redeemer redeemer = Redeemer.deserialize(keyArrayDI, valueArrayDI);
+            redeemers.add(redeemer);
+        }
+
+        assertThat(redeemers.size()).isEqualTo(2);
+        assertThat(redeemers.get(0).getTag()).isEqualTo(RedeemerTag.Cert);
+        assertThat(redeemers.get(0).getIndex()).isEqualTo(1);
+        assertThat(redeemers.get(0).getData().getCbor()).isEqualTo(BigIntPlutusData.of(777000).serializeToHex());
+        assertThat(redeemers.get(0).getExUnits().getMem()).isEqualTo(BigInteger.valueOf(22000));
+        assertThat(redeemers.get(0).getExUnits().getSteps()).isEqualTo(BigInteger.valueOf(33000));
+
+        assertThat(redeemers.get(1).getTag()).isEqualTo(RedeemerTag.Reward);
+        assertThat(redeemers.get(1).getIndex()).isEqualTo(0);
+        assertThat(redeemers.get(1).getData().getCbor()).isEqualTo(BigIntPlutusData.of(1000).serializeToHex());
+        assertThat(redeemers.get(1).getExUnits().getMem()).isEqualTo(BigInteger.valueOf(2000));
+        assertThat(redeemers.get(1).getExUnits().getSteps()).isEqualTo(BigInteger.valueOf(3000));
+
+    }
+
+    @Test
+    @SneakyThrows
+    void getArrayBytes() {
+        var redeemer1 = createRedeemerArray(2, 1, new BigIntPlutusData(BigInteger.valueOf(777000)),
+                BigInteger.valueOf(22000), BigInteger.valueOf(33000));
+        var redeemer2 = createRedeemerArray(3, 0, new BigIntPlutusData(BigInteger.valueOf(1000)),
+                BigInteger.valueOf(2000), BigInteger.valueOf(3000));
+
+        Array redeemerArray = new Array();
+        redeemerArray.add(redeemer1);
+        redeemerArray.add(redeemer2);
+
+        var redeemerBytes = CborSerializationUtil.serialize(redeemerArray);
+
+        var deRedeemerBytesList = WitnessUtil.getArrayBytes(redeemerBytes);
+
+        List<Redeemer> redeemers = new ArrayList<>();
+        for (byte[] redeemerByte : deRedeemerBytesList) {
+            var deRedeemerArray = (Array) CborSerializationUtil.deserializeOne(redeemerByte);
+            Redeemer redeemer = Redeemer.deserializePreConway(deRedeemerArray);
+            redeemers.add(redeemer);
+        }
+
+        assertThat(redeemers.size()).isEqualTo(2);
+        assertThat(redeemers.get(0).getTag()).isEqualTo(RedeemerTag.Cert);
+        assertThat(redeemers.get(0).getIndex()).isEqualTo(1);
+        assertThat(redeemers.get(0).getData().getCbor()).isEqualTo(BigIntPlutusData.of(777000).serializeToHex());
+        assertThat(redeemers.get(0).getExUnits().getMem()).isEqualTo(BigInteger.valueOf(22000));
+        assertThat(redeemers.get(0).getExUnits().getSteps()).isEqualTo(BigInteger.valueOf(33000));
+
+        assertThat(redeemers.get(1).getTag()).isEqualTo(RedeemerTag.Reward);
+        assertThat(redeemers.get(1).getIndex()).isEqualTo(0);
+        assertThat(redeemers.get(1).getData().getCbor()).isEqualTo(BigIntPlutusData.of(1000).serializeToHex());
+        assertThat(redeemers.get(1).getExUnits().getMem()).isEqualTo(BigInteger.valueOf(2000));
+        assertThat(redeemers.get(1).getExUnits().getSteps()).isEqualTo(BigInteger.valueOf(3000));
+    }
+
+    @SneakyThrows
+    public static Tuple<Array, Array> createRedeemerKeyValue(int tag, int index, BigIntPlutusData data,
+                                               BigInteger mem, BigInteger steps) {
+        var redeemerTag = new UnsignedInteger(tag);
+        var redeemerIndex = new UnsignedInteger(index);
+
+        var redeemerData = data.serialize();
+
+        ExUnits exUnits = ExUnits.builder()
+                .mem(mem)
+                .steps(steps)
+                .build();
+
+        var exUnitsDI = exUnits.serialize();
+
+        var keyArray = new Array();
+        keyArray.add(redeemerTag);
+        keyArray.add(redeemerIndex);
+
+        var valueArray = new Array();
+        valueArray.add(redeemerData);
+        valueArray.add(exUnitsDI);
+
+        return new Tuple<>(keyArray, valueArray);
+    }
+
+    @SneakyThrows
+    public static Array createRedeemerArray(int tag, int index, BigIntPlutusData data,
+                                               BigInteger mem, BigInteger steps) {
+        var redeemerTag = new UnsignedInteger(tag);
+        var redeemerIndex = new UnsignedInteger(index);
+
+        var redeemerData = data.serialize();
+
+        ExUnits exUnits = ExUnits.builder()
+                .mem(mem)
+                .steps(steps)
+                .build();
+
+        var exUnitsDI = exUnits.serialize();
+
+        Array array = new Array();
+        array.add(redeemerTag);
+        array.add(redeemerIndex);
+        array.add(redeemerData);
+        array.add(exUnitsDI);
+
+        return array;
+    }
+}


### PR DESCRIPTION
- Add implementation to handle redeemers as map in Conway era
- Unit tests

```
; Flat Array support is included for backwards compatibility and will be removed in the next era.
; It is recommended for tools to adopt using a Map instead of Array going forward.
redeemers =
  [ + [ tag: redeemer_tag, index: uint, data: plutus_data, ex_units: ex_units ] ]
  / { + [ tag: redeemer_tag, index: uint ] => [ data: plutus_data, ex_units: ex_units ] }

```