### PR TITLE
Deprecate old relay addresses and update to public versions

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/common/Constants.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/common/Constants.java
@@ -4,7 +4,6 @@ import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
 
 public class Constants {
     public final static Point WELL_KNOWN_MAINNET_POINT = new Point(16588737, "4e9bbbb67e3ae262133d94c3da5bffce7b1127fc436e7433b87668dba34c354a");
-    public final static Point WELL_KNOWN_TESTNET_POINT = new Point(13694363, "b596f9739b647ab5af901c8fc6f75791e262b0aeba81994a1d622543459734f2");
     public final static Point WELL_KNOWN_PREPROD_POINT = new Point(87480, "528c3e6a00c82dd5331b116103b6e427acf447891ce3ade6c4c7a61d2f0a2b1c");
     public final static Point WELL_KNOWN_PREVIEW_POINT = new Point(8000, "70da683c00985e23903da00656fae96644e1f31dce914aab4ed50e35e4c4842d");
     public final static Point WELL_KNOWN_SANCHONET_POINT = new Point(20, "6a7d97aae2a65ca790fd14802808b7fce00a3362bd7b21c4ed4ccb4296783b98");
@@ -14,18 +13,39 @@ public class Constants {
     public final static long PREVIEW_PROTOCOL_MAGIC = NetworkType.PREVIEW.getProtocolMagic();
     public final static long SANCHONET_PROTOCOL_MAGIC = NetworkType.SANCHONET.getProtocolMagic();
 
+    /**
+     * @deprecated Use MAINNET_PUBLIC_RELAY_ADDR
+     */
     @Deprecated(since = "0.3.4")
     public final static String MAINNET_IOHK_RELAY_ADDR = "backbone.cardano.iog.io";
+
+    /**
+     * @deprecated Use MAINNET_PUBLIC_RELAY_PORT
+     */
     @Deprecated(since = "0.3.4")
     public final static int MAINNET_IOHK_RELAY_PORT = 3001;
 
+    /**
+     * @deprecated Use PREPROD_PUBLIC_RELAY_ADDR
+     */
     @Deprecated(since = "0.3.4")
     public final static String PREPROD_IOHK_RELAY_ADDR = "preprod-node.play.dev.cardano.org";
+
+    /**
+     * @deprecated Use PREPROD_PUBLIC_RELAY_PORT
+     */
     @Deprecated(since = "0.3.4")
     public final static int PREPROD_IOHK_RELAY_PORT = 3001;
 
+    /**
+     * @deprecated Use PREVIEW_PUBLIC_RELAY_ADDR
+     */
     @Deprecated(since = "0.3.4")
     public final static String PREVIEW_IOHK_RELAY_ADDR = "preview-node.world.dev.cardano.org";
+
+    /**
+     * @deprecated Use PREVIEW_PUBLIC_RELAY_PORT
+     */
     @Deprecated(since = "0.3.4")
     public final static int PREVIEW_IOHK_RELAY_PORT = 3001;
 

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/common/Constants.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/common/Constants.java
@@ -10,22 +10,33 @@ public class Constants {
     public final static Point WELL_KNOWN_SANCHONET_POINT = new Point(20, "6a7d97aae2a65ca790fd14802808b7fce00a3362bd7b21c4ed4ccb4296783b98");
 
     public final static long MAINNET_PROTOCOL_MAGIC = NetworkType.MAINNET.getProtocolMagic();
-    public final static long LEGACY_TESTNET_PROTOCOL_MAGIC = NetworkType.LEGACY_TESTNET.getProtocolMagic();
     public final static long PREPROD_PROTOCOL_MAGIC = NetworkType.PREPROD.getProtocolMagic();
     public final static long PREVIEW_PROTOCOL_MAGIC = NetworkType.PREVIEW.getProtocolMagic();
     public final static long SANCHONET_PROTOCOL_MAGIC = NetworkType.SANCHONET.getProtocolMagic();
 
-    public final static String TESTNET_IOHK_RELAY_ADDR = "relays-new.cardano-testnet.iohkdev.io";
-    public final static int TESTNET_IOHK_RELAY_PORT = 3001;
-
-    public final static String MAINNET_IOHK_RELAY_ADDR = "relays-new.cardano-mainnet.iohk.io";
+    @Deprecated(since = "0.3.4")
+    public final static String MAINNET_IOHK_RELAY_ADDR = "backbone.cardano.iog.io";
+    @Deprecated(since = "0.3.4")
     public final static int MAINNET_IOHK_RELAY_PORT = 3001;
 
-    public final static String PREPROD_IOHK_RELAY_ADDR = "preprod-node.world.dev.cardano.org";
-    public final static int PREPROD_IOHK_RELAY_PORT = 30000;
+    @Deprecated(since = "0.3.4")
+    public final static String PREPROD_IOHK_RELAY_ADDR = "preprod-node.play.dev.cardano.org";
+    @Deprecated(since = "0.3.4")
+    public final static int PREPROD_IOHK_RELAY_PORT = 3001;
 
+    @Deprecated(since = "0.3.4")
     public final static String PREVIEW_IOHK_RELAY_ADDR = "preview-node.world.dev.cardano.org";
-    public final static int PREVIEW_IOHK_RELAY_PORT = 30002;
+    @Deprecated(since = "0.3.4")
+    public final static int PREVIEW_IOHK_RELAY_PORT = 3001;
+
+    public final static String MAINNET_PUBLIC_RELAY_ADDR = "backbone.cardano.iog.io";
+    public final static int MAINNET_PUBLIC_RELAY_PORT = 3001;
+
+    public final static String PREPROD_PUBLIC_RELAY_ADDR = "preprod-node.play.dev.cardano.org";
+    public final static int PREPROD_PUBLIC_RELAY_PORT = 3001;
+
+    public final static String PREVIEW_PUBLIC_RELAY_ADDR = "preview-node.play.dev.cardano.org";
+    public final static int PREVIEW_PUBLIC_RELAY_PORT = 3001;
 
     public final static String SANCHONET_PUBLIC_RELAY_ADDR = "sanchonet-node.play.dev.cardano.org";
     public final static int SANCHONET_PUBLIC_RELAY_PORT = 3001;

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/common/Constants.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/common/Constants.java
@@ -3,62 +3,62 @@ package com.bloxbean.cardano.yaci.core.common;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
 
 public class Constants {
-    public final static Point WELL_KNOWN_MAINNET_POINT = new Point(16588737, "4e9bbbb67e3ae262133d94c3da5bffce7b1127fc436e7433b87668dba34c354a");
-    public final static Point WELL_KNOWN_PREPROD_POINT = new Point(87480, "528c3e6a00c82dd5331b116103b6e427acf447891ce3ade6c4c7a61d2f0a2b1c");
-    public final static Point WELL_KNOWN_PREVIEW_POINT = new Point(8000, "70da683c00985e23903da00656fae96644e1f31dce914aab4ed50e35e4c4842d");
-    public final static Point WELL_KNOWN_SANCHONET_POINT = new Point(20, "6a7d97aae2a65ca790fd14802808b7fce00a3362bd7b21c4ed4ccb4296783b98");
+    public static final Point WELL_KNOWN_MAINNET_POINT = new Point(16588737, "4e9bbbb67e3ae262133d94c3da5bffce7b1127fc436e7433b87668dba34c354a");
+    public static final Point WELL_KNOWN_PREPROD_POINT = new Point(87480, "528c3e6a00c82dd5331b116103b6e427acf447891ce3ade6c4c7a61d2f0a2b1c");
+    public static final Point WELL_KNOWN_PREVIEW_POINT = new Point(8000, "70da683c00985e23903da00656fae96644e1f31dce914aab4ed50e35e4c4842d");
+    public static final Point WELL_KNOWN_SANCHONET_POINT = new Point(20, "6a7d97aae2a65ca790fd14802808b7fce00a3362bd7b21c4ed4ccb4296783b98");
 
-    public final static long MAINNET_PROTOCOL_MAGIC = NetworkType.MAINNET.getProtocolMagic();
-    public final static long PREPROD_PROTOCOL_MAGIC = NetworkType.PREPROD.getProtocolMagic();
-    public final static long PREVIEW_PROTOCOL_MAGIC = NetworkType.PREVIEW.getProtocolMagic();
-    public final static long SANCHONET_PROTOCOL_MAGIC = NetworkType.SANCHONET.getProtocolMagic();
+    public static final long MAINNET_PROTOCOL_MAGIC = NetworkType.MAINNET.getProtocolMagic();
+    public static final long PREPROD_PROTOCOL_MAGIC = NetworkType.PREPROD.getProtocolMagic();
+    public static final long PREVIEW_PROTOCOL_MAGIC = NetworkType.PREVIEW.getProtocolMagic();
+    public static final long SANCHONET_PROTOCOL_MAGIC = NetworkType.SANCHONET.getProtocolMagic();
 
     /**
      * @deprecated Use MAINNET_PUBLIC_RELAY_ADDR
      */
     @Deprecated(since = "0.3.4")
-    public final static String MAINNET_IOHK_RELAY_ADDR = "backbone.cardano.iog.io";
+    public static final String MAINNET_IOHK_RELAY_ADDR = "backbone.cardano.iog.io";
 
     /**
      * @deprecated Use MAINNET_PUBLIC_RELAY_PORT
      */
     @Deprecated(since = "0.3.4")
-    public final static int MAINNET_IOHK_RELAY_PORT = 3001;
+    public static final int MAINNET_IOHK_RELAY_PORT = 3001;
 
     /**
      * @deprecated Use PREPROD_PUBLIC_RELAY_ADDR
      */
     @Deprecated(since = "0.3.4")
-    public final static String PREPROD_IOHK_RELAY_ADDR = "preprod-node.play.dev.cardano.org";
+    public static final String PREPROD_IOHK_RELAY_ADDR = "preprod-node.play.dev.cardano.org";
 
     /**
      * @deprecated Use PREPROD_PUBLIC_RELAY_PORT
      */
     @Deprecated(since = "0.3.4")
-    public final static int PREPROD_IOHK_RELAY_PORT = 3001;
+    public static final int PREPROD_IOHK_RELAY_PORT = 3001;
 
     /**
      * @deprecated Use PREVIEW_PUBLIC_RELAY_ADDR
      */
     @Deprecated(since = "0.3.4")
-    public final static String PREVIEW_IOHK_RELAY_ADDR = "preview-node.world.dev.cardano.org";
+    public static final String PREVIEW_IOHK_RELAY_ADDR = "preview-node.world.dev.cardano.org";
 
     /**
      * @deprecated Use PREVIEW_PUBLIC_RELAY_PORT
      */
     @Deprecated(since = "0.3.4")
-    public final static int PREVIEW_IOHK_RELAY_PORT = 3001;
+    public static final int PREVIEW_IOHK_RELAY_PORT = 3001;
 
-    public final static String MAINNET_PUBLIC_RELAY_ADDR = "backbone.cardano.iog.io";
-    public final static int MAINNET_PUBLIC_RELAY_PORT = 3001;
+    public static final String MAINNET_PUBLIC_RELAY_ADDR = "backbone.cardano.iog.io";
+    public static final int MAINNET_PUBLIC_RELAY_PORT = 3001;
 
-    public final static String PREPROD_PUBLIC_RELAY_ADDR = "preprod-node.play.dev.cardano.org";
-    public final static int PREPROD_PUBLIC_RELAY_PORT = 3001;
+    public static final String PREPROD_PUBLIC_RELAY_ADDR = "preprod-node.play.dev.cardano.org";
+    public static final int PREPROD_PUBLIC_RELAY_PORT = 3001;
 
-    public final static String PREVIEW_PUBLIC_RELAY_ADDR = "preview-node.play.dev.cardano.org";
-    public final static int PREVIEW_PUBLIC_RELAY_PORT = 3001;
+    public static final String PREVIEW_PUBLIC_RELAY_ADDR = "preview-node.play.dev.cardano.org";
+    public static final int PREVIEW_PUBLIC_RELAY_PORT = 3001;
 
-    public final static String SANCHONET_PUBLIC_RELAY_ADDR = "sanchonet-node.play.dev.cardano.org";
-    public final static int SANCHONET_PUBLIC_RELAY_PORT = 3001;
+    public static final String SANCHONET_PUBLIC_RELAY_ADDR = "sanchonet-node.play.dev.cardano.org";
+    public static final int SANCHONET_PUBLIC_RELAY_PORT = 3001;
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.bloxbean.cardano
 artifactId = yaci
-version = 0.3.4-SNAPSHOT
+version = 0.3.4

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/reactive/BlockStreamer.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/reactive/BlockStreamer.java
@@ -51,8 +51,6 @@ public class BlockStreamer {
         switch (networkType) {
             case MAINNET:
                 return fromLatest(MAINNET_IOHK_RELAY_ADDR, MAINNET_IOHK_RELAY_PORT, WELL_KNOWN_MAINNET_POINT, networkType.getN2NVersionTable());
-            case LEGACY_TESTNET:
-                return fromLatest(TESTNET_IOHK_RELAY_ADDR, TESTNET_IOHK_RELAY_PORT, WELL_KNOWN_TESTNET_POINT, networkType.getN2NVersionTable());
             case PREPROD:
                 return fromLatest(PREPROD_IOHK_RELAY_ADDR, PREPROD_IOHK_RELAY_PORT, WELL_KNOWN_PREPROD_POINT, networkType.getN2NVersionTable());
             case PREVIEW:
@@ -73,8 +71,6 @@ public class BlockStreamer {
         switch (networkType) {
             case MAINNET:
                 return fromPoint(MAINNET_IOHK_RELAY_ADDR, MAINNET_IOHK_RELAY_PORT, point, networkType.getN2NVersionTable());
-            case LEGACY_TESTNET:
-                return fromPoint(TESTNET_IOHK_RELAY_ADDR, TESTNET_IOHK_RELAY_PORT, point, networkType.getN2NVersionTable());
             case PREPROD:
                 return fromPoint(PREPROD_IOHK_RELAY_ADDR, PREPROD_IOHK_RELAY_PORT, point, networkType.getN2NVersionTable());
             case PREVIEW:
@@ -242,8 +238,6 @@ public class BlockStreamer {
         switch (networkType) {
             case MAINNET:
                 return forRange(MAINNET_IOHK_RELAY_ADDR, MAINNET_IOHK_RELAY_PORT, fromPoint, toPoint, networkType.getN2NVersionTable());
-            case LEGACY_TESTNET:
-                return forRange(TESTNET_IOHK_RELAY_ADDR, TESTNET_IOHK_RELAY_PORT, fromPoint, toPoint, networkType.getN2NVersionTable());
             case PREPROD:
                 return forRange(PREPROD_IOHK_RELAY_ADDR, PREPROD_IOHK_RELAY_PORT, fromPoint, toPoint, networkType.getN2NVersionTable());
             case PREVIEW:


### PR DESCRIPTION
Replace old IOHK relay addresses with new public relay addresses and mark them as deprecated since version 0.3.4. Also, update the project version from 0.3.4-SNAPSHOT to 0.3.4.