### PR TITLE
Change default era to Conway in local queries

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/ConstitutionQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/ConstitutionQuery.java
@@ -19,7 +19,7 @@ import java.util.List;
 @AllArgsConstructor
 @ToString
 // ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
-public class ConstitutionQuery implements EraQuery<ConstitutionResult> {
+public class ConstitutionQuery implements EraQuery<ConstitutionQueryResult> {
     @NonNull
     private Era era;
 
@@ -36,7 +36,7 @@ public class ConstitutionQuery implements EraQuery<ConstitutionResult> {
     }
 
     @Override
-    public ConstitutionResult deserializeResult(AcceptVersion protocolVersion, DataItem[] di) {
+    public ConstitutionQueryResult deserializeResult(AcceptVersion protocolVersion, DataItem[] di) {
         List<DataItem> dataItemList = ((Array)di[0]).getDataItems();
 
         int type = ((UnsignedInteger)dataItemList.get(0)).getValue().intValue(); //4
@@ -45,6 +45,6 @@ public class ConstitutionQuery implements EraQuery<ConstitutionResult> {
         var items = (Array)resultDIList.get(0);
 
         Anchor anchor = AnchorSerializer.INSTANCE.deserializeDI(items.getDataItems().get(0));
-        return new ConstitutionResult(anchor);
+        return new ConstitutionQueryResult(anchor);
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/ConstitutionQueryResult.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/ConstitutionQueryResult.java
@@ -9,6 +9,6 @@ import lombok.ToString;
 @Getter
 @AllArgsConstructor
 @ToString
-public class ConstitutionResult implements QueryResult {
+public class ConstitutionQueryResult implements QueryResult {
     private Anchor anchor;
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/DelegationsAndRewardAccountsQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/DelegationsAndRewardAccountsQuery.java
@@ -55,7 +55,7 @@ public class DelegationsAndRewardAccountsQuery implements EraQuery<DelegationsAn
      * @param stakeAddresses
      */
     public DelegationsAndRewardAccountsQuery(Set<Address> stakeAddresses) {
-        this(Era.Babbage, stakeAddresses);
+        this(Era.Conway, stakeAddresses);
     }
 
     /**

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GovStateQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GovStateQuery.java
@@ -35,7 +35,7 @@ import static com.bloxbean.cardano.yaci.core.util.CborSerializationUtil.*;
 @Getter
 @AllArgsConstructor
 @ToString
-public class GovStateQuery implements EraQuery<GovStateResult> {
+public class GovStateQuery implements EraQuery<GovStateQueryResult> {
     private Era era;
 
     public GovStateQuery() {
@@ -51,8 +51,8 @@ public class GovStateQuery implements EraQuery<GovStateResult> {
     }
 
     @Override
-    public GovStateResult deserializeResult(AcceptVersion protocolVersion, DataItem[] di) {
-        GovStateResult govStateResult = new GovStateResult();
+    public GovStateQueryResult deserializeResult(AcceptVersion protocolVersion, DataItem[] di) {
+        GovStateQueryResult govStateQueryResult = new GovStateQueryResult();
         Array array = (Array) di[0];
         Array resultArray = (Array) ((Array) array.getDataItems().get(1)).getDataItems().get(0);
 
@@ -60,14 +60,14 @@ public class GovStateQuery implements EraQuery<GovStateResult> {
         Array committeeResult =  (Array) resultArray.getDataItems().get(1);
         Array committeeDI =  (Array) committeeResult.getDataItems().get(0);
         Committee committee = deserializeCommitteeResult(committeeDI.getDataItems());
-        govStateResult.setCommittee(committee);
+        govStateQueryResult.setCommittee(committee);
 
         // constitution
         Array constitutionArr = (Array) resultArray.getDataItems().get(2);
         var constitutionDI = constitutionArr.getDataItems().get(0);
 
         Constitution constitution = deserializeConstitutionResult(constitutionDI);
-        govStateResult.setConstitution(constitution);
+        govStateQueryResult.setConstitution(constitution);
 
         // current protocol params
         Array currentPParams = (Array) resultArray.getDataItems().get(3);
@@ -75,13 +75,13 @@ public class GovStateQuery implements EraQuery<GovStateResult> {
 
         ProtocolParamUpdate currentProtocolParam = deserializePPResult(paramsDIList);
 
-        govStateResult.setCurrentPParams(currentProtocolParam);
+        govStateQueryResult.setCurrentPParams(currentProtocolParam);
 
         Array futurePParams = (Array) resultArray.getDataItems().get(5);
         if (!futurePParams.getDataItems().isEmpty() && futurePParams.getDataItems().size() > 1) {
             List<DataItem> futureParamsDIList = ((Array)futurePParams.getDataItems().get(1)).getDataItems();
             ProtocolParamUpdate futureProtocolParam = deserializePPResult(futureParamsDIList);
-            govStateResult.setFuturePParams(futureProtocolParam);
+            govStateQueryResult.setFuturePParams(futureProtocolParam);
         }
 
         // next ratify state
@@ -163,14 +163,14 @@ public class GovStateQuery implements EraQuery<GovStateResult> {
                 .expiredGovActions(expiredGovActions)
                 .build();
 
-        govStateResult.setNextRatifyState(nextRatifyState);
+        govStateQueryResult.setNextRatifyState(nextRatifyState);
 
         // previous protocol params
         Array prevPParams = (Array) resultArray.getDataItems().get(4);
         paramsDIList = prevPParams.getDataItems();
         ProtocolParamUpdate prevProtocolParam = deserializePPResult(paramsDIList);
 
-        govStateResult.setPreviousPParams(prevProtocolParam);
+        govStateQueryResult.setPreviousPParams(prevProtocolParam);
 
         // proposals
         Array proposalArr = (Array)((Array) resultArray.getDataItems().get(0)).getDataItems().get(1);
@@ -184,9 +184,9 @@ public class GovStateQuery implements EraQuery<GovStateResult> {
             proposals.add(proposal);
         }
 
-        govStateResult.setProposals(proposals);
+        govStateQueryResult.setProposals(proposals);
 
-        return govStateResult;
+        return govStateQueryResult;
     }
 
     public ProtocolParamUpdate deserializePPResult(List<DataItem> paramsDIList) {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GovStateQueryResult.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GovStateQueryResult.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Getter
 @Setter
 @ToString
-public class GovStateResult implements QueryResult {
+public class GovStateQueryResult implements QueryResult {
     private Committee committee;
     private Constitution constitution;
     private ProtocolParamUpdate currentPParams;

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/PoolDistrQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/PoolDistrQuery.java
@@ -21,7 +21,7 @@ public class PoolDistrQuery implements EraQuery<PoolDistrQueryResult> {
     private List<String> poolIds;
 
     public PoolDistrQuery(List<String> poolIds) {
-        this(Era.Babbage, poolIds);
+        this(Era.Conway, poolIds);
     }
 
     @Override

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/StakeDistributionQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/StakeDistributionQuery.java
@@ -23,7 +23,7 @@ public class StakeDistributionQuery implements EraQuery<StakeDistributionQueryRe
     private Era era;
 
     public StakeDistributionQuery() {
-        this(Era.Babbage);
+        this(Era.Conway);
     }
 
     @Override

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/StakePoolParamsQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/StakePoolParamsQuery.java
@@ -22,7 +22,7 @@ public class StakePoolParamsQuery implements EraQuery<StakePoolParamQueryResult>
     private List<String> poolIds;
 
     public StakePoolParamsQuery(@NonNull List<String> poolIds) {
-        this(Era.Babbage, poolIds);
+        this(Era.Conway, poolIds);
     }
 
     @Override

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/StakeSnapshotQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/StakeSnapshotQuery.java
@@ -19,7 +19,7 @@ public class StakeSnapshotQuery implements EraQuery<StakeSnapshotQueryResult> {
     private String poolId;
 
     public StakeSnapshotQuery(String poolId) {
-        this(Era.Babbage, poolId);
+        this(Era.Conway, poolId);
     }
 
     @Override

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/UtxoByAddressQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/UtxoByAddressQuery.java
@@ -27,7 +27,7 @@ public class UtxoByAddressQuery implements EraQuery<UtxoByAddressQueryResult> {
     private Address address;
 
     public UtxoByAddressQuery(Address address) {
-        this(Era.Babbage, address);
+        this(Era.Conway, address);
     }
 
     @Override

--- a/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/LocalStateQueryClientIT.java
+++ b/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/LocalStateQueryClientIT.java
@@ -326,20 +326,20 @@ class LocalStateQueryClientIT extends BaseTest {
 
     @Test
     void govStateQuery() {
-        Mono<GovStateResult> mono = localStateQueryClient.executeQuery(new GovStateQuery(Era.Conway));
+        Mono<GovStateQueryResult> mono = localStateQueryClient.executeQuery(new GovStateQuery(Era.Conway));
         mono = mono.log();
 
-        GovStateResult result = mono.block(Duration.ofSeconds(10));
+        GovStateQueryResult result = mono.block(Duration.ofSeconds(10));
         assertThat(result.getCommittee()).isNotNull();
         assertThat(result.getCurrentPParams()).isNotNull();
     }
 
     @Test
     void constitutionQuery() {
-        Mono<ConstitutionResult> mono = localStateQueryClient.executeQuery(new ConstitutionQuery(Era.Conway));
+        Mono<ConstitutionQueryResult> mono = localStateQueryClient.executeQuery(new ConstitutionQuery(Era.Conway));
         mono = mono.log();
 
-        ConstitutionResult result = mono.block(Duration.ofSeconds(5));
+        ConstitutionQueryResult result = mono.block(Duration.ofSeconds(5));
         assertThat(result).isNotNull();
     }
 

--- a/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/LocalStateQueryClientIT.java
+++ b/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/LocalStateQueryClientIT.java
@@ -1,9 +1,7 @@
 package com.bloxbean.cardano.yaci.helper;
 
 import com.bloxbean.cardano.client.address.Address;
-import com.bloxbean.cardano.client.transaction.spec.governance.Constitution;
 import com.bloxbean.cardano.client.transaction.spec.governance.DRep;
-import com.bloxbean.cardano.yaci.core.common.Constants;
 import com.bloxbean.cardano.yaci.core.model.Credential;
 import com.bloxbean.cardano.yaci.core.model.certs.StakeCredType;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
@@ -16,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
+
 import java.math.BigInteger;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -23,7 +22,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
 
-import static com.bloxbean.cardano.yaci.core.common.Constants.SANCHONET_PROTOCOL_MAGIC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
@@ -35,7 +33,7 @@ class LocalStateQueryClientIT extends BaseTest {
 
     @BeforeEach
     public void setup() {
-        this.era = Era.Babbage;
+        this.era = Era.Conway;
         this.localQueryProvider = new LocalClientProvider(nodeSocketFile, protocolMagic);
         this.localStateQueryClient = localQueryProvider.getLocalStateQueryClient();
         localQueryProvider.start();
@@ -111,12 +109,7 @@ class LocalStateQueryClientIT extends BaseTest {
     @Test
     void protocolParameters() {
         Mono<CurrentProtocolParamQueryResult> mono = null;
-
-        if (protocolMagic == Constants.SANCHONET_PROTOCOL_MAGIC) {
-            mono = localStateQueryClient.executeQuery(new CurrentProtocolParamsQuery(Era.Conway));
-        } else {
-            mono = localStateQueryClient.executeQuery(new CurrentProtocolParamsQuery(Era.Babbage));
-        }
+        mono = localStateQueryClient.executeQuery(new CurrentProtocolParamsQuery(Era.Conway));
 
         mono = mono.log();
 
@@ -157,7 +150,7 @@ class LocalStateQueryClientIT extends BaseTest {
     @Test
     void acquireReacquireAndQuery() {
         localStateQueryClient.acquire().block(Duration.ofSeconds(15));
-        Mono<CurrentProtocolParamQueryResult> mono = localStateQueryClient.executeQuery(new CurrentProtocolParamsQuery(Era.Babbage));
+        Mono<CurrentProtocolParamQueryResult> mono = localStateQueryClient.executeQuery(new CurrentProtocolParamsQuery(Era.Conway));
         CurrentProtocolParamQueryResult protocolParams = mono.block(Duration.ofSeconds(8));
         log.info("Protocol Params >> " + protocolParams);
 
@@ -216,7 +209,7 @@ class LocalStateQueryClientIT extends BaseTest {
     @Test
     void stakeSnapshotsQuery() {
         Mono<StakeSnapshotQueryResult> mono = localStateQueryClient.executeQuery(new StakeSnapshotQuery("032a04334a846fdf542fd5633c9b3928998691b8276e004facbc8af1"));
-        StakeSnapshotQueryResult result = mono.block();
+        StakeSnapshotQueryResult result = mono.block(Duration.ofSeconds(5));
 
         System.out.println(result);
     }
@@ -248,7 +241,7 @@ class LocalStateQueryClientIT extends BaseTest {
 
     @Test
     void genesisConfigQuery() {
-        Mono<GenesisConfigQueryResult> mono = localStateQueryClient.executeQuery(new GenesisConfigQuery(Era.Babbage));
+        Mono<GenesisConfigQueryResult> mono = localStateQueryClient.executeQuery(new GenesisConfigQuery(Era.Conway));
         GenesisConfigQueryResult result = mono.block(Duration.ofSeconds(5));
 
         LocalDate localDate = LocalDate.ofYearDay(2017, 30);
@@ -303,7 +296,7 @@ class LocalStateQueryClientIT extends BaseTest {
 
     @Test
     void accountStateQuery() {
-        Mono<AccountStateQueryResult> mono = localStateQueryClient.executeQuery(new AccountStateQuery(Era.Babbage));
+        Mono<AccountStateQueryResult> mono = localStateQueryClient.executeQuery(new AccountStateQuery(Era.Conway));
 
         mono = mono.log();
 
@@ -320,8 +313,8 @@ class LocalStateQueryClientIT extends BaseTest {
                 new DRepStakeDistributionQuery(
                         Era.Conway,
                         List.of(
-                                DRep.addrKeyHash("001021a9b538f693f5293b9ad77e9fd2febe5ecd66cf8bb2844b4a8d")
-                               , DRep.scriptHash("1ffa2ae5f54e88a2e6a29642936aceebdd3aea948d70ace645912440")
+                                DRep.addrKeyHash("23bc63ced4e40b22dd4e6051c258ba38d5679d81e33f34fe5e5cdb4d")
+                               , DRep.addrKeyHash("fa6a8dc2635dddcf9af495cb144f7eb4ff845866fe48695ad7cb65d3")
                         ))
         );
 
@@ -358,29 +351,29 @@ class LocalStateQueryClientIT extends BaseTest {
                         Credential
                                 .builder()
                                 .type(StakeCredType.ADDR_KEYHASH)
-                                .hash("5e80b2b80990a738aece6d6068b2991eaea21c52e79c7974719ac275")
+                                .hash("23bc63ced4e40b22dd4e6051c258ba38d5679d81e33f34fe5e5cdb4d")
                                 .build(),
                         Credential
                                 .builder()
                                 .type(StakeCredType.ADDR_KEYHASH)
-                                .hash("6e066d1a8bce348956b34438556abb43d597d075f9fdab03bb6f4d39")
+                                .hash("fa6a8dc2635dddcf9af495cb144f7eb4ff845866fe48695ad7cb65d3")
                                 .build()
                 ))
         );
         mono = mono.log();
 
         DRepStateQueryResult result = mono.block(Duration.ofSeconds(5));
-        assertThat(result.getDRepStates()).isNotNull();
+        assertThat(result.getDRepStates()).hasSizeGreaterThan(0);
     }
 
     @Test
     void SPOStakeDistrQuery() {
         Mono<SPOStakeDistributionQueryResult> mono = localStateQueryClient.executeQuery(new SPOStakeDistributionQuery(
-                List.of("3c4fb94e1a2c5649a870aee5a70f21cd64807c7dc38632efcaf3d921")
+                List.of("032a04334a846fdf542fd5633c9b3928998691b8276e004facbc8af1")
                 )
         );
 
         SPOStakeDistributionQueryResult result = mono.block();
-        assertThat(result.getSpoStakeMap()).isNotNull();
+        assertThat(result.getSpoStakeMap()).hasSize(1);
     }
 }


### PR DESCRIPTION
- Change default era to Conway in local queries
- Change default era to Conway in tests (LocalStateQueryClientIT), change some parameters
- Rename ConstitutionResult to ConstitutionQueryResult, GovStateResult to GovStateQueryResult