### PR TITLE
Support PV11 handshake versions and fix GovStateQuery for Preview

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/util/N2CVersionTableConstant.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/util/N2CVersionTableConstant.java
@@ -29,6 +29,9 @@ public class N2CVersionTableConstant {
     public final static long PROTOCOL_V18 = 32786;
     public final static long PROTOCOL_V19 = 32787;
     public final static long PROTOCOL_V20 = 32788;
+    public final static long PROTOCOL_V21 = 32789;
+    public final static long PROTOCOL_V22 = 32790;
+    public final static long PROTOCOL_V23 = 32791;
 
     public static VersionTable v1AndAbove(long networkMagic) {
         OldN2CVersionData oldVersionData = new OldN2CVersionData(networkMagic);
@@ -55,6 +58,9 @@ public class N2CVersionTableConstant {
         versionTableMap.put(PROTOCOL_V18, versionData);
         versionTableMap.put(PROTOCOL_V19, versionData);
         versionTableMap.put(PROTOCOL_V20, versionData);
+        versionTableMap.put(PROTOCOL_V21, versionData);
+        versionTableMap.put(PROTOCOL_V22, versionData);
+        versionTableMap.put(PROTOCOL_V23, versionData);
 
         return new VersionTable(versionTableMap);
     }
@@ -72,6 +78,9 @@ public class N2CVersionTableConstant {
         versionTableMap.put(PROTOCOL_V18, versionData);
         versionTableMap.put(PROTOCOL_V19, versionData);
         versionTableMap.put(PROTOCOL_V20, versionData);
+        versionTableMap.put(PROTOCOL_V21, versionData);
+        versionTableMap.put(PROTOCOL_V22, versionData);
+        versionTableMap.put(PROTOCOL_V23, versionData);
 
         return new VersionTable(versionTableMap);
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/util/N2NVersionTableConstant.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/util/N2NVersionTableConstant.java
@@ -19,6 +19,7 @@ public class N2NVersionTableConstant {
     public final static long PROTOCOL_V12 = 12;
     public final static long PROTOCOL_V13 = 13;
     public final static long PROTOCOL_V14 = 14;
+    public final static long PROTOCOL_V15 = 15; //srv support
 
     public static VersionTable v4AndAbove(long networkMagic) {
         N2NVersionData versionData = new N2NVersionData(networkMagic, true);
@@ -35,6 +36,7 @@ public class N2NVersionTableConstant {
         versionTableMap.put(PROTOCOL_V12, versionData);
         versionTableMap.put(PROTOCOL_V13, versionData);
         versionTableMap.put(PROTOCOL_V14, versionData);
+        versionTableMap.put(PROTOCOL_V15, versionData);
 
         return new VersionTable(versionTableMap);
     }
@@ -51,6 +53,7 @@ public class N2NVersionTableConstant {
         versionTableMap.put(PROTOCOL_V12, versionData);
         versionTableMap.put(PROTOCOL_V13, versionData);
         versionTableMap.put(PROTOCOL_V14, versionData);
+        versionTableMap.put(PROTOCOL_V15, versionData);
 
         return new VersionTable(versionTableMap);
     }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GovStateQuery.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/localstate/queries/GovStateQuery.java
@@ -79,11 +79,35 @@ public class GovStateQuery implements EraQuery<GovStateQueryResult> {
 
         govStateQueryResult.setCurrentPParams(currentProtocolParam);
 
+        // futurePParams is a tagged sum (FuturePParams):
+        //   [0]            -> NoPParamsUpdate
+        //   [1, pp]        -> DefinitePParamsUpdate pp                  ; pp is the PParams array
+        //   [2, maybe_pp]  -> PotentialPParamsUpdate (Maybe pp)         ; maybe_pp is [] (Nothing) or [pp] (Just)
+        // Source: cardano-ledger libs/cardano-ledger-core/src/Cardano/Ledger/State/Governance.hs
+        //   data FuturePParams era = NoPParamsUpdate
+        //                          | DefinitePParamsUpdate (PParams era)
+        //                          | PotentialPParamsUpdate (Maybe (PParams era))
+        //   instance EncCBOR (FuturePParams era):
+        //     NoPParamsUpdate           -> Sum NoPParamsUpdate 0
+        //     DefinitePParamsUpdate pp  -> Sum DefinitePParamsUpdate 1 !> To pp
+        //     PotentialPParamsUpdate pp -> Sum PotentialPParamsUpdate 2 !> To pp
         Array futurePParams = (Array) resultArray.getDataItems().get(5);
-        if (!futurePParams.getDataItems().isEmpty() && futurePParams.getDataItems().size() > 1) {
-            List<DataItem> futureParamsDIList = ((Array)futurePParams.getDataItems().get(1)).getDataItems();
-            ProtocolParamUpdate futureProtocolParam = deserializePPResult(futureParamsDIList);
-            govStateQueryResult.setFuturePParams(futureProtocolParam);
+        List<DataItem> fpItems = futurePParams.getDataItems();
+        if (!fpItems.isEmpty()) {
+            int variantTag = toInt(fpItems.get(0));
+            List<DataItem> futureParamsDIList = null;
+            if (variantTag == 1 && fpItems.size() > 1) {
+                futureParamsDIList = ((Array) fpItems.get(1)).getDataItems();
+            } else if (variantTag == 2 && fpItems.size() > 1) {
+                Array maybeWrapper = (Array) fpItems.get(1);
+                if (!maybeWrapper.getDataItems().isEmpty()) {
+                    futureParamsDIList = ((Array) maybeWrapper.getDataItems().get(0)).getDataItems();
+                }
+            }
+            if (futureParamsDIList != null && !futureParamsDIList.isEmpty()) {
+                ProtocolParamUpdate futureProtocolParam = deserializePPResult(futureParamsDIList);
+                govStateQueryResult.setFuturePParams(futureProtocolParam);
+            }
         }
 
         // next ratify state

--- a/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/BaseTest.java
+++ b/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/BaseTest.java
@@ -4,10 +4,17 @@ import com.bloxbean.cardano.yaci.core.common.Constants;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
 
 public class BaseTest {
-    protected String node = Constants.PREPROD_IOHK_RELAY_ADDR;
-    protected int nodePort = Constants.PREPROD_IOHK_RELAY_PORT;
+    protected String node = Constants.PREPROD_PUBLIC_RELAY_ADDR;
+    protected int nodePort = Constants.PREPROD_PUBLIC_RELAY_PORT;
     protected long protocolMagic = Constants.PREPROD_PROTOCOL_MAGIC;
     protected Point knownPoint = new Point(13003663, "b896e43a25de269cfc47be7afbcbf00cad41a5011725c2732393f1b4508cf41d");
 
-    protected String nodeSocketFile = "/Users/satya/work/cardano-node/preprod-9.1.0/db/node.socket";
+    protected String nodeSocketFile = "/Users/satya/work/cardano-node/preprod/db/node.socket";
+
+    protected String previewNode = Constants.PREVIEW_PUBLIC_RELAY_ADDR;
+    protected int previewNodePot = Constants.PREVIEW_PUBLIC_RELAY_PORT;
+    protected long previewProtocolMagic = Constants.PREVIEW_PROTOCOL_MAGIC;
+    protected Point previewKnownPoint = new Point(2000, "5659572d8014080f38efe74c8fe9ab7c1195bac6e64c24bf0a2d41fafe87e8f8");
+
+    protected String previewNodeSocketFile = "/Users/satya/work/cardano-node/preview/db/node.socket";
 }

--- a/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/GovStateQueryIT.java
+++ b/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/GovStateQueryIT.java
@@ -1,0 +1,206 @@
+package com.bloxbean.cardano.yaci.helper;
+
+import com.bloxbean.cardano.yaci.core.protocol.localstate.api.Era;
+import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.GovStateQuery;
+import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.GovStateQueryResult;
+import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.EnactState;
+import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.model.RatifyState;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+class GovStateQueryIT extends BaseTest {
+
+    private LocalClientProvider localQueryProvider;
+    private LocalStateQueryClient localStateQueryClient;
+
+    @BeforeEach
+    public void setup() {
+        this.localQueryProvider = new LocalClientProvider(previewNodeSocketFile, previewProtocolMagic);
+        this.localStateQueryClient = localQueryProvider.getLocalStateQueryClient();
+        localQueryProvider.start();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        this.localQueryProvider.shutdown();
+    }
+
+    @Test
+    void govStateQuery_allFields() {
+        Mono<GovStateQueryResult> mono = localStateQueryClient
+                .executeQuery(new GovStateQuery(Era.Conway));
+
+        GovStateQueryResult result = mono.block(Duration.ofSeconds(15));
+        log.info("GovStateQueryResult: {}", result);
+
+        assertThat(result).isNotNull();
+
+        assertCommittee(result);
+        assertConstitution(result);
+        assertCurrentPParams(result);
+        assertPreviousPParams(result);
+        assertProposals(result);
+        assertNextRatifyState(result);
+    }
+
+    private void assertCommittee(GovStateQueryResult result) {
+        assertThat(result.getCommittee())
+                .as("committee")
+                .isNotNull();
+        assertThat(result.getCommittee().getThreshold())
+                .as("committee threshold")
+                .isNotNull();
+        assertThat(result.getCommittee().getCommitteeColdCredentialEpoch())
+                .as("committee cold credential -> epoch map")
+                .isNotNull();
+    }
+
+    private void assertConstitution(GovStateQueryResult result) {
+        assertThat(result.getConstitution())
+                .as("constitution")
+                .isNotNull();
+        assertThat(result.getConstitution().getAnchor())
+                .as("constitution anchor")
+                .isNotNull();
+        assertThat(result.getConstitution().getAnchor().getAnchor_url())
+                .as("constitution anchor url")
+                .isNotBlank();
+        assertThat(result.getConstitution().getAnchor().getAnchor_data_hash())
+                .as("constitution anchor data hash")
+                .isNotBlank();
+    }
+
+    private void assertCurrentPParams(GovStateQueryResult result) {
+        assertThat(result.getCurrentPParams())
+                .as("currentPParams")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getMinFeeA())
+                .as("currentPParams.minFeeA")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getMinFeeB())
+                .as("currentPParams.minFeeB")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getMaxBlockSize())
+                .as("currentPParams.maxBlockSize")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getMaxTxSize())
+                .as("currentPParams.maxTxSize")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getKeyDeposit())
+                .as("currentPParams.keyDeposit")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getPoolDeposit())
+                .as("currentPParams.poolDeposit")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getProtocolMajorVer())
+                .as("currentPParams.protocolMajorVer")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getCostModels())
+                .as("currentPParams.costModels")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getPriceMem())
+                .as("currentPParams.priceMem")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getPriceStep())
+                .as("currentPParams.priceStep")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getMaxTxExMem())
+                .as("currentPParams.maxTxExMem")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getMaxBlockExMem())
+                .as("currentPParams.maxBlockExMem")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getCollateralPercent())
+                .as("currentPParams.collateralPercent")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getMaxCollateralInputs())
+                .as("currentPParams.maxCollateralInputs")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getPoolVotingThresholds())
+                .as("currentPParams.poolVotingThresholds")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getDrepVotingThresholds())
+                .as("currentPParams.drepVotingThresholds")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getCommitteeMinSize())
+                .as("currentPParams.committeeMinSize")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getGovActionLifetime())
+                .as("currentPParams.govActionLifetime")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getGovActionDeposit())
+                .as("currentPParams.govActionDeposit")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getDrepDeposit())
+                .as("currentPParams.drepDeposit")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getDrepActivity())
+                .as("currentPParams.drepActivity")
+                .isNotNull();
+        assertThat(result.getCurrentPParams().getMinFeeRefScriptCostPerByte())
+                .as("currentPParams.minFeeRefScriptCostPerByte")
+                .isNotNull();
+    }
+
+    private void assertPreviousPParams(GovStateQueryResult result) {
+        assertThat(result.getPreviousPParams())
+                .as("previousPParams")
+                .isNotNull();
+        assertThat(result.getPreviousPParams().getMinFeeA())
+                .as("previousPParams.minFeeA")
+                .isNotNull();
+        assertThat(result.getPreviousPParams().getProtocolMajorVer())
+                .as("previousPParams.protocolMajorVer")
+                .isNotNull();
+    }
+
+    private void assertProposals(GovStateQueryResult result) {
+        assertThat(result.getProposals())
+                .as("proposals")
+                .isNotNull();
+    }
+
+    private void assertNextRatifyState(GovStateQueryResult result) {
+        RatifyState nextRatifyState = result.getNextRatifyState();
+        assertThat(nextRatifyState)
+                .as("nextRatifyState")
+                .isNotNull();
+        assertThat(nextRatifyState.getEnactedGovActions())
+                .as("nextRatifyState.enactedGovActions")
+                .isNotNull();
+        assertThat(nextRatifyState.getExpiredGovActions())
+                .as("nextRatifyState.expiredGovActions")
+                .isNotNull();
+        assertThat(nextRatifyState.getRatificationDelayed())
+                .as("nextRatifyState.ratificationDelayed")
+                .isNotNull();
+
+        EnactState nextEnactState = nextRatifyState.getNextEnactState();
+        assertThat(nextEnactState)
+                .as("nextRatifyState.nextEnactState")
+                .isNotNull();
+        assertThat(nextEnactState.getCommittee())
+                .as("nextEnactState.committee")
+                .isNotNull();
+        assertThat(nextEnactState.getConstitution())
+                .as("nextEnactState.constitution")
+                .isNotNull();
+        assertThat(nextEnactState.getCurrentPParams())
+                .as("nextEnactState.currentPParams")
+                .isNotNull();
+        assertThat(nextEnactState.getPrevPParams())
+                .as("nextEnactState.prevPParams")
+                .isNotNull();
+        assertThat(nextEnactState.getPrevGovActionIds())
+                .as("nextEnactState.prevGovActionIds")
+                .isNotNull();
+    }
+}

--- a/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/LocalStateQueryClientIT.java
+++ b/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/LocalStateQueryClientIT.java
@@ -118,7 +118,7 @@ class LocalStateQueryClientIT extends BaseTest {
                 .create(mono)
                 .expectNextMatches(protoParams -> protoParams.getProtocolParams().getCollateralPercent() == 150
                         && protoParams.getProtocolParams().getMaxCollateralInputs().equals(3)
-                        && protoParams.getProtocolParams().getMaxTxExMem().equals(BigInteger.valueOf(14000000))
+                        && protoParams.getProtocolParams().getMaxTxExMem().equals(BigInteger.valueOf(16500000))
                 )
                 .expectComplete()
                 .verify();

--- a/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/LocalTxSubmissionClientIT.java
+++ b/helper/src/integrationTest/java/com/bloxbean/cardano/yaci/helper/LocalTxSubmissionClientIT.java
@@ -125,7 +125,7 @@ class LocalTxSubmissionClientIT extends BaseTest {
         Account account = new Account(Networks.testnet(), mnemonic);
         var signedTransaction = account.sign(transaction);
 
-        var txSubmissionRequest = new TxSubmissionRequest(TxBodyType.BABBAGE, signedTransaction.serialize());
+        var txSubmissionRequest = new TxSubmissionRequest(TxBodyType.CONWAY, signedTransaction.serialize());
         var txResult = localTxSubmissionClient.submitTx(txSubmissionRequest).block(Duration.ofSeconds(20));
 
         System.out.println(signedTransaction.serializeToHex());


### PR DESCRIPTION
 ## Summary

  - Add the new node-to-node and node-to-client handshake protocol versions
    needed to talk to recent cardano-node releases:
    - **N2N**: `PROTOCOL_V15`
    - **N2C**: `PROTOCOL_V21`, `PROTOCOL_V22`, `PROTOCOL_V23`
  - Fix `GovStateQuery` to correctly decode the `futurePParams` field when the node returns `PotentialPParamsUpdate (Just pp)`. The previous code only handled the `DefinitePParamsUpdate` variant and crashed with an NPE on every other shape, which made `getGovState` unusable on Cardano Preview (currently at PV11 with active governance proposals).                                                                                                                                                                                         
  - Add a focused `GovStateQueryIT` integration test that asserts on every populated field of `GovStateQueryResult`, run against a local Preview                                                                                                                                                                                   node socket configured in `BaseTest`.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                  
  ## Why                                                                                                                                                                                                                                                          
                                                         
  `cgsFuturePParams :: FuturePParams era` is encoded as a tagged sum (see                                                                                                                                                                                         
  [`Cardano.Ledger.State.Governance`](https://github.com/IntersectMBO/cardano-ledger/blob/master/libs/cardano-ledger-core/src/Cardano/Ledger/State/Governance.hs)):
 
 ```                                                                                                                                                                                                                                                                 
  NoPParamsUpdate           -> [0]                       
  DefinitePParamsUpdate pp  -> [1, pp]                ; pp is the PParams array                                                                                                                                                                                   
  PotentialPParamsUpdate m  -> [2, m]                 ; m :: Maybe pp -> [] or [pp]                                                                                                                                                                               
 ```
                                                                                                                                                                                                                                                                  
The pre-fix code treated `result[5][1]` as the `PParams` array unconditionally. For tag `2` with `Just pp`, that index is the `Maybe` wrapper `[pp]`, so `paramsDIList.get(0)` returned an `Array` rather than  an integer, and `toBigInteger` returned `null` — surfacing as a `NullPointerException`  when reading `minFeeA`.                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                      
                                                                                                                                                                                                                                              
  Preprod (PV10) returns `NoPParamsUpdate`, which the existing branch skipped cleanly, so the regression only showed up against Preview.                                                                                                                                                                                            
                                                                                                                                                                                                                                                       
The new code dispatches on the variant tag, unwraps the `Maybe` for tag  `2`, and leaves `futurePParams` unset for the `Nothing` / `NoPParamsUpdate`  cases. A Haskell-source reference is inlined in the comment block to keep   the encoding contract auditable.                                                                                                                                                                                       
                                                                                                                                                                                                                                                    
ConwayPParams field shape itself is unchanged between PV10 and PV11  (Conway era spans `ProtVerLow=9..ProtVerHigh=11`; Dijkstra and the four  new ref-script pparams only activate at PV12), so no other parsing logic needed to change for this hardfork.                                                                                                                                                                                            
                                                                                                                                                                                                                                                       
## Stacktrace before the fix                                                                                                                                                                                                                                    

```                                                                                                                                                                                                                                                       
  java.lang.NullPointerException: Cannot invoke "java.math.BigInteger.intValue()"                                                                                                                                                                                 
    because the return value of "...toBigInteger(...)" is null
      at CborSerializationUtil.toInt(CborSerializationUtil.java:56)                                                                                                                                                                                               
      at GovStateQuery.deserializePPResult(GovStateQuery.java:201)   ← reading minFeeA                                                                                                                                                                            
      at GovStateQuery.deserializeResult(GovStateQuery.java:85)      ← parsing futurePParams  
  ```    