### PR TITLE
feat: #48 Added onParsingError call back to listen to any block parsing error

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/blockfetch/BlockfetchAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/blockfetch/BlockfetchAgent.java
@@ -137,9 +137,17 @@ public class BlockfetchAgent extends Agent<BlockfetchAgentListener> {
         } catch (Exception e) {
             errorBlks++;
             log.error("Error in parsing", e);
-            Array headerArray = (Array) ((Array)array.getDataItems().get(1)).getDataItems().get(0);
-            BlockHeader blockHeader = BlockHeaderSerializer.INSTANCE.getBlockHeaderFromHeaderArray(headerArray);
-            log.error("BlockHeader >> Block No: " + blockHeader.getHeaderBody().getBlockNumber() +", Slot: " + blockHeader.getHeaderBody().getSlot());
+
+            //Catch exception to avoid exception propagation
+            try {
+                Array headerArray = (Array) ((Array) array.getDataItems().get(1)).getDataItems().get(0);
+                BlockHeader blockHeader = BlockHeaderSerializer.INSTANCE.getBlockHeaderFromHeaderArray(headerArray);
+                log.error("BlockHeader >> Block No: " + blockHeader.getHeaderBody().getBlockNumber() + ", Slot: " + blockHeader.getHeaderBody().getSlot());
+            } catch (Exception e1) {
+                log.error("Error in parsing block header", e1);
+            }
+
+            getAgentListeners().stream().forEach(blockfetchAgentListener -> blockfetchAgentListener.onParsingError(e));
         }
     }
 

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/blockfetch/BlockfetchAgentListener.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/blockfetch/BlockfetchAgentListener.java
@@ -35,4 +35,8 @@ public interface BlockfetchAgentListener extends AgentListener {
 
     }
 
+    default void onParsingError(Exception e) {
+
+    }
+
 }

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/listener/BlockChainDataListener.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/listener/BlockChainDataListener.java
@@ -42,4 +42,6 @@ public interface BlockChainDataListener {
     default void intersactNotFound(Tip tip) {}
 
     default void onDisconnect() {}
+
+    default void onParsingError(Exception e) {}
 }

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/listener/BlockFetchAgentListenerAdapter.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/listener/BlockFetchAgentListenerAdapter.java
@@ -131,4 +131,9 @@ public class BlockFetchAgentListenerAdapter implements BlockfetchAgentListener {
     public void onDisconnect() {
         blockChainDataListener.onDisconnect();
     }
+
+    @Override
+    public void onParsingError(Exception e) {
+        blockChainDataListener.onParsingError(e);
+    }
 }


### PR DESCRIPTION
- A new callback method "onParsingError" added to BlockfetchAgentListener and BlockchainDataListener
- Application can listen to this event to stop the process during parse error