### PR TITLE
Fix Json serialization issue for UnitInterval/NonNegativeInterval

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
@@ -7,11 +7,13 @@ import java.math.BigInteger;
 
 @Getter
 @EqualsAndHashCode
-@AllArgsConstructor
-@NoArgsConstructor
 @ToString
 @Slf4j
 public class NonNegativeInterval extends UnitInterval {
+
+    public NonNegativeInterval() {
+        super();
+    }
 
     public NonNegativeInterval(BigInteger numerator, BigInteger denominator) {
         super(numerator, denominator);

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/types/NonNegativeInterval.java
@@ -1,14 +1,14 @@
 package com.bloxbean.cardano.yaci.core.types;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigInteger;
 
 @Getter
 @EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor
 @ToString
 @Slf4j
 public class NonNegativeInterval extends UnitInterval {
@@ -19,6 +19,11 @@ public class NonNegativeInterval extends UnitInterval {
             //Just a warning, don't throw exception
             log.warn("Numerator should not be non-negative and Denominator should be a positive int. Numerator: {}, Denominator: {}", numerator, denominator);
         }
+    }
+
+    public static NonNegativeInterval fromString(String str) {
+        String[] parts = str.split("/");
+        return new NonNegativeInterval(new BigInteger(parts[0]), new BigInteger(parts[1]));
     }
 }
 

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/types/UnitInterval.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/types/UnitInterval.java
@@ -1,9 +1,6 @@
 package com.bloxbean.cardano.yaci.core.types;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -11,6 +8,7 @@ import java.math.MathContext;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 @EqualsAndHashCode
 @ToString
 public class UnitInterval {
@@ -23,16 +21,24 @@ public class UnitInterval {
         return numerator + "/" + denominator;
     }
 
+    public BigDecimal safeRatio() {
+        return safeRatio(numerator, denominator);
+    }
+
+    public BigDecimal safeRatio(MathContext mathContext) {
+        return safeRatio(numerator, denominator, mathContext);
+    }
+
     public static UnitInterval fromString(String str) {
         String[] parts = str.split("/");
         return new UnitInterval(new BigInteger(parts[0]), new BigInteger(parts[1]));
     }
 
-    public static BigDecimal safeRatio(BigInteger numerator, BigInteger denominator) {
+    private static BigDecimal safeRatio(BigInteger numerator, BigInteger denominator) {
         return safeRatio(numerator, denominator, defaultMathContext);
     }
 
-    public static BigDecimal safeRatio(BigInteger numerator, BigInteger denominator, MathContext mathContext) {
+    private static BigDecimal safeRatio(BigInteger numerator, BigInteger denominator, MathContext mathContext) {
         if (isInvalidUnitInterval(numerator, denominator)) {
             return BigDecimal.ZERO;
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.bloxbean.cardano
 artifactId = yaci
-version = 0.4.0-beta1
+version = 0.4.0-beta2-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.bloxbean.cardano
 artifactId = yaci
-version = 0.4.0-beta2-SNAPSHOT
+version = 0.4.0-beta2


### PR DESCRIPTION
- Jackson serialization issue for UnitInterval/NonNegativeInterval
- `safeRatio` method in instance level instead of static method
- `fromString` method for `NonNegativeInterval`