### PR TITLE
fix: #109 Instead of converting RationalNumber to BigDecimal, return UnitInterval or NonNegativeInterval

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/DrepVoteThresholds.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/DrepVoteThresholds.java
@@ -1,8 +1,7 @@
 package com.bloxbean.cardano.yaci.core.model;
 
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import lombok.*;
-
-import java.math.BigDecimal;
 
 /**
  * drep_voting_thresholds =
@@ -24,14 +23,14 @@ import java.math.BigDecimal;
 @Builder
 @ToString
 public class DrepVoteThresholds {
-    private BigDecimal dvtMotionNoConfidence;
-    private BigDecimal dvtCommitteeNormal;
-    private BigDecimal dvtCommitteeNoConfidence;
-    private BigDecimal dvtUpdateToConstitution;
-    private BigDecimal dvtHardForkInitiation;
-    private BigDecimal dvtPPNetworkGroup;
-    private BigDecimal dvtPPEconomicGroup;
-    private BigDecimal dvtPPTechnicalGroup;
-    private BigDecimal dvtPPGovGroup;
-    private BigDecimal dvtTreasuryWithdrawal;
+    private UnitInterval dvtMotionNoConfidence;
+    private UnitInterval dvtCommitteeNormal;
+    private UnitInterval dvtCommitteeNoConfidence;
+    private UnitInterval dvtUpdateToConstitution;
+    private UnitInterval dvtHardForkInitiation;
+    private UnitInterval dvtPPNetworkGroup;
+    private UnitInterval dvtPPEconomicGroup;
+    private UnitInterval dvtPPTechnicalGroup;
+    private UnitInterval dvtPPGovGroup;
+    private UnitInterval dvtTreasuryWithdrawal;
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/PoolParams.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/PoolParams.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.core.model;
 
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import lombok.*;
 
 import java.math.BigInteger;
@@ -16,7 +17,7 @@ public class PoolParams {
     private String vrfKeyHash;
     private BigInteger pledge;
     private BigInteger cost;
-    private String margin;
+    private UnitInterval margin;
     private String rewardAccount;
     private Set<String> poolOwners;
     private List<Relay> relays;

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/PoolVotingThresholds.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/PoolVotingThresholds.java
@@ -1,8 +1,7 @@
 package com.bloxbean.cardano.yaci.core.model;
 
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import lombok.*;
-
-import java.math.BigDecimal;
 
 /**
  * pool_voting_thresholds =
@@ -18,9 +17,9 @@ import java.math.BigDecimal;
 @Builder
 @ToString
 public class PoolVotingThresholds {
-    private BigDecimal pvtMotionNoConfidence;
-    private BigDecimal pvtCommitteeNormal;
-    private BigDecimal pvtCommitteeNoConfidence;
-    private BigDecimal pvtHardForkInitiation;
-    private BigDecimal pvtPPSecurityGroup;
+    private UnitInterval pvtMotionNoConfidence;
+    private UnitInterval pvtCommitteeNormal;
+    private UnitInterval pvtCommitteeNoConfidence;
+    private UnitInterval pvtHardForkInitiation;
+    private UnitInterval pvtPPSecurityGroup;
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/ProtocolParamUpdate.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/ProtocolParamUpdate.java
@@ -1,5 +1,7 @@
 package com.bloxbean.cardano.yaci.core.model;
 
+import com.bloxbean.cardano.yaci.core.types.NonNegativeInterval;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.Tuple;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
@@ -25,10 +27,10 @@ public class ProtocolParamUpdate {
     private Integer maxEpoch; //7
     @JsonProperty("nopt")
     private Integer nOpt; //8
-    private BigDecimal poolPledgeInfluence; //rational //9
-    private BigDecimal expansionRate; //unit interval //10
-    private BigDecimal treasuryGrowthRate; //11
-    private BigDecimal decentralisationParam; //12
+    private NonNegativeInterval poolPledgeInfluence; //rational //9
+    private UnitInterval expansionRate; //unit interval //10
+    private UnitInterval treasuryGrowthRate; //11
+    private UnitInterval decentralisationParam; //12
     private Tuple<Integer, String> extraEntropy; //13
     private Integer protocolMajorVer; //14
     private Integer protocolMinorVer; //14
@@ -43,8 +45,8 @@ public class ProtocolParamUpdate {
     private String costModelsHash; //derived field
 
     //ex_unit_prices
-    private BigDecimal priceMem; //19
-    private BigDecimal priceStep; //19
+    private NonNegativeInterval priceMem; //19
+    private NonNegativeInterval priceStep; //19
 
     //max tx ex units
     private BigInteger maxTxExMem; //20
@@ -74,5 +76,5 @@ public class ProtocolParamUpdate {
     private BigInteger govActionDeposit; //30
     private BigInteger drepDeposit; //31
     private Integer drepActivity; //32
-    private BigDecimal minFeeRefScriptCostPerByte; //33
+    private NonNegativeInterval minFeeRefScriptCostPerByte; //33
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/governance/Committee.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/governance/Committee.java
@@ -1,9 +1,9 @@
 package com.bloxbean.cardano.yaci.core.model.governance;
 
 import com.bloxbean.cardano.yaci.core.model.Credential;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import lombok.*;
 
-import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -21,5 +21,5 @@ import java.util.Map;
 public class Committee {
     @Builder.Default
     private Map<Credential, Long> committeeColdCredentialEpoch = new LinkedHashMap<>();
-    private BigDecimal threshold; //TODO?? Check the correct name.
+    private UnitInterval threshold; //TODO?? Check the correct name.
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/governance/actions/UpdateCommittee.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/governance/actions/UpdateCommittee.java
@@ -6,7 +6,6 @@ import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
 import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import lombok.*;
 
-import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -32,6 +31,6 @@ public class UpdateCommittee implements GovAction {
 
     @Builder.Default
     private Map<Credential, Integer> newMembersAndTerms = new LinkedHashMap<>();
-    private UnitInterval quorumThreshold; //TODO?? Check the correct name.
+    private UnitInterval threshold; //TODO?? Check the correct name.
 
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/governance/actions/UpdateCommittee.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/governance/actions/UpdateCommittee.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.core.model.governance.actions;
 import com.bloxbean.cardano.yaci.core.model.Credential;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionId;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -31,6 +32,6 @@ public class UpdateCommittee implements GovAction {
 
     @Builder.Default
     private Map<Credential, Integer> newMembersAndTerms = new LinkedHashMap<>();
-    private BigDecimal quorumThreshold; //TODO?? Check the correct name.
+    private UnitInterval quorumThreshold; //TODO?? Check the correct name.
 
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/serializers/PoolRegistrationSerializer.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/serializers/PoolRegistrationSerializer.java
@@ -6,6 +6,7 @@ import com.bloxbean.cardano.yaci.core.model.PoolParams;
 import com.bloxbean.cardano.yaci.core.model.Relay;
 import com.bloxbean.cardano.yaci.core.model.certs.PoolRegistration;
 import com.bloxbean.cardano.yaci.core.protocol.Serializer;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +45,8 @@ public enum PoolRegistrationSerializer implements Serializer<PoolRegistration> {
         String vrfKeyHash = toHex(dataItemList.get(2));
         BigInteger pledge = toBigInteger(dataItemList.get(3));
         BigInteger cost = toBigInteger(dataItemList.get(4));
-        String margin = ((RationalNumber) dataItemList.get(5)).getNumerator() + "/" + ((RationalNumber) dataItemList.get(5)).getDenominator();
+
+        UnitInterval margin = toUnitInterval(dataItemList.get(5));
         String rewardAccount = toHex(dataItemList.get(6));
 
         //Pool Owners0

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/serializers/UpdateSerializer.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/serializers/UpdateSerializer.java
@@ -7,11 +7,12 @@ import com.bloxbean.cardano.yaci.core.model.PoolVotingThresholds;
 import com.bloxbean.cardano.yaci.core.model.ProtocolParamUpdate;
 import com.bloxbean.cardano.yaci.core.model.Update;
 import com.bloxbean.cardano.yaci.core.protocol.Serializer;
+import com.bloxbean.cardano.yaci.core.types.NonNegativeInterval;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import com.bloxbean.cardano.yaci.core.util.Tuple;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.HashMap;
@@ -81,16 +82,16 @@ public enum UpdateSerializer implements Serializer<Update> {
         Integer nOpt = itemDI != null ? toInt(itemDI) : null;
 
         itemDI = genesisProtocolParamsMap.get(new UnsignedInteger(9));
-        BigDecimal poolPledgeInfluence = itemDI != null ? toRationalNumber(itemDI) : null;
+        NonNegativeInterval poolPledgeInfluence = itemDI != null ? toNonNegativeInterval(itemDI) : null;
 
         itemDI = genesisProtocolParamsMap.get(new UnsignedInteger(10));
-        BigDecimal expansionRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval expansionRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         itemDI = genesisProtocolParamsMap.get(new UnsignedInteger(11));
-        BigDecimal treasuryGrowthRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval treasuryGrowthRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         itemDI = genesisProtocolParamsMap.get(new UnsignedInteger(12));
-        BigDecimal decentralizationParam = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval decentralizationParam = itemDI != null ? toUnitInterval(itemDI) : null;
 
         Tuple<Integer, String> extraEntropy = null;
 //                $nonce /= [ 0 // 1, bytes .size 32 ]
@@ -141,12 +142,12 @@ public enum UpdateSerializer implements Serializer<Update> {
         }
 
         //exUnits prices
-        BigDecimal priceMem = null;
-        BigDecimal priceSteps = null;
+        NonNegativeInterval priceMem = null;
+        NonNegativeInterval priceSteps = null;
         itemDI = genesisProtocolParamsMap.get(new UnsignedInteger(19));
         if (itemDI != null) {
             List<DataItem> exUnitPriceList = ((Array) itemDI).getDataItems();
-            Tuple<BigDecimal, BigDecimal> tuple = getExUnitPrices(exUnitPriceList);
+            Tuple<NonNegativeInterval, NonNegativeInterval> tuple = getExUnitPrices(exUnitPriceList);
             priceMem = tuple._1;
             priceSteps = tuple._2;
         }
@@ -208,7 +209,7 @@ public enum UpdateSerializer implements Serializer<Update> {
         Integer drepInactivityPeriod = itemDI != null ? toInt(itemDI) : null;
 
         itemDI = genesisProtocolParamsMap.get(new UnsignedInteger(33));
-        BigDecimal minFeeRefScriptCostPerByte = itemDI != null ? toRationalNumber(itemDI) : null;
+        NonNegativeInterval minFeeRefScriptCostPerByte = itemDI != null ? toNonNegativeInterval(itemDI) : null;
 
         ProtocolParamUpdate protocolParamUpdate = ProtocolParamUpdate.builder()
                 .minFeeA(minFeeA)
@@ -264,12 +265,12 @@ public enum UpdateSerializer implements Serializer<Update> {
         return new Tuple<>(mem, steps);
     }
 
-    private Tuple<BigDecimal, BigDecimal> getExUnitPrices(List<DataItem> exunits) {
+    private Tuple<NonNegativeInterval, NonNegativeInterval> getExUnitPrices(List<DataItem> exunits) {
         RationalNumber memPriceRN = (RationalNumber) exunits.get(0);
         RationalNumber stepPriceRN = (RationalNumber) exunits.get(1);
 
-        BigDecimal memPrice = toRationalNumber(memPriceRN);
-        BigDecimal stepPrice = toRationalNumber(stepPriceRN);
+        var memPrice = toNonNegativeInterval(memPriceRN);
+        var stepPrice = toNonNegativeInterval(stepPriceRN);
 
         return new Tuple<>(memPrice, stepPrice);
     }
@@ -289,11 +290,11 @@ public enum UpdateSerializer implements Serializer<Update> {
             return null;
 
         List<DataItem> poolVotingThresholds = ((Array) itemDI).getDataItems();
-        BigDecimal motionNoConfidence = toRationalNumber((RationalNumber) poolVotingThresholds.get(0));
-        BigDecimal committeeNormal = toRationalNumber((RationalNumber) poolVotingThresholds.get(1));
-        BigDecimal committeeNoConfidence = toRationalNumber((RationalNumber) poolVotingThresholds.get(2));
-        BigDecimal hardForkInitiation = toRationalNumber((RationalNumber) poolVotingThresholds.get(3));
-        BigDecimal ppSecurityGroup = toRationalNumber((RationalNumber) poolVotingThresholds.get(4));
+        UnitInterval motionNoConfidence = toUnitInterval(poolVotingThresholds.get(0));
+        UnitInterval committeeNormal = toUnitInterval(poolVotingThresholds.get(1));
+        UnitInterval committeeNoConfidence = toUnitInterval(poolVotingThresholds.get(2));
+        UnitInterval hardForkInitiation = toUnitInterval(poolVotingThresholds.get(3));
+        UnitInterval ppSecurityGroup = toUnitInterval(poolVotingThresholds.get(4));
 
         return PoolVotingThresholds.builder()
                 .pvtMotionNoConfidence(motionNoConfidence)
@@ -326,16 +327,16 @@ public enum UpdateSerializer implements Serializer<Update> {
             return null;
 
         List<DataItem> drepVotingThresholds = ((Array) itemDI).getDataItems();
-        BigDecimal motionNoConfidence = toRationalNumber((RationalNumber) drepVotingThresholds.get(0));
-        BigDecimal committeeNormal = toRationalNumber((RationalNumber) drepVotingThresholds.get(1));
-        BigDecimal committeeNoConfidence = toRationalNumber((RationalNumber) drepVotingThresholds.get(2));
-        BigDecimal updateConstitution = toRationalNumber((RationalNumber) drepVotingThresholds.get(3));
-        BigDecimal hardForkInitiation = toRationalNumber((RationalNumber) drepVotingThresholds.get(4));
-        BigDecimal ppNetworkGroup = toRationalNumber((RationalNumber) drepVotingThresholds.get(5));
-        BigDecimal ppEconomicGroup = toRationalNumber((RationalNumber) drepVotingThresholds.get(6));
-        BigDecimal ppTechnicalGroup = toRationalNumber((RationalNumber) drepVotingThresholds.get(7));
-        BigDecimal ppGovernanceGroup = toRationalNumber((RationalNumber) drepVotingThresholds.get(8));
-        BigDecimal treasuryWithdrawal = toRationalNumber((RationalNumber) drepVotingThresholds.get(9));
+        UnitInterval motionNoConfidence = toUnitInterval(drepVotingThresholds.get(0));
+        UnitInterval committeeNormal = toUnitInterval(drepVotingThresholds.get(1));
+        UnitInterval committeeNoConfidence = toUnitInterval(drepVotingThresholds.get(2));
+        UnitInterval updateConstitution = toUnitInterval(drepVotingThresholds.get(3));
+        UnitInterval hardForkInitiation = toUnitInterval(drepVotingThresholds.get(4));
+        UnitInterval ppNetworkGroup = toUnitInterval(drepVotingThresholds.get(5));
+        UnitInterval ppEconomicGroup = toUnitInterval(drepVotingThresholds.get(6));
+        UnitInterval ppTechnicalGroup = toUnitInterval(drepVotingThresholds.get(7));
+        UnitInterval ppGovernanceGroup = toUnitInterval(drepVotingThresholds.get(8));
+        UnitInterval treasuryWithdrawal = toUnitInterval(drepVotingThresholds.get(9));
 
         return DrepVoteThresholds.builder()
                 .dvtMotionNoConfidence(motionNoConfidence)

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/model/serializers/governance/GovActionSerializer.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/model/serializers/governance/GovActionSerializer.java
@@ -14,6 +14,7 @@ import com.bloxbean.cardano.yaci.core.model.governance.actions.*;
 import com.bloxbean.cardano.yaci.core.model.serializers.UpdateSerializer;
 import com.bloxbean.cardano.yaci.core.model.serializers.WithdrawalsSerializer;
 import com.bloxbean.cardano.yaci.core.protocol.Serializer;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 
 import java.math.BigDecimal;
@@ -151,7 +152,7 @@ public enum GovActionSerializer implements Serializer<GovAction> {
         }
 
         //unit_interval
-        BigDecimal unitInterval = toRationalNumber(govActionArray.get(4));
+        UnitInterval unitInterval = toUnitInterval(govActionArray.get(4));
         return new UpdateCommittee(govActionId, committeeColdCredSet, committeeColdCredEpochMap, unitInterval);
     }
 

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/CurrentProtocolParamsQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/CurrentProtocolParamsQuery.java
@@ -8,6 +8,8 @@ import com.bloxbean.cardano.yaci.core.model.ProtocolParamUpdate;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.api.Era;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.api.EraQuery;
+import com.bloxbean.cardano.yaci.core.types.NonNegativeInterval;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import lombok.AllArgsConstructor;
@@ -93,13 +95,13 @@ public class CurrentProtocolParamsQuery implements EraQuery<CurrentProtocolParam
         Integer nOpt = itemDI != null ? toInt(itemDI) : null;
 
         itemDI = paramsDIList.get(9);
-        BigDecimal poolPledgeInfluence = itemDI != null ? toRationalNumber(itemDI) : null;
+        NonNegativeInterval poolPledgeInfluence = itemDI != null ? toNonNegativeInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(10);
-        BigDecimal expansionRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval expansionRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(11);
-        BigDecimal treasuryGrowthRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval treasuryGrowthRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
 //        itemDI = paramsDIList.get(12);
 //        BigDecimal decentralizationParam = itemDI != null? toRationalNumber(itemDI): null;
@@ -142,12 +144,12 @@ public class CurrentProtocolParamsQuery implements EraQuery<CurrentProtocolParam
         }
 
         //exUnits prices
-        BigDecimal priceMem = null;
-        BigDecimal priceSteps = null;
+        NonNegativeInterval priceMem = null;
+        NonNegativeInterval priceSteps = null;
         itemDI = paramsDIList.get(17);
         if (itemDI != null) {
             List<DataItem> exUnitPriceList = ((Array) itemDI).getDataItems();
-            Tuple<BigDecimal, BigDecimal> tuple = getExUnitPrices(exUnitPriceList);
+            Tuple<NonNegativeInterval, NonNegativeInterval> tuple = getExUnitPrices(exUnitPriceList);
             priceMem = tuple._1;
             priceSteps = tuple._2;
         }
@@ -259,13 +261,13 @@ public class CurrentProtocolParamsQuery implements EraQuery<CurrentProtocolParam
         Integer nOpt = itemDI != null ? toInt(itemDI) : null;
 
         itemDI = paramsDIList.get(9);
-        BigDecimal poolPledgeInfluence = itemDI != null ? toRationalNumber(itemDI) : null;
+        NonNegativeInterval poolPledgeInfluence = itemDI != null ? toNonNegativeInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(10);
-        BigDecimal expansionRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval expansionRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(11);
-        BigDecimal treasuryGrowthRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval treasuryGrowthRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         Integer protocolMajorVersion = null;
         Integer protocolMinorVersion = null;
@@ -296,12 +298,12 @@ public class CurrentProtocolParamsQuery implements EraQuery<CurrentProtocolParam
         }
 
         //exUnits prices
-        BigDecimal priceMem = null;
-        BigDecimal priceSteps = null;
+        NonNegativeInterval priceMem = null;
+        NonNegativeInterval priceSteps = null;
         itemDI = paramsDIList.get(16);
         if (itemDI != null) {
             List<DataItem> exUnitPriceList = ((Array) itemDI).getDataItems();
-            Tuple<BigDecimal, BigDecimal> tuple = getExUnitPrices(exUnitPriceList);
+            Tuple<NonNegativeInterval, NonNegativeInterval> tuple = getExUnitPrices(exUnitPriceList);
             priceMem = tuple._1;
             priceSteps = tuple._2;
         }
@@ -340,11 +342,11 @@ public class CurrentProtocolParamsQuery implements EraQuery<CurrentProtocolParam
 
         //Pool Voting Threshold
         itemDI = paramsDIList.get(22);
-        BigDecimal motionNoConfidence = null;
-        BigDecimal committeeNormal = null;
-        BigDecimal committeeNoConfidence = null;
-        BigDecimal hardForkInitiation = null;
-        BigDecimal ppSecurityGroup = null;
+        UnitInterval motionNoConfidence = null;
+        UnitInterval committeeNormal = null;
+        UnitInterval committeeNoConfidence = null;
+        UnitInterval hardForkInitiation = null;
+        UnitInterval ppSecurityGroup = null;
         if (itemDI != null) {
             List<DataItem> poolVotingThresholdList = ((Array) itemDI).getDataItems();
             if (poolVotingThresholdList.size() != 5)
@@ -356,25 +358,25 @@ public class CurrentProtocolParamsQuery implements EraQuery<CurrentProtocolParam
             var pvtHardForkInitiationDI = (RationalNumber) poolVotingThresholdList.get(3);
             var pvtPPSecurityGroupDI = (RationalNumber) poolVotingThresholdList.get(4);
 
-            motionNoConfidence = toRationalNumber(pvtMotionNoConfidenceDI);
-            committeeNormal = toRationalNumber(pvtCommitteeNormalDI);
-            committeeNoConfidence = toRationalNumber(pvtCommitteeNoConfidenceDI);
-            hardForkInitiation = toRationalNumber(pvtHardForkInitiationDI);
-            ppSecurityGroup = toRationalNumber(pvtPPSecurityGroupDI);
+            motionNoConfidence = toUnitInterval(pvtMotionNoConfidenceDI);
+            committeeNormal = toUnitInterval(pvtCommitteeNormalDI);
+            committeeNoConfidence = toUnitInterval(pvtCommitteeNoConfidenceDI);
+            hardForkInitiation = toUnitInterval(pvtHardForkInitiationDI);
+            ppSecurityGroup = toUnitInterval(pvtPPSecurityGroupDI);
         }
 
         //DRep voting thresholds
         itemDI = paramsDIList.get(23);
-        BigDecimal dvtMotionNoConfidence = null;
-        BigDecimal dvtCommitteeNormal = null;
-        BigDecimal dvtCommitteeNoConfidence = null;
-        BigDecimal dvtUpdateToConstitution = null;
-        BigDecimal dvtHardForkInitiation = null;
-        BigDecimal dvtPPNetworkGroup = null;
-        BigDecimal dvtPPEconomicGroup = null;
-        BigDecimal dvtPPTechnicalGroup = null;
-        BigDecimal dvtPPGovGroup = null;
-        BigDecimal dvtTreasuryWithdrawal = null;
+        UnitInterval dvtMotionNoConfidence = null;
+        UnitInterval dvtCommitteeNormal = null;
+        UnitInterval dvtCommitteeNoConfidence = null;
+        UnitInterval dvtUpdateToConstitution = null;
+        UnitInterval dvtHardForkInitiation = null;
+        UnitInterval dvtPPNetworkGroup = null;
+        UnitInterval dvtPPEconomicGroup = null;
+        UnitInterval dvtPPTechnicalGroup = null;
+        UnitInterval dvtPPGovGroup = null;
+        UnitInterval dvtTreasuryWithdrawal = null;
 
         if (itemDI != null) {
             List<DataItem> dRepVotingThresholdList = ((Array) itemDI).getDataItems();
@@ -392,16 +394,16 @@ public class CurrentProtocolParamsQuery implements EraQuery<CurrentProtocolParam
             var dvtPPGovGroupDI = (RationalNumber) dRepVotingThresholdList.get(8);
             var dvtTreasuryWithdrawalDI = (RationalNumber) dRepVotingThresholdList.get(9);
 
-            dvtMotionNoConfidence = toRationalNumber(dvtMotionNoConfidenceDI);
-            dvtCommitteeNormal = toRationalNumber(dvtCommitteeNormalDI);
-            dvtCommitteeNoConfidence = toRationalNumber(dvtCommitteeNoConfidenceDI);
-            dvtUpdateToConstitution = toRationalNumber(dvtUpdateToConstitutionDI);
-            dvtHardForkInitiation = toRationalNumber(dvtHardForkInitiationDI);
-            dvtPPNetworkGroup = toRationalNumber(dvtPPNetworkGroupDI);
-            dvtPPEconomicGroup = toRationalNumber(dvtPPEconomicGroupDI);
-            dvtPPTechnicalGroup = toRationalNumber(dvtPPTechnicalGroupDI);
-            dvtPPGovGroup = toRationalNumber(dvtPPGovGroupDI);
-            dvtTreasuryWithdrawal = toRationalNumber(dvtTreasuryWithdrawalDI);
+            dvtMotionNoConfidence = toUnitInterval(dvtMotionNoConfidenceDI);
+            dvtCommitteeNormal = toUnitInterval(dvtCommitteeNormalDI);
+            dvtCommitteeNoConfidence = toUnitInterval(dvtCommitteeNoConfidenceDI);
+            dvtUpdateToConstitution = toUnitInterval(dvtUpdateToConstitutionDI);
+            dvtHardForkInitiation = toUnitInterval(dvtHardForkInitiationDI);
+            dvtPPNetworkGroup = toUnitInterval(dvtPPNetworkGroupDI);
+            dvtPPEconomicGroup = toUnitInterval(dvtPPEconomicGroupDI);
+            dvtPPTechnicalGroup = toUnitInterval(dvtPPTechnicalGroupDI);
+            dvtPPGovGroup = toUnitInterval(dvtPPGovGroupDI);
+            dvtTreasuryWithdrawal = toUnitInterval(dvtTreasuryWithdrawalDI);
         }
 
         itemDI = paramsDIList.get(24);
@@ -422,10 +424,10 @@ public class CurrentProtocolParamsQuery implements EraQuery<CurrentProtocolParam
         itemDI = paramsDIList.get(29);
         Integer drepInactivityPeriod = itemDI != null ? toInt(itemDI) : null;
 
-        BigDecimal minFeeRefScriptCostPerByte = null; //TODO -- Remove if condition once this is available in the node release
+        NonNegativeInterval minFeeRefScriptCostPerByte = null; //TODO -- Remove if condition once this is available in the node release
         if (paramsDIList.size() > 30) {
             itemDI = paramsDIList.get(30);
-            minFeeRefScriptCostPerByte = itemDI != null ? toRationalNumber(itemDI) : null;
+            minFeeRefScriptCostPerByte = itemDI != null ? toNonNegativeInterval(itemDI) : null;
         }
 
         ProtocolParamUpdate protocolParams = ProtocolParamUpdate.builder()
@@ -496,12 +498,12 @@ public class CurrentProtocolParamsQuery implements EraQuery<CurrentProtocolParam
         return new Tuple<>(mem, steps);
     }
 
-    private Tuple<BigDecimal, BigDecimal> getExUnitPrices(List<DataItem> exunits) {
+    private Tuple<NonNegativeInterval, NonNegativeInterval> getExUnitPrices(List<DataItem> exunits) {
         RationalNumber memPriceRN = (RationalNumber) exunits.get(0);
         RationalNumber stepPriceRN = (RationalNumber) exunits.get(1);
 
-        BigDecimal memPrice = toRationalNumber(memPriceRN);
-        BigDecimal stepPrice = toRationalNumber(stepPriceRN);
+        NonNegativeInterval memPrice = toNonNegativeInterval(memPriceRN);
+        NonNegativeInterval stepPrice = toNonNegativeInterval(stepPriceRN);
 
         return new Tuple<>(memPrice, stepPrice);
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GetFuturePParamsQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GetFuturePParamsQuery.java
@@ -8,13 +8,14 @@ import com.bloxbean.cardano.yaci.core.model.ProtocolParamUpdate;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.api.Era;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.api.EraQuery;
+import com.bloxbean.cardano.yaci.core.types.NonNegativeInterval;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -87,13 +88,13 @@ public class GetFuturePParamsQuery implements EraQuery<GetFuturePParamsQueryResu
         Integer nOpt = itemDI != null ? toInt(itemDI) : null;
 
         itemDI = paramsDIList.get(9);
-        BigDecimal poolPledgeInfluence = itemDI != null ? toRationalNumber(itemDI) : null;
+        NonNegativeInterval poolPledgeInfluence = itemDI != null ? toNonNegativeInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(10);
-        BigDecimal expansionRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval expansionRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(11);
-        BigDecimal treasuryGrowthRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval treasuryGrowthRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         Integer protocolMajorVersion = null;
         Integer protocolMinorVersion = null;
@@ -124,12 +125,12 @@ public class GetFuturePParamsQuery implements EraQuery<GetFuturePParamsQueryResu
         }
 
         //exUnits prices
-        BigDecimal priceMem = null;
-        BigDecimal priceSteps = null;
+        NonNegativeInterval priceMem = null;
+        NonNegativeInterval priceSteps = null;
         itemDI = paramsDIList.get(16);
         if (itemDI != null) {
             List<DataItem> exUnitPriceList = ((Array) itemDI).getDataItems();
-            Tuple<BigDecimal, BigDecimal> tuple = getExUnitPrices(exUnitPriceList);
+            Tuple<NonNegativeInterval, NonNegativeInterval> tuple = getExUnitPrices(exUnitPriceList);
             priceMem = tuple._1;
             priceSteps = tuple._2;
         }
@@ -168,11 +169,11 @@ public class GetFuturePParamsQuery implements EraQuery<GetFuturePParamsQueryResu
 
         //Pool Voting Threshold
         itemDI = paramsDIList.get(22);
-        BigDecimal motionNoConfidence = null;
-        BigDecimal committeeNormal = null;
-        BigDecimal committeeNoConfidence = null;
-        BigDecimal hardForkInitiation = null;
-        BigDecimal ppSecurityGroup = null;
+        UnitInterval motionNoConfidence = null;
+        UnitInterval committeeNormal = null;
+        UnitInterval committeeNoConfidence = null;
+        UnitInterval hardForkInitiation = null;
+        UnitInterval ppSecurityGroup = null;
         if (itemDI != null) {
             List<DataItem> poolVotingThresholdList = ((Array) itemDI).getDataItems();
             if (poolVotingThresholdList.size() != 5)
@@ -184,25 +185,25 @@ public class GetFuturePParamsQuery implements EraQuery<GetFuturePParamsQueryResu
             var pvtHardForkInitiationDI = (RationalNumber) poolVotingThresholdList.get(3);
             var pvtPPSecurityGroupDI = (RationalNumber) poolVotingThresholdList.get(4);
 
-            motionNoConfidence = toRationalNumber(pvtMotionNoConfidenceDI);
-            committeeNormal = toRationalNumber(pvtCommitteeNormalDI);
-            committeeNoConfidence = toRationalNumber(pvtCommitteeNoConfidenceDI);
-            hardForkInitiation = toRationalNumber(pvtHardForkInitiationDI);
-            ppSecurityGroup = toRationalNumber(pvtPPSecurityGroupDI);
+            motionNoConfidence = toUnitInterval(pvtMotionNoConfidenceDI);
+            committeeNormal = toUnitInterval(pvtCommitteeNormalDI);
+            committeeNoConfidence = toUnitInterval(pvtCommitteeNoConfidenceDI);
+            hardForkInitiation = toUnitInterval(pvtHardForkInitiationDI);
+            ppSecurityGroup = toUnitInterval(pvtPPSecurityGroupDI);
         }
 
         //DRep voting thresholds
         itemDI = paramsDIList.get(23);
-        BigDecimal dvtMotionNoConfidence = null;
-        BigDecimal dvtCommitteeNormal = null;
-        BigDecimal dvtCommitteeNoConfidence = null;
-        BigDecimal dvtUpdateToConstitution = null;
-        BigDecimal dvtHardForkInitiation = null;
-        BigDecimal dvtPPNetworkGroup = null;
-        BigDecimal dvtPPEconomicGroup = null;
-        BigDecimal dvtPPTechnicalGroup = null;
-        BigDecimal dvtPPGovGroup = null;
-        BigDecimal dvtTreasuryWithdrawal = null;
+        UnitInterval dvtMotionNoConfidence = null;
+        UnitInterval dvtCommitteeNormal = null;
+        UnitInterval dvtCommitteeNoConfidence = null;
+        UnitInterval dvtUpdateToConstitution = null;
+        UnitInterval dvtHardForkInitiation = null;
+        UnitInterval dvtPPNetworkGroup = null;
+        UnitInterval dvtPPEconomicGroup = null;
+        UnitInterval dvtPPTechnicalGroup = null;
+        UnitInterval dvtPPGovGroup = null;
+        UnitInterval dvtTreasuryWithdrawal = null;
 
         if (itemDI != null) {
             List<DataItem> dRepVotingThresholdList = ((Array) itemDI).getDataItems();
@@ -220,16 +221,16 @@ public class GetFuturePParamsQuery implements EraQuery<GetFuturePParamsQueryResu
             var dvtPPGovGroupDI = (RationalNumber) dRepVotingThresholdList.get(8);
             var dvtTreasuryWithdrawalDI = (RationalNumber) dRepVotingThresholdList.get(9);
 
-            dvtMotionNoConfidence = toRationalNumber(dvtMotionNoConfidenceDI);
-            dvtCommitteeNormal = toRationalNumber(dvtCommitteeNormalDI);
-            dvtCommitteeNoConfidence = toRationalNumber(dvtCommitteeNoConfidenceDI);
-            dvtUpdateToConstitution = toRationalNumber(dvtUpdateToConstitutionDI);
-            dvtHardForkInitiation = toRationalNumber(dvtHardForkInitiationDI);
-            dvtPPNetworkGroup = toRationalNumber(dvtPPNetworkGroupDI);
-            dvtPPEconomicGroup = toRationalNumber(dvtPPEconomicGroupDI);
-            dvtPPTechnicalGroup = toRationalNumber(dvtPPTechnicalGroupDI);
-            dvtPPGovGroup = toRationalNumber(dvtPPGovGroupDI);
-            dvtTreasuryWithdrawal = toRationalNumber(dvtTreasuryWithdrawalDI);
+            dvtMotionNoConfidence = toUnitInterval(dvtMotionNoConfidenceDI);
+            dvtCommitteeNormal = toUnitInterval(dvtCommitteeNormalDI);
+            dvtCommitteeNoConfidence = toUnitInterval(dvtCommitteeNoConfidenceDI);
+            dvtUpdateToConstitution = toUnitInterval(dvtUpdateToConstitutionDI);
+            dvtHardForkInitiation = toUnitInterval(dvtHardForkInitiationDI);
+            dvtPPNetworkGroup = toUnitInterval(dvtPPNetworkGroupDI);
+            dvtPPEconomicGroup = toUnitInterval(dvtPPEconomicGroupDI);
+            dvtPPTechnicalGroup = toUnitInterval(dvtPPTechnicalGroupDI);
+            dvtPPGovGroup = toUnitInterval(dvtPPGovGroupDI);
+            dvtTreasuryWithdrawal = toUnitInterval(dvtTreasuryWithdrawalDI);
         }
 
         itemDI = paramsDIList.get(24);
@@ -250,10 +251,10 @@ public class GetFuturePParamsQuery implements EraQuery<GetFuturePParamsQueryResu
         itemDI = paramsDIList.get(29);
         Integer drepInactivityPeriod = itemDI != null ? toInt(itemDI) : null;
 
-        BigDecimal minFeeRefScriptCostPerByte = null;
+        NonNegativeInterval minFeeRefScriptCostPerByte = null;
         if (paramsDIList.size() > 30) {
             itemDI = paramsDIList.get(30);
-            minFeeRefScriptCostPerByte = itemDI != null ? toRationalNumber(itemDI) : null;
+            minFeeRefScriptCostPerByte = itemDI != null ? toNonNegativeInterval(itemDI) : null;
         }
 
         return ProtocolParamUpdate.builder()
@@ -322,12 +323,12 @@ public class GetFuturePParamsQuery implements EraQuery<GetFuturePParamsQueryResu
         return new Tuple<>(mem, steps);
     }
 
-    private Tuple<BigDecimal, BigDecimal> getExUnitPrices(List<DataItem> exunits) {
+    private Tuple<NonNegativeInterval, NonNegativeInterval> getExUnitPrices(List<DataItem> exunits) {
         RationalNumber memPriceRN = (RationalNumber) exunits.get(0);
         RationalNumber stepPriceRN = (RationalNumber) exunits.get(1);
 
-        BigDecimal memPrice = toRationalNumber(memPriceRN);
-        BigDecimal stepPrice = toRationalNumber(stepPriceRN);
+        NonNegativeInterval memPrice = toNonNegativeInterval(memPriceRN);
+        NonNegativeInterval stepPrice = toNonNegativeInterval(stepPriceRN);
 
         return new Tuple<>(memPrice, stepPrice);
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GetRatifyStateQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GetRatifyStateQuery.java
@@ -17,13 +17,14 @@ import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.EnactSta
 import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.Proposal;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.ProposalType;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.RatifyState;
+import com.bloxbean.cardano.yaci.core.types.NonNegativeInterval;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,7 +32,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import static com.bloxbean.cardano.yaci.core.util.CborSerializationUtil.*;
-import static com.bloxbean.cardano.yaci.core.util.CborSerializationUtil.toRationalNumber;
 
 @Getter
 @AllArgsConstructor
@@ -246,7 +246,7 @@ public class GetRatifyStateQuery implements EraQuery<GetRatifyStateQueryResult> 
         }
 
         var committeeThresholdDI = (RationalNumber) committeeDIList.get(1);
-        BigDecimal committeeThreshold = toRationalNumber(committeeThresholdDI);
+        UnitInterval committeeThreshold = toUnitInterval(committeeThresholdDI);
 
         return Committee.builder()
                 .committeeColdCredentialEpoch(committeeColdCredentialEpoch)
@@ -292,13 +292,13 @@ public class GetRatifyStateQuery implements EraQuery<GetRatifyStateQueryResult> 
         Integer nOpt = itemDI != null ? toInt(itemDI) : null;
 
         itemDI = paramsDIList.get(9);
-        BigDecimal poolPledgeInfluence = itemDI != null ? toRationalNumber(itemDI) : null;
+        NonNegativeInterval poolPledgeInfluence = itemDI != null ? toNonNegativeInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(10);
-        BigDecimal expansionRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval expansionRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(11);
-        BigDecimal treasuryGrowthRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval treasuryGrowthRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         Integer protocolMajorVersion = null;
         Integer protocolMinorVersion = null;
@@ -329,12 +329,12 @@ public class GetRatifyStateQuery implements EraQuery<GetRatifyStateQueryResult> 
         }
 
         //exUnits prices
-        BigDecimal priceMem = null;
-        BigDecimal priceSteps = null;
+        NonNegativeInterval priceMem = null;
+        NonNegativeInterval priceSteps = null;
         itemDI = paramsDIList.get(16);
         if (itemDI != null) {
             List<DataItem> exUnitPriceList = ((Array) itemDI).getDataItems();
-            Tuple<BigDecimal, BigDecimal> tuple = getExUnitPrices(exUnitPriceList);
+            Tuple<NonNegativeInterval, NonNegativeInterval> tuple = getExUnitPrices(exUnitPriceList);
             priceMem = tuple._1;
             priceSteps = tuple._2;
         }
@@ -373,11 +373,11 @@ public class GetRatifyStateQuery implements EraQuery<GetRatifyStateQueryResult> 
 
         //Pool Voting Threshold
         itemDI = paramsDIList.get(22);
-        BigDecimal motionNoConfidence = null;
-        BigDecimal committeeNormal = null;
-        BigDecimal committeeNoConfidence = null;
-        BigDecimal hardForkInitiation = null;
-        BigDecimal ppSecurityGroup = null;
+        UnitInterval motionNoConfidence = null;
+        UnitInterval committeeNormal = null;
+        UnitInterval committeeNoConfidence = null;
+        UnitInterval hardForkInitiation = null;
+        UnitInterval ppSecurityGroup = null;
         if (itemDI != null) {
             List<DataItem> poolVotingThresholdList = ((Array) itemDI).getDataItems();
             if (poolVotingThresholdList.size() != 5)
@@ -389,25 +389,25 @@ public class GetRatifyStateQuery implements EraQuery<GetRatifyStateQueryResult> 
             var pvtHardForkInitiationDI = (RationalNumber) poolVotingThresholdList.get(3);
             var pvtPPSecurityGroupDI = (RationalNumber) poolVotingThresholdList.get(4);
 
-            motionNoConfidence = toRationalNumber(pvtMotionNoConfidenceDI);
-            committeeNormal = toRationalNumber(pvtCommitteeNormalDI);
-            committeeNoConfidence = toRationalNumber(pvtCommitteeNoConfidenceDI);
-            hardForkInitiation = toRationalNumber(pvtHardForkInitiationDI);
-            ppSecurityGroup = toRationalNumber(pvtPPSecurityGroupDI);
+            motionNoConfidence = toUnitInterval(pvtMotionNoConfidenceDI);
+            committeeNormal = toUnitInterval(pvtCommitteeNormalDI);
+            committeeNoConfidence = toUnitInterval(pvtCommitteeNoConfidenceDI);
+            hardForkInitiation = toUnitInterval(pvtHardForkInitiationDI);
+            ppSecurityGroup = toUnitInterval(pvtPPSecurityGroupDI);
         }
 
         //DRep voting thresholds
         itemDI = paramsDIList.get(23);
-        BigDecimal dvtMotionNoConfidence = null;
-        BigDecimal dvtCommitteeNormal = null;
-        BigDecimal dvtCommitteeNoConfidence = null;
-        BigDecimal dvtUpdateToConstitution = null;
-        BigDecimal dvtHardForkInitiation = null;
-        BigDecimal dvtPPNetworkGroup = null;
-        BigDecimal dvtPPEconomicGroup = null;
-        BigDecimal dvtPPTechnicalGroup = null;
-        BigDecimal dvtPPGovGroup = null;
-        BigDecimal dvtTreasuryWithdrawal = null;
+        UnitInterval dvtMotionNoConfidence = null;
+        UnitInterval dvtCommitteeNormal = null;
+        UnitInterval dvtCommitteeNoConfidence = null;
+        UnitInterval dvtUpdateToConstitution = null;
+        UnitInterval dvtHardForkInitiation = null;
+        UnitInterval dvtPPNetworkGroup = null;
+        UnitInterval dvtPPEconomicGroup = null;
+        UnitInterval dvtPPTechnicalGroup = null;
+        UnitInterval dvtPPGovGroup = null;
+        UnitInterval dvtTreasuryWithdrawal = null;
 
         if (itemDI != null) {
             List<DataItem> dRepVotingThresholdList = ((Array) itemDI).getDataItems();
@@ -425,16 +425,16 @@ public class GetRatifyStateQuery implements EraQuery<GetRatifyStateQueryResult> 
             var dvtPPGovGroupDI = (RationalNumber) dRepVotingThresholdList.get(8);
             var dvtTreasuryWithdrawalDI = (RationalNumber) dRepVotingThresholdList.get(9);
 
-            dvtMotionNoConfidence = toRationalNumber(dvtMotionNoConfidenceDI);
-            dvtCommitteeNormal = toRationalNumber(dvtCommitteeNormalDI);
-            dvtCommitteeNoConfidence = toRationalNumber(dvtCommitteeNoConfidenceDI);
-            dvtUpdateToConstitution = toRationalNumber(dvtUpdateToConstitutionDI);
-            dvtHardForkInitiation = toRationalNumber(dvtHardForkInitiationDI);
-            dvtPPNetworkGroup = toRationalNumber(dvtPPNetworkGroupDI);
-            dvtPPEconomicGroup = toRationalNumber(dvtPPEconomicGroupDI);
-            dvtPPTechnicalGroup = toRationalNumber(dvtPPTechnicalGroupDI);
-            dvtPPGovGroup = toRationalNumber(dvtPPGovGroupDI);
-            dvtTreasuryWithdrawal = toRationalNumber(dvtTreasuryWithdrawalDI);
+            dvtMotionNoConfidence = toUnitInterval(dvtMotionNoConfidenceDI);
+            dvtCommitteeNormal = toUnitInterval(dvtCommitteeNormalDI);
+            dvtCommitteeNoConfidence = toUnitInterval(dvtCommitteeNoConfidenceDI);
+            dvtUpdateToConstitution = toUnitInterval(dvtUpdateToConstitutionDI);
+            dvtHardForkInitiation = toUnitInterval(dvtHardForkInitiationDI);
+            dvtPPNetworkGroup = toUnitInterval(dvtPPNetworkGroupDI);
+            dvtPPEconomicGroup = toUnitInterval(dvtPPEconomicGroupDI);
+            dvtPPTechnicalGroup = toUnitInterval(dvtPPTechnicalGroupDI);
+            dvtPPGovGroup = toUnitInterval(dvtPPGovGroupDI);
+            dvtTreasuryWithdrawal = toUnitInterval(dvtTreasuryWithdrawalDI);
         }
 
         itemDI = paramsDIList.get(24);
@@ -455,10 +455,10 @@ public class GetRatifyStateQuery implements EraQuery<GetRatifyStateQueryResult> 
         itemDI = paramsDIList.get(29);
         Integer drepInactivityPeriod = itemDI != null ? toInt(itemDI) : null;
 
-        BigDecimal minFeeRefScriptCostPerByte = null; //TODO -- Remove if condition once this is available in the node release
+        NonNegativeInterval minFeeRefScriptCostPerByte = null; //TODO -- Remove if condition once this is available in the node release
         if (paramsDIList.size() > 30) {
             itemDI = paramsDIList.get(30);
-            minFeeRefScriptCostPerByte = itemDI != null ? toRationalNumber(itemDI) : null;
+            minFeeRefScriptCostPerByte = itemDI != null ? toNonNegativeInterval(itemDI) : null;
         }
 
         return ProtocolParamUpdate.builder()
@@ -527,12 +527,12 @@ public class GetRatifyStateQuery implements EraQuery<GetRatifyStateQueryResult> 
         return new Tuple<>(mem, steps);
     }
 
-    private Tuple<BigDecimal, BigDecimal> getExUnitPrices(List<DataItem> exunits) {
+    private Tuple<NonNegativeInterval, NonNegativeInterval> getExUnitPrices(List<DataItem> exunits) {
         RationalNumber memPriceRN = (RationalNumber) exunits.get(0);
         RationalNumber stepPriceRN = (RationalNumber) exunits.get(1);
 
-        BigDecimal memPrice = toRationalNumber(memPriceRN);
-        BigDecimal stepPrice = toRationalNumber(stepPriceRN);
+        NonNegativeInterval memPrice = toNonNegativeInterval(memPriceRN);
+        NonNegativeInterval stepPrice = toNonNegativeInterval(stepPriceRN);
 
         return new Tuple<>(memPrice, stepPrice);
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GovStateQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GovStateQuery.java
@@ -17,6 +17,8 @@ import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.EnactSta
 import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.Proposal;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.ProposalType;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.RatifyState;
+import com.bloxbean.cardano.yaci.core.types.NonNegativeInterval;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import lombok.AllArgsConstructor;
@@ -222,13 +224,13 @@ public class GovStateQuery implements EraQuery<GovStateQueryResult> {
         Integer nOpt = itemDI != null ? toInt(itemDI) : null;
 
         itemDI = paramsDIList.get(9);
-        BigDecimal poolPledgeInfluence = itemDI != null ? toRationalNumber(itemDI) : null;
+        NonNegativeInterval poolPledgeInfluence = itemDI != null ? toNonNegativeInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(10);
-        BigDecimal expansionRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval expansionRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         itemDI = paramsDIList.get(11);
-        BigDecimal treasuryGrowthRate = itemDI != null ? toRationalNumber(itemDI) : null;
+        UnitInterval treasuryGrowthRate = itemDI != null ? toUnitInterval(itemDI) : null;
 
         Integer protocolMajorVersion = null;
         Integer protocolMinorVersion = null;
@@ -259,12 +261,12 @@ public class GovStateQuery implements EraQuery<GovStateQueryResult> {
         }
 
         //exUnits prices
-        BigDecimal priceMem = null;
-        BigDecimal priceSteps = null;
+        NonNegativeInterval priceMem = null;
+        NonNegativeInterval priceSteps = null;
         itemDI = paramsDIList.get(16);
         if (itemDI != null) {
             List<DataItem> exUnitPriceList = ((Array) itemDI).getDataItems();
-            Tuple<BigDecimal, BigDecimal> tuple = getExUnitPrices(exUnitPriceList);
+            Tuple<NonNegativeInterval, NonNegativeInterval> tuple = getExUnitPrices(exUnitPriceList);
             priceMem = tuple._1;
             priceSteps = tuple._2;
         }
@@ -303,11 +305,11 @@ public class GovStateQuery implements EraQuery<GovStateQueryResult> {
 
         //Pool Voting Threshold
         itemDI = paramsDIList.get(22);
-        BigDecimal motionNoConfidence = null;
-        BigDecimal committeeNormal = null;
-        BigDecimal committeeNoConfidence = null;
-        BigDecimal hardForkInitiation = null;
-        BigDecimal ppSecurityGroup = null;
+        UnitInterval motionNoConfidence = null;
+        UnitInterval committeeNormal = null;
+        UnitInterval committeeNoConfidence = null;
+        UnitInterval hardForkInitiation = null;
+        UnitInterval ppSecurityGroup = null;
         if (itemDI != null) {
             List<DataItem> poolVotingThresholdList = ((Array) itemDI).getDataItems();
             if (poolVotingThresholdList.size() != 5)
@@ -319,25 +321,25 @@ public class GovStateQuery implements EraQuery<GovStateQueryResult> {
             var pvtHardForkInitiationDI = (RationalNumber) poolVotingThresholdList.get(3);
             var pvtPPSecurityGroupDI = (RationalNumber) poolVotingThresholdList.get(4);
 
-            motionNoConfidence = toRationalNumber(pvtMotionNoConfidenceDI);
-            committeeNormal = toRationalNumber(pvtCommitteeNormalDI);
-            committeeNoConfidence = toRationalNumber(pvtCommitteeNoConfidenceDI);
-            hardForkInitiation = toRationalNumber(pvtHardForkInitiationDI);
-            ppSecurityGroup = toRationalNumber(pvtPPSecurityGroupDI);
+            motionNoConfidence = toUnitInterval(pvtMotionNoConfidenceDI);
+            committeeNormal = toUnitInterval(pvtCommitteeNormalDI);
+            committeeNoConfidence = toUnitInterval(pvtCommitteeNoConfidenceDI);
+            hardForkInitiation = toUnitInterval(pvtHardForkInitiationDI);
+            ppSecurityGroup = toUnitInterval(pvtPPSecurityGroupDI);
         }
 
         //DRep voting thresholds
         itemDI = paramsDIList.get(23);
-        BigDecimal dvtMotionNoConfidence = null;
-        BigDecimal dvtCommitteeNormal = null;
-        BigDecimal dvtCommitteeNoConfidence = null;
-        BigDecimal dvtUpdateToConstitution = null;
-        BigDecimal dvtHardForkInitiation = null;
-        BigDecimal dvtPPNetworkGroup = null;
-        BigDecimal dvtPPEconomicGroup = null;
-        BigDecimal dvtPPTechnicalGroup = null;
-        BigDecimal dvtPPGovGroup = null;
-        BigDecimal dvtTreasuryWithdrawal = null;
+        UnitInterval dvtMotionNoConfidence = null;
+        UnitInterval dvtCommitteeNormal = null;
+        UnitInterval dvtCommitteeNoConfidence = null;
+        UnitInterval dvtUpdateToConstitution = null;
+        UnitInterval dvtHardForkInitiation = null;
+        UnitInterval dvtPPNetworkGroup = null;
+        UnitInterval dvtPPEconomicGroup = null;
+        UnitInterval dvtPPTechnicalGroup = null;
+        UnitInterval dvtPPGovGroup = null;
+        UnitInterval dvtTreasuryWithdrawal = null;
 
         if (itemDI != null) {
             List<DataItem> dRepVotingThresholdList = ((Array) itemDI).getDataItems();
@@ -355,16 +357,16 @@ public class GovStateQuery implements EraQuery<GovStateQueryResult> {
             var dvtPPGovGroupDI = (RationalNumber) dRepVotingThresholdList.get(8);
             var dvtTreasuryWithdrawalDI = (RationalNumber) dRepVotingThresholdList.get(9);
 
-            dvtMotionNoConfidence = toRationalNumber(dvtMotionNoConfidenceDI);
-            dvtCommitteeNormal = toRationalNumber(dvtCommitteeNormalDI);
-            dvtCommitteeNoConfidence = toRationalNumber(dvtCommitteeNoConfidenceDI);
-            dvtUpdateToConstitution = toRationalNumber(dvtUpdateToConstitutionDI);
-            dvtHardForkInitiation = toRationalNumber(dvtHardForkInitiationDI);
-            dvtPPNetworkGroup = toRationalNumber(dvtPPNetworkGroupDI);
-            dvtPPEconomicGroup = toRationalNumber(dvtPPEconomicGroupDI);
-            dvtPPTechnicalGroup = toRationalNumber(dvtPPTechnicalGroupDI);
-            dvtPPGovGroup = toRationalNumber(dvtPPGovGroupDI);
-            dvtTreasuryWithdrawal = toRationalNumber(dvtTreasuryWithdrawalDI);
+            dvtMotionNoConfidence = toUnitInterval(dvtMotionNoConfidenceDI);
+            dvtCommitteeNormal = toUnitInterval(dvtCommitteeNormalDI);
+            dvtCommitteeNoConfidence = toUnitInterval(dvtCommitteeNoConfidenceDI);
+            dvtUpdateToConstitution = toUnitInterval(dvtUpdateToConstitutionDI);
+            dvtHardForkInitiation = toUnitInterval(dvtHardForkInitiationDI);
+            dvtPPNetworkGroup = toUnitInterval(dvtPPNetworkGroupDI);
+            dvtPPEconomicGroup = toUnitInterval(dvtPPEconomicGroupDI);
+            dvtPPTechnicalGroup = toUnitInterval(dvtPPTechnicalGroupDI);
+            dvtPPGovGroup = toUnitInterval(dvtPPGovGroupDI);
+            dvtTreasuryWithdrawal = toUnitInterval(dvtTreasuryWithdrawalDI);
         }
 
         itemDI = paramsDIList.get(24);
@@ -385,10 +387,10 @@ public class GovStateQuery implements EraQuery<GovStateQueryResult> {
         itemDI = paramsDIList.get(29);
         Integer drepInactivityPeriod = itemDI != null ? toInt(itemDI) : null;
 
-        BigDecimal minFeeRefScriptCostPerByte = null; //TODO -- Remove if condition once this is available in the node release
+        NonNegativeInterval minFeeRefScriptCostPerByte = null; //TODO -- Remove if condition once this is available in the node release
         if (paramsDIList.size() > 30) {
             itemDI = paramsDIList.get(30);
-            minFeeRefScriptCostPerByte = itemDI != null ? toRationalNumber(itemDI) : null;
+            minFeeRefScriptCostPerByte = itemDI != null ? toNonNegativeInterval(itemDI) : null;
         }
 
         return ProtocolParamUpdate.builder()
@@ -457,12 +459,12 @@ public class GovStateQuery implements EraQuery<GovStateQueryResult> {
         return new Tuple<>(mem, steps);
     }
 
-    private Tuple<BigDecimal, BigDecimal> getExUnitPrices(List<DataItem> exunits) {
+    private Tuple<NonNegativeInterval, NonNegativeInterval> getExUnitPrices(List<DataItem> exunits) {
         RationalNumber memPriceRN = (RationalNumber) exunits.get(0);
         RationalNumber stepPriceRN = (RationalNumber) exunits.get(1);
 
-        BigDecimal memPrice = toRationalNumber(memPriceRN);
-        BigDecimal stepPrice = toRationalNumber(stepPriceRN);
+        NonNegativeInterval memPrice = toNonNegativeInterval(memPriceRN);
+        NonNegativeInterval stepPrice = toNonNegativeInterval(stepPriceRN);
 
         return new Tuple<>(memPrice, stepPrice);
     }
@@ -484,7 +486,7 @@ public class GovStateQuery implements EraQuery<GovStateQueryResult> {
         }
 
         var committeeThresholdDI = (RationalNumber) committeeDIList.get(1);
-        BigDecimal committeeThreshold = toRationalNumber(committeeThresholdDI);
+        UnitInterval committeeThreshold = toUnitInterval(committeeThresholdDI);
 
         return Committee.builder()
                 .committeeColdCredentialEpoch(committeeColdCredentialEpoch)

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/StakePoolParamsQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/StakePoolParamsQuery.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.yaci.core.model.Relay;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.api.Era;
 import com.bloxbean.cardano.yaci.core.protocol.localstate.api.EraQuery;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -58,7 +59,7 @@ public class StakePoolParamsQuery implements EraQuery<StakePoolParamQueryResult>
             String vrfKeyHash = toHex(poolParamDIList.get(1));
             BigInteger pledge = toBigInteger(poolParamDIList.get(2));
             BigInteger cost = toBigInteger(poolParamDIList.get(3));
-            String margin = ((RationalNumber) poolParamDIList.get(4)).getNumerator() + "/" + ((RationalNumber) poolParamDIList.get(4)).getDenominator();
+            UnitInterval margin = toUnitInterval(poolParamDIList.get(4));
             String rewardAccount = toHex(poolParamDIList.get(5));
 
             //Pool Owners0

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
@@ -15,9 +15,9 @@ public class NonNegativeInterval extends UnitInterval {
 
     public NonNegativeInterval(BigInteger numerator, BigInteger denominator) {
         super(numerator, denominator);
-        if(denominator.compareTo(BigInteger.ZERO) < 0) {
+        if(numerator.compareTo(BigInteger.ZERO) < 0 || denominator.compareTo(BigInteger.ZERO) < 0) {
             //Just a warning, don't throw exception
-            log.warn("Denominator should be non-negative. Numerator: {}, Denominator: {}", numerator, denominator);
+            log.warn("Numerator or Denominator should be non-negative. Numerator: {}, Denominator: {}", numerator, denominator);
         }
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
@@ -15,9 +15,9 @@ public class NonNegativeInterval extends UnitInterval {
 
     public NonNegativeInterval(BigInteger numerator, BigInteger denominator) {
         super(numerator, denominator);
-        if(numerator.compareTo(BigInteger.ZERO) < 0 || denominator.compareTo(BigInteger.ZERO) < 0) {
+        if(numerator.compareTo(BigInteger.ZERO) < 0 || denominator.compareTo(BigInteger.ZERO) <= 0) {
             //Just a warning, don't throw exception
-            log.warn("Numerator or Denominator should be non-negative. Numerator: {}, Denominator: {}", numerator, denominator);
+            log.warn("Numerator should not be non-negative and Denominator should be a positive int. Numerator: {}, Denominator: {}", numerator, denominator);
         }
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.core.types;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigInteger;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+@Slf4j
+public class NonNegativeInterval extends UnitInterval {
+
+    public NonNegativeInterval(BigInteger numerator, BigInteger denominator) {
+        super(numerator, denominator);
+        if(denominator.compareTo(BigInteger.ZERO) < 0) {
+            //Just a warning, don't throw exception
+            log.warn("Denominator should be non-negative. Numerator: {}, Denominator: {}", numerator, denominator);
+        }
+    }
+}
+

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/types/UnitInterval.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/types/UnitInterval.java
@@ -1,0 +1,54 @@
+package com.bloxbean.cardano.yaci.core.types;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class UnitInterval {
+    private static MathContext defaultMathContext = new MathContext(35);
+
+    private BigInteger numerator;
+    private BigInteger denominator;
+
+    public String toString() {
+        return numerator + "/" + denominator;
+    }
+
+    public static UnitInterval fromString(String str) {
+        String[] parts = str.split("/");
+        return new UnitInterval(new BigInteger(parts[0]), new BigInteger(parts[1]));
+    }
+
+    public static BigDecimal safeRatio(BigInteger numerator, BigInteger denominator) {
+        return safeRatio(numerator, denominator, defaultMathContext);
+    }
+
+    public static BigDecimal safeRatio(BigInteger numerator, BigInteger denominator, MathContext mathContext) {
+        if (isInvalidUnitInterval(numerator, denominator)) {
+            return BigDecimal.ZERO;
+        }
+
+        var numeratorBD = new BigDecimal(numerator);
+        var denominatorBD = new BigDecimal(denominator);
+
+        return numeratorBD.divide(denominatorBD, mathContext);
+    }
+
+    private static boolean isInvalidUnitInterval(BigInteger numerator, BigInteger denominator) {
+        boolean denominatorIsZero = denominator != null && denominator.equals(BigInteger.ZERO);
+        return numerator == null || denominator == null || denominatorIsZero;
+
+        //Ideally, we should also check numerator <= denominator and throw exception
+        //But, the caller is expected to pass the correct values to the safeRatio method
+    }
+}
+

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/util/CborSerializationUtil.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/util/CborSerializationUtil.java
@@ -7,12 +7,12 @@ import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.*;
 import co.nstant.in.cbor.model.Number;
 import com.bloxbean.cardano.yaci.core.exception.CborRuntimeException;
+import com.bloxbean.cardano.yaci.core.types.NonNegativeInterval;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import lombok.NonNull;
 
 import java.io.ByteArrayOutputStream;
-import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.RoundingMode;
 
 public class CborSerializationUtil {
 
@@ -76,23 +76,14 @@ public class CborSerializationUtil {
         return ((UnicodeString)di).getString();
     }
 
-    //convert [1,50] to "1/50"
-    public static String toRationalNumberStr(DataItem di) {
+    public static UnitInterval toUnitInterval(DataItem di) {
         RationalNumber rdi = (RationalNumber) di;
-        return rdi.getNumerator() + "/" + rdi.getDenominator();
+        return new UnitInterval(rdi.getNumerator().getValue(), rdi.getDenominator().getValue());
     }
 
-    //convert [1, 50] to 0.02
-    public static BigDecimal toRationalNumber(DataItem di) {
+    public static NonNegativeInterval toNonNegativeInterval(DataItem di) {
         RationalNumber rdi = (RationalNumber) di;
-        Number numerator = rdi.getNumerator();
-        Number denominator = rdi.getDenominator();
-
-        try {
-            return new BigDecimal(numerator.getValue()).divide(new BigDecimal(denominator.getValue()));
-        } catch (ArithmeticException e) { //set scale and try again
-            return new BigDecimal(numerator.getValue()).divide(new BigDecimal(denominator.getValue()), 10, RoundingMode.HALF_UP);
-        }
+        return new NonNegativeInterval(rdi.getNumerator().getValue(), rdi.getDenominator().getValue());
     }
 
     /**

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/model/serializers/PoolRegistrationSerializerTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/model/serializers/PoolRegistrationSerializerTest.java
@@ -2,9 +2,12 @@ package com.bloxbean.cardano.yaci.core.model.serializers;
 
 import com.bloxbean.cardano.yaci.core.model.Relay;
 import com.bloxbean.cardano.yaci.core.model.certs.PoolRegistration;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,7 +23,7 @@ class PoolRegistrationSerializerTest {
         assertThat(poolRegistration.getPoolParams().getVrfKeyHash()).isEqualTo("ca6306b471f5937ac69bda9b04915ff71a450644f36ea6163403dc2666659b8b");
         assertThat(poolRegistration.getPoolParams().getPledge()).isEqualTo(100000000);
         assertThat(poolRegistration.getPoolParams().getCost()).isEqualTo(340000000);
-        assertThat(poolRegistration.getPoolParams().getMargin()).isEqualTo("1/100");
+        assertThat(poolRegistration.getPoolParams().getMargin()).isEqualTo(new UnitInterval(BigInteger.valueOf(1), BigInteger.valueOf(100)));
         assertThat(poolRegistration.getPoolParams().getRewardAccount()).isEqualTo("e1ab737aaf2b421c22a15de788d61d375b135da0cbf1850fbd285d5a74");
         assertThat(poolRegistration.getPoolParams().getPoolOwners()).contains("ab737aaf2b421c22a15de788d61d375b135da0cbf1850fbd285d5a74");
         assertThat(poolRegistration.getPoolParams().getPoolMetadataUrl()).isEqualTo("https://bit.ly/3AfwvRQ");


### PR DESCRIPTION
- To avoid rounding issue during calculation and to keep the original value, return UnitInterval/NonNegativeInterval instead of derived BigDecimal