### PR TITLE
chore: updated netty due to security issues.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [libraries]
 cardano-client-core = "com.bloxbean.cardano:cardano-client-core:0.5.1"
 cbor = "co.nstant.in:cbor:0.9"
-netty = "io.netty:netty-all:4.1.107.Final"
+netty = "io.netty:netty-all:4.1.108.Final"
 project-reactor-core = "io.projectreactor:reactor-core:3.6.3"
 project-reactor-test = "io.projectreactor:reactor-test:3.6.3"
 


### PR DESCRIPTION
Updated netty to fix a security issue.
Can be found here: https://mvnrepository.com/artifact/io.netty/netty-all/4.1.107.Final 

Fixed in version 4.1.108.Final