### PR TITLE
[RFC] Feat: Making mini protocol components server/client aware

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/Agent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/Agent.java
@@ -17,6 +17,12 @@ public abstract class Agent<T extends AgentListener> {
     private final List<T> agentListeners = new ArrayList<>();
     private AcceptVersion acceptVersion;
 
+    private final boolean isClient;
+
+    public Agent(boolean isClient) {
+        this.isClient = isClient;
+    }
+
     public void setChannel(Channel channel) {
         if (this.channel != null && this.channel.isActive())
             log.warn("An active channel is already attached to this agent");
@@ -25,7 +31,7 @@ public abstract class Agent<T extends AgentListener> {
     }
 
     public void sendRequest(Message message) {
-        if (currenState.hasAgency()) {
+        if (currenState.hasAgency(isClient)) {
             currenState = currenState.nextState(message);
         } else {
             //TODO
@@ -69,7 +75,7 @@ public abstract class Agent<T extends AgentListener> {
     }
 
     public final boolean hasAgency() {
-        return currenState.hasAgency();
+        return currenState.hasAgency(isClient);
     }
 
     public final synchronized void addListener(T agentListener) {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/State.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/State.java
@@ -6,7 +6,7 @@ import java.util.List;
 public interface State {
     State nextState(Message message);
 
-    boolean hasAgency();
+    boolean hasAgency(boolean isClient);
 
     default Message handleInbound(byte[] bytes) {
         return null;

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/blockfetch/BlockfetchAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/blockfetch/BlockfetchAgent.java
@@ -32,6 +32,10 @@ public class BlockfetchAgent extends Agent<BlockfetchAgentListener> {
     private long errorBlks;
 
     public BlockfetchAgent() {
+        this(true);
+    }
+    public BlockfetchAgent(boolean isClient) {
+        super(isClient);
         this.currenState = Idle;
 
         this.startTime = System.currentTimeMillis();

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/blockfetch/BlockfetchState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/blockfetch/BlockfetchState.java
@@ -17,8 +17,8 @@ public enum BlockfetchState implements BlockfetchStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     Busy {
@@ -33,8 +33,8 @@ public enum BlockfetchState implements BlockfetchStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     Streaming {
@@ -49,8 +49,8 @@ public enum BlockfetchState implements BlockfetchStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     Done {
@@ -60,7 +60,7 @@ public enum BlockfetchState implements BlockfetchStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
+        public boolean hasAgency(boolean isClient) {
             return false;
         }
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2c/LocalChainSyncAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2c/LocalChainSyncAgent.java
@@ -21,6 +21,10 @@ public class LocalChainSyncAgent extends Agent<LocalChainSyncAgentListener> {
     private int counter = 0;
 
     public LocalChainSyncAgent(Point[] knownPoints) {
+        this(knownPoints, true);
+    }
+    public LocalChainSyncAgent(Point[] knownPoints, boolean isClient) {
+        super(isClient);
         this.currenState = Idle;
         this.knownPoints = knownPoints;
 
@@ -29,6 +33,10 @@ public class LocalChainSyncAgent extends Agent<LocalChainSyncAgentListener> {
     }
 
     public LocalChainSyncAgent(Point[] knownPoints, long stopSlotNo, int agentNo) {
+        this(knownPoints,stopSlotNo, agentNo, true);
+    }
+    public LocalChainSyncAgent(Point[] knownPoints, long stopSlotNo, int agentNo, boolean isClient) {
+        super(isClient);
         this.currenState = Idle;
         this.knownPoints = knownPoints;
         this.stopAt = stopSlotNo;

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2c/LocalChainSyncState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2c/LocalChainSyncState.java
@@ -21,8 +21,8 @@ public enum LocalChainSyncState implements LocalChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     CanAwait {
@@ -39,8 +39,8 @@ public enum LocalChainSyncState implements LocalChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     MustReply {
@@ -55,8 +55,8 @@ public enum LocalChainSyncState implements LocalChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     Intersect {
@@ -71,8 +71,8 @@ public enum LocalChainSyncState implements LocalChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     Done {
@@ -82,7 +82,7 @@ public enum LocalChainSyncState implements LocalChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
+        public boolean hasAgency(boolean isClient) {
             return false;
         }
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2n/ChainSyncState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2n/ChainSyncState.java
@@ -21,8 +21,8 @@ public enum ChainSyncState implements ChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     CanAwait {
@@ -39,8 +39,8 @@ public enum ChainSyncState implements ChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     MustReply {
@@ -55,8 +55,8 @@ public enum ChainSyncState implements ChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     Intersect {
@@ -71,8 +71,8 @@ public enum ChainSyncState implements ChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     Done {
@@ -82,7 +82,7 @@ public enum ChainSyncState implements ChainSyncStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
+        public boolean hasAgency(boolean isClient) {
             return false;
         }
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2n/ChainsyncAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2n/ChainsyncAgent.java
@@ -23,6 +23,10 @@ public class ChainsyncAgent extends Agent<ChainSyncAgentListener> {
     private long startTime;
 
     public ChainsyncAgent(Point[] knownPoints) {
+        this(knownPoints, true);
+    }
+    public ChainsyncAgent(Point[] knownPoints, boolean isClient) {
+        super(isClient);
         this.currenState = Idle;
         this.knownPoints = knownPoints;
 
@@ -31,6 +35,10 @@ public class ChainsyncAgent extends Agent<ChainSyncAgentListener> {
     }
 
     public ChainsyncAgent(Point[] knownPoints, long stopSlotNo, int agentNo) {
+        this(knownPoints, stopSlotNo, agentNo, true);
+    }
+    public ChainsyncAgent(Point[] knownPoints, long stopSlotNo, int agentNo, boolean isClient) {
+        super(isClient);
         this.currenState = Idle;
         this.knownPoints = knownPoints;
         this.stopAt = stopSlotNo;

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeAgent.java
@@ -14,7 +14,8 @@ import static com.bloxbean.cardano.yaci.core.protocol.handshake.HandshkeState.Pr
 public class HandshakeAgent extends Agent<HandshakeAgentListener> {
     private final VersionTable versionTable;
 
-    public HandshakeAgent(VersionTable versionTable) {
+    public HandshakeAgent(VersionTable versionTable, boolean isClient) {
+        super(isClient);
         this.versionTable = versionTable;
         this.currenState = Propose;
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeAgent.java
@@ -14,6 +14,9 @@ import static com.bloxbean.cardano.yaci.core.protocol.handshake.HandshkeState.Pr
 public class HandshakeAgent extends Agent<HandshakeAgentListener> {
     private final VersionTable versionTable;
 
+    public HandshakeAgent(VersionTable versionTable) {
+        this(versionTable,true);
+    }
     public HandshakeAgent(VersionTable versionTable, boolean isClient) {
         super(isClient);
         this.versionTable = versionTable;

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshkeState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshkeState.java
@@ -10,8 +10,8 @@ public enum HandshkeState implements HandshakeStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     Confirm {
@@ -21,8 +21,8 @@ public enum HandshkeState implements HandshakeStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     Done {
@@ -32,7 +32,7 @@ public enum HandshkeState implements HandshakeStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
+        public boolean hasAgency(boolean isClient) {
             return false;
         }
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/keepalive/KeepAliveAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/keepalive/KeepAliveAgent.java
@@ -21,6 +21,10 @@ public class KeepAliveAgent extends Agent<KeepAliveListener> {
     private Queue<MsgKeepAlive> reqQueue;
 
     public KeepAliveAgent() {
+        this(true);
+    }
+    public KeepAliveAgent(boolean isClient) {
+        super(isClient);
         this.currenState = Client;
         this.reqQueue = new ConcurrentLinkedQueue<>();
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/keepalive/KeepAliveState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/keepalive/KeepAliveState.java
@@ -17,8 +17,8 @@ public enum KeepAliveState implements KeepAliveStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     Server {
@@ -28,8 +28,8 @@ public enum KeepAliveState implements KeepAliveStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     Done {
@@ -39,8 +39,8 @@ public enum KeepAliveState implements KeepAliveStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/LocalStateQueryAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/LocalStateQueryAgent.java
@@ -24,6 +24,10 @@ public class LocalStateQueryAgent extends Agent<LocalStateQueryListener> {
     private Queue<Query> pendingQueryCommands;
 
     public LocalStateQueryAgent() {
+        this(true);
+    }
+    public LocalStateQueryAgent(boolean isClient) {
+        super(isClient);
         this.currenState = Idle;
 
         acquiredCommands = new ConcurrentLinkedQueue<>();

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/LocalStateQueryState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/LocalStateQueryState.java
@@ -20,8 +20,8 @@ public enum LocalStateQueryState implements LocalStateQueryStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
 
         List<Class> allowedMsgTypes = List.of(MsgAcquire.class, MsgDone.class);
@@ -44,8 +44,8 @@ public enum LocalStateQueryState implements LocalStateQueryStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
 
         List<Class> allowedMsgTypes = List.of(MsgAcquired.class, MsgFailure.class);
@@ -70,8 +70,8 @@ public enum LocalStateQueryState implements LocalStateQueryStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
 
         List<Class> allowedMsgTypes = List.of(MsgQuery.class, MsgReAcquire.class, MsgRelease.class);
@@ -92,8 +92,8 @@ public enum LocalStateQueryState implements LocalStateQueryStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
 
         List<Class> allowedMsgTypes = List.of(MsgResult.class);
@@ -111,7 +111,7 @@ public enum LocalStateQueryState implements LocalStateQueryStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
+        public boolean hasAgency(boolean isClient) {
             return false;
         }
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localtx/LocalTxSubmissionAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localtx/LocalTxSubmissionAgent.java
@@ -19,6 +19,10 @@ public class LocalTxSubmissionAgent extends Agent<LocalTxSubmissionListener> {
     private Queue<TxSubmissionRequest> pendingQueue;
 
     public LocalTxSubmissionAgent() {
+        this(true);
+    }
+    public LocalTxSubmissionAgent(boolean isClient) {
+        super(isClient);
         txnQueue = new ConcurrentLinkedQueue<>();
         pendingQueue = new ConcurrentLinkedQueue<>();
         this.currenState = LocalTxSubmissionState.Idle;

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localtx/LocalTxSubmissionState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localtx/LocalTxSubmissionState.java
@@ -20,8 +20,8 @@ public enum LocalTxSubmissionState implements LocalTxSubmissionStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     Busy {
@@ -34,8 +34,8 @@ public enum LocalTxSubmissionState implements LocalTxSubmissionStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     Done {
@@ -45,7 +45,7 @@ public enum LocalTxSubmissionState implements LocalTxSubmissionStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
+        public boolean hasAgency(boolean isClient) {
             return false;
         }
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localtxmonitor/LocalTxMonitorAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localtxmonitor/LocalTxMonitorAgent.java
@@ -19,6 +19,10 @@ public class LocalTxMonitorAgent extends Agent<LocalTxMonitorListener> {
     private Queue<MsgQuery> pendingQueryQueue;
 
     public LocalTxMonitorAgent() {
+        this(true);
+    }
+    public LocalTxMonitorAgent(boolean isClient) {
+        super(isClient);
         this.currenState = Idle;
         this.acquiredCommands = new ConcurrentLinkedQueue<>();
         this.pendingQueryQueue = new ConcurrentLinkedQueue<>();

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localtxmonitor/LocalTxMonitorState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localtxmonitor/LocalTxMonitorState.java
@@ -19,8 +19,8 @@ public enum LocalTxMonitorState implements LocalTxMonitorStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
 
         List<Class> allowedMsgTypes = List.of(MsgAwaitAcquire.class, MsgAcquire.class, MsgDone.class);
@@ -40,8 +40,8 @@ public enum LocalTxMonitorState implements LocalTxMonitorStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
 
         List<Class> allowedMsgTypes = List.of(MsgAcquired.class);
@@ -65,8 +65,8 @@ public enum LocalTxMonitorState implements LocalTxMonitorStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
 
         List<Class> allowedMsgTypes = List.of(MsgAwaitAcquire.class, MsgRelease.class, MsgHasTx.class, MsgNextTx.class, MsgGetSizes.class);
@@ -86,8 +86,8 @@ public enum LocalTxMonitorState implements LocalTxMonitorStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
 
         List<Class> allowedMsgTypes = List.of(MsgReplyHasTx.class, MsgReplyNextTx.class, MsgReplyGetSizes.class);
@@ -104,7 +104,7 @@ public enum LocalTxMonitorState implements LocalTxMonitorStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
+        public boolean hasAgency(boolean isClient) {
             return false;
         }
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionAgent.java
@@ -17,6 +17,10 @@ public class TxSubmissionAgent extends Agent {
     private final List<String> reqNonBlockingTxIds;
 
     public TxSubmissionAgent() {
+        this(true);
+    }
+    public TxSubmissionAgent(boolean isClient) {
+        super(isClient);
         this.currenState = TxSubmissionState.Init;
         txs = new HashMap<>();
         reqTxIds = new ArrayList<>();

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionState.java
@@ -18,8 +18,8 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     Idle {
@@ -35,8 +35,8 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return false;
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
         }
     },
     TxIdsBlocking {
@@ -49,8 +49,8 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     TxIdsNonBlocking {
@@ -63,8 +63,8 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     Txs {
@@ -77,8 +77,8 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
-            return true;
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
         }
     },
     Done {
@@ -88,7 +88,7 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         }
 
         @Override
-        public boolean hasAgency() {
+        public boolean hasAgency(boolean isClient) {
             return false;
         }
     }


### PR DESCRIPTION
Cardano mini protocol is a state machine. Server and client move throughout the state machine at the same time, but just either one of them, and in final states none of them, is supposed to send messages. This is called agency.

Agency depends on state and whether the we are on the client or the server.

In Yaci, the state has been cleverly wrapped in enums, that by design are enumeration. In order to implement the isAgency we need to enhance that method with a parameter that tells whether we are on the client or server side.

Agents will be initialised w/ the isClient property and pass it to State enumeration to properly calculate agency.

This PR represents a Request For Comments where to discuss, accept or push back about the suggested design.

The code is not complete but gives an idea on the implementation.