### PR TITLE
Option to suppress connection info log during n2c connection

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClient.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClient.java
@@ -93,7 +93,8 @@ public abstract class NodeClient {
     }
 
     public void shutdown() {
-        log.info("Shutdown connection !!!");
+        if (showConnectionLog())
+            log.info("Shutdown connection !!!");
 
         if (session != null) {
             session.disableReconnection();
@@ -162,7 +163,8 @@ public abstract class NodeClient {
 
         @Override
         public void disconnected() {
-            log.info("Connection closed !!!");
+            if (showConnectionLog())
+                log.info("Connection closed !!!");
             if (session != null) {
                 session.dispose();
             }
@@ -182,7 +184,12 @@ public abstract class NodeClient {
 
         @Override
         public void connected() {
-            log.info("Connected !!!");
+            if (showConnectionLog())
+                log.info("Connected !!!");
         }
+    }
+
+    private boolean showConnectionLog() {
+        return log.isDebugEnabled() || (handshakeAgent != null && !handshakeAgent.isSuppressConnectionInfoLog());
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yaci.core.network;
 
 import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgent;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -18,12 +19,12 @@ class Session implements Disposable {
     private final Bootstrap clientBootstrap;
     private Channel activeChannel;
     private final AtomicBoolean shouldReconnect; //Not used currently
-    private final Agent handshakeAgent;
+    private final HandshakeAgent handshakeAgent;
     private final Agent[] agents;
 
     private SessionListener sessionListener;
 
-    public Session(SocketAddress socketAddress, Bootstrap clientBootstrap, Agent handshakeAgent, Agent[] agents) {
+    public Session(SocketAddress socketAddress, Bootstrap clientBootstrap, HandshakeAgent handshakeAgent, Agent[] agents) {
         this.socketAddress = socketAddress;
         this.clientBootstrap = clientBootstrap;
         this.shouldReconnect = new AtomicBoolean(true);
@@ -67,7 +68,8 @@ class Session implements Disposable {
 
         connectFuture.addListeners((ChannelFuture cf) -> {
             if (cf.isSuccess()) {
-                log.info("Connection established");
+                if (showConnectionLog())
+                    log.info("Connection established");
                 if (sessionListener != null)
                     sessionListener.connected();
                 //Listen to the channel closing
@@ -96,7 +98,8 @@ class Session implements Disposable {
      */
     @Override
     public void dispose() {
-        log.info("Disposing the session !!!");
+        if (showConnectionLog())
+            log.info("Disposing the session !!!");
       //  try {
             if (activeChannel != null) {
                 activeChannel.close();
@@ -128,5 +131,9 @@ class Session implements Disposable {
 
         if (log.isDebugEnabled())
             log.debug("Handshake successful");
+    }
+
+    private boolean showConnectionLog() {
+        return log.isDebugEnabled() || (handshakeAgent != null && !handshakeAgent.isSuppressConnectionInfoLog());
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeAgent.java
@@ -13,6 +13,7 @@ import static com.bloxbean.cardano.yaci.core.protocol.handshake.HandshkeState.Pr
 @Slf4j
 public class HandshakeAgent extends Agent<HandshakeAgentListener> {
     private final VersionTable versionTable;
+    private boolean suppressConnectionInfoLog = false;
 
     public HandshakeAgent(VersionTable versionTable) {
         this.versionTable = versionTable;
@@ -38,7 +39,8 @@ public class HandshakeAgent extends Agent<HandshakeAgentListener> {
     public void processResponse(Message message) {
         if (message == null) return;
         if (message instanceof AcceptVersion) {
-            log.info("Handshake Ok!!! {}", message);
+            if (log.isDebugEnabled() || !suppressConnectionInfoLog)
+                log.info("Handshake Ok!!! {}", message);
             setProtocolVersion((AcceptVersion)message);
             handshakeOk();
         } else if (message instanceof VersionTable) {
@@ -67,5 +69,13 @@ public class HandshakeAgent extends Agent<HandshakeAgentListener> {
 
     public void reset() {
         this.currenState = Propose;
+    }
+
+    public void setSuppressConnectionInfoLog(boolean suppressConnectionInfoLog) {
+        this.suppressConnectionInfoLog = suppressConnectionInfoLog;
+    }
+
+    public boolean isSuppressConnectionInfoLog() {
+        return suppressConnectionInfoLog;
     }
 }

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/LocalClientProvider.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/LocalClientProvider.java
@@ -224,4 +224,13 @@ public class LocalClientProvider {
     public void setLocalClientProviderListener(LocalClientProviderListener listener) {
         this.localClientProviderListener = listener;
     }
+
+    /**
+     * Suppress connection info log. Default is false
+     *
+     * @param flag
+     */
+    public void suppressConnectionInfoLog(boolean flag) {
+        handshakeAgent.setSuppressConnectionInfoLog(flag);
+    }
 }


### PR DESCRIPTION
This will hide excessive connection info logs when an N2C connection is used through a connection pool or in connection/request mode.
