### PR TITLE
Refactor rollforward logic in ChainSync agents to avoid updating currentPoint in case of listener error

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2c/LocalChainSyncAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2c/LocalChainSyncAgent.java
@@ -140,28 +140,6 @@ public class LocalChainSyncAgent extends Agent<LocalChainSyncAgentListener> {
     }
 
     private void onRollForward(LocalRollForward rollForward) {
-        if (rollForward.getBlock() != null) { //For Byron era, this value is null. Will be fixed later
-            this.currentPoint = new Point(rollForward.getBlock().getHeader().getHeaderBody().getSlot(), rollForward.getBlock().getHeader().getHeaderBody().getBlockHash());
-        } else if (rollForward.getByronBlock() != null) {
-            this.currentPoint = new Point(rollForward.getByronBlock().getHeader().getConsensusData().getSlotId().getSlot(), rollForward.getByronBlock().getHeader().getBlockHash());
-        } else if (rollForward.getByronEbBlock() != null) {
-            this.currentPoint = new Point(0, rollForward.getByronEbBlock().getHeader().getBlockHash()); //TODO -- SlotId == 0 for ByronEbBlock ??
-        }
-
-        if (counter++ % 100 == 0 || (tip.getPoint().getSlot() - currentPoint.getSlot()) < 10) {
-
-            if (log.isDebugEnabled()) {
-                log.debug("**********************************************************");
-                log.debug(String.valueOf(currentPoint));
-                log.debug("[Agent No: " + agentNo + "] : " + rollForward);
-                log.debug("**********************************************************");
-            }
-
-            if (stopAt != 0 && rollForward.getBlock().getHeader().getHeaderBody().getSlot() >= stopAt) {
-                this.currenState = HandshkeState.Done;
-            }
-        }
-
         if (rollForward.getBlock() != null) { //For shelley and later era
             getAgentListeners().stream().forEach(
                     chainSyncAgentListener -> {
@@ -184,6 +162,28 @@ public class LocalChainSyncAgent extends Agent<LocalChainSyncAgentListener> {
                         chainSyncAgentListener.rollforwardByronEra(rollForward.getTip(), rollForward.getByronEbBlock());
                     }
             );
+        }
+
+        if (rollForward.getBlock() != null) { //For Byron era, this value is null. Will be fixed later
+            this.currentPoint = new Point(rollForward.getBlock().getHeader().getHeaderBody().getSlot(), rollForward.getBlock().getHeader().getHeaderBody().getBlockHash());
+        } else if (rollForward.getByronBlock() != null) {
+            this.currentPoint = new Point(rollForward.getByronBlock().getHeader().getConsensusData().getSlotId().getSlot(), rollForward.getByronBlock().getHeader().getBlockHash());
+        } else if (rollForward.getByronEbBlock() != null) {
+            this.currentPoint = new Point(0, rollForward.getByronEbBlock().getHeader().getBlockHash()); //TODO -- SlotId == 0 for ByronEbBlock ??
+        }
+
+        if (counter++ % 100 == 0 || (tip.getPoint().getSlot() - currentPoint.getSlot()) < 10) {
+
+            if (log.isDebugEnabled()) {
+                log.debug("**********************************************************");
+                log.debug(String.valueOf(currentPoint));
+                log.debug("[Agent No: " + agentNo + "] : " + rollForward);
+                log.debug("**********************************************************");
+            }
+
+            if (stopAt != 0 && rollForward.getBlock().getHeader().getHeaderBody().getSlot() >= stopAt) {
+                this.currenState = HandshkeState.Done;
+            }
         }
     }
 

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2n/ChainsyncAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/chainsync/n2n/ChainsyncAgent.java
@@ -140,6 +140,30 @@ public class ChainsyncAgent extends Agent<ChainSyncAgentListener> {
     }
 
     private void onRollForward(RollForward rollForward) {
+        if (rollForward.getBlockHeader() != null) { //For Shelley and later eras
+            getAgentListeners().stream().forEach(
+                    chainSyncAgentListener -> {
+                        chainSyncAgentListener.rollforward(rollForward.getTip(), rollForward.getBlockHeader());
+                    }
+            );
+        } else if (rollForward.getByronBlockHead() != null) { //For Byron main block
+            if (log.isTraceEnabled())
+                log.trace("Byron Block: " + rollForward.getByronBlockHead().getConsensusData().getSlotId());
+            getAgentListeners().stream().forEach(
+                    chainSyncAgentListener -> {
+                        chainSyncAgentListener.rollforwardByronEra(rollForward.getTip(), rollForward.getByronBlockHead());
+                    }
+            );
+        } else if (rollForward.getByronEbHead() != null) { //For Byron Eb block
+            if (log.isTraceEnabled())
+                log.trace("Byron Eb Block: " + rollForward.getByronEbHead().getConsensusData());
+            getAgentListeners().stream().forEach(
+                    chainSyncAgentListener -> {
+                        chainSyncAgentListener.rollforwardByronEra(rollForward.getTip(), rollForward.getByronEbHead());
+                    }
+            );
+        }
+
         if (rollForward.getBlockHeader() != null) { //shelley and later
             this.currentPoint = new Point(rollForward.getBlockHeader().getHeaderBody().getSlot(), rollForward.getBlockHeader().getHeaderBody().getBlockHash());
         } else if (rollForward.getByronBlockHead() != null) { //Byron Block
@@ -161,30 +185,6 @@ public class ChainsyncAgent extends Agent<ChainSyncAgentListener> {
                 this.currenState = HandshkeState.Done;
             }
         }
-
-       if (rollForward.getBlockHeader() != null) { //For Shelley and later eras
-            getAgentListeners().stream().forEach(
-                    chainSyncAgentListener -> {
-                        chainSyncAgentListener.rollforward(rollForward.getTip(), rollForward.getBlockHeader());
-                    }
-            );
-        } else if(rollForward.getByronBlockHead() != null) { //For Byron main block
-            if (log.isTraceEnabled())
-                log.trace("Byron Block: " + rollForward.getByronBlockHead().getConsensusData().getSlotId());
-            getAgentListeners().stream().forEach(
-                    chainSyncAgentListener -> {
-                        chainSyncAgentListener.rollforwardByronEra(rollForward.getTip(), rollForward.getByronBlockHead());
-                    }
-            );
-        } else if (rollForward.getByronEbHead() != null) { //For Byron Eb block
-           if (log.isTraceEnabled())
-               log.trace("Byron Eb Block: " + rollForward.getByronEbHead().getConsensusData());
-           getAgentListeners().stream().forEach(
-                   chainSyncAgentListener -> {
-                       chainSyncAgentListener.rollforwardByronEra(rollForward.getTip(), rollForward.getByronEbHead());
-                   }
-           );
-       }
     }
 
     @Override


### PR DESCRIPTION
Moved and reorganized rollforward logic to handle correct currentPoint in case of failure in listener processing. 