### PR TITLE
Fix PeerClient DNS reconnect handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ subprojects {
         testRuntimeOnly libs.junit.jupiter.engine
         testRuntimeOnly libs.junit.platform.launcher
         testImplementation libs.harmcrest.library
-        testImplementation libs.mockito.inline
+        testImplementation libs.mockito.core
         testImplementation libs.mockito.junit.jupiter
         testImplementation libs.assertj.core
         testRuntimeOnly libs.slf4j.reload4j

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClient.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClient.java
@@ -14,6 +14,7 @@ import io.netty.channel.EventLoopGroup;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.SocketAddress;
+import java.util.List;
 import java.util.function.Supplier;
 
 @Slf4j
@@ -85,7 +86,7 @@ public abstract class NodeClient {
                 workerGroup = configureEventLoopGroup();
             }
 
-            Bootstrap b = new Bootstrap();
+            Bootstrap b = createBootstrap();
             b.group(workerGroup);
             b.channel(getChannelClass());
 
@@ -102,7 +103,7 @@ public abstract class NodeClient {
                 }
             });
 
-            session = new Session(createSocketAddressSupplier(), b, config, handshakeAgent, agents);
+            session = new Session(this::createSocketAddressCandidates, b, config, handshakeAgent, agents);
             session.setSessionListener(sessionListener);
             session.start();
         } catch (Exception e) {
@@ -193,6 +194,25 @@ public abstract class NodeClient {
      */
     protected Supplier<SocketAddress> createSocketAddressSupplier() {
         return this::createSocketAddress;
+    }
+
+    /**
+     * Create socket address candidates for a connection attempt cycle. Session will try all candidates
+     * before applying the retry policy.
+     *
+     * @return socket address candidates
+     */
+    protected List<SocketAddress> createSocketAddressCandidates() {
+        return List.of(createSocketAddressSupplier().get());
+    }
+
+    /**
+     * Create the Netty bootstrap used by this client.
+     *
+     * @return bootstrap
+     */
+    protected Bootstrap createBootstrap() {
+        return new Bootstrap();
     }
 
     /**

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClient.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClient.java
@@ -14,6 +14,7 @@ import io.netty.channel.EventLoopGroup;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.SocketAddress;
+import java.util.function.Supplier;
 
 @Slf4j
 public abstract class NodeClient {
@@ -79,6 +80,11 @@ public abstract class NodeClient {
             throw new RuntimeException("Session already available. Only one session is allowed per N2NClient. To start again, please call shutdown() first.");
 
         try {
+            if (workerGroup == null || workerGroup.isShuttingDown() || workerGroup.isShutdown()
+                    || workerGroup.isTerminated()) {
+                workerGroup = configureEventLoopGroup();
+            }
+
             Bootstrap b = new Bootstrap();
             b.group(workerGroup);
             b.channel(getChannelClass());
@@ -96,12 +102,28 @@ public abstract class NodeClient {
                 }
             });
 
-            SocketAddress socketAddress = createSocketAddress();
-
-            session = new Session(socketAddress, b, config, handshakeAgent, agents);
+            session = new Session(createSocketAddressSupplier(), b, config, handshakeAgent, agents);
             session.setSessionListener(sessionListener);
             session.start();
         } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+
+            if (session != null) {
+                session.disableReconnection();
+                session.dispose();
+                session = null;
+            }
+
+            if (config.isPropagateStartupFailure()) {
+                if (workerGroup != null) {
+                    workerGroup.shutdownGracefully();
+                    workerGroup = null;
+                }
+                throw new NodeClientException("Failed to start node client", e);
+            }
+
             log.error("Error", e);
         }
     }
@@ -163,6 +185,15 @@ public abstract class NodeClient {
      * @return
      */
     protected abstract SocketAddress createSocketAddress();
+
+    /**
+     * Create a socket address supplier. The supplier is invoked for every connection attempt.
+     *
+     * @return socket address supplier
+     */
+    protected Supplier<SocketAddress> createSocketAddressSupplier() {
+        return this::createSocketAddress;
+    }
 
     /**
      * Create and configure an EventLoopGroup. This method is invoked from {@link #start()}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfig.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfig.java
@@ -38,9 +38,11 @@ public class NodeClientConfig {
     private final int initialRetryDelayMs = 8000;
 
     /**
-     * Maximum number of retry attempts before giving up.
+     * Maximum number of retry cycles before giving up.
+     * In DNS_ROTATING mode, one cycle tries every resolved socket address candidate once.
+     * In STANDARD mode, one cycle has a single JVM-selected socket address candidate.
      * This is used only when autoReconnect is enabled. If autoReconnect is false,
-     * startup fails after the first failed connection attempt.
+     * startup fails after the first failed cycle.
      * Default: Integer.MAX_VALUE (unlimited retries for backward compatibility)
      */
     @Builder.Default
@@ -73,7 +75,25 @@ public class NodeClientConfig {
     private final boolean propagateStartupFailure = false;
 
     /**
-     * Creates a default configuration with backward-compatible settings.
+     * Controls how TCP socket addresses are resolved for connection attempts.
+     * Default: STANDARD, which creates a fresh InetSocketAddress for each attempt
+     * and lets the JVM choose the address.
+     *
+     * DNS_ROTATING uses the JVM InetAddress resolver and is subject to the JVM DNS cache TTL.
+     * Operators that need faster DNS refresh should set networkaddress.cache.ttl or sun.net.inetaddr.ttl.
+     */
+    @Builder.Default
+    private final SocketAddressResolutionMode socketAddressResolutionMode = SocketAddressResolutionMode.STANDARD;
+
+    /**
+     * Controls address-family filtering and preference for DNS_ROTATING mode.
+     * Default: ANY, which keeps all resolved addresses.
+     */
+    @Builder.Default
+    private final SocketAddressFamily socketAddressFamily = SocketAddressFamily.ANY;
+
+    /**
+     * Creates a default configuration.
      * This is equivalent to calling {@code NodeClientConfig.builder().build()}
      *
      * @return a new NodeClientConfig with default values

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfig.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfig.java
@@ -39,6 +39,8 @@ public class NodeClientConfig {
 
     /**
      * Maximum number of retry attempts before giving up.
+     * This is used only when autoReconnect is enabled. If autoReconnect is false,
+     * startup fails after the first failed connection attempt.
      * Default: Integer.MAX_VALUE (unlimited retries for backward compatibility)
      */
     @Builder.Default
@@ -61,6 +63,14 @@ public class NodeClientConfig {
      */
     @Builder.Default
     private final int connectionTimeoutMs = 30000;
+
+    /**
+     * Whether startup failures should be propagated to the caller.
+     * Default: false to preserve historical behavior where start() logs startup errors.
+     * Set to true for supervised applications that need to fail over to another peer.
+     */
+    @Builder.Default
+    private final boolean propagateStartupFailure = false;
 
     /**
      * Creates a default configuration with backward-compatible settings.

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClientException.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClientException.java
@@ -1,0 +1,7 @@
+package com.bloxbean.cardano.yaci.core.network;
+
+public class NodeClientException extends RuntimeException {
+    public NodeClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
@@ -8,6 +8,7 @@ import io.netty.channel.ChannelFuture;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.SocketAddress;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
@@ -16,7 +17,7 @@ import java.util.function.Supplier;
  */
 @Slf4j
 class Session implements Disposable {
-    private final Supplier<SocketAddress> socketAddressSupplier;
+    private final SocketAddressProvider socketAddressProvider;
     private final Bootstrap clientBootstrap;
     private Channel activeChannel;
     private final AtomicBoolean shouldReconnect;
@@ -29,7 +30,27 @@ class Session implements Disposable {
     /**
      * Constructor with NodeClientConfig for configurable connection behavior.
      *
-     * @param socketAddressSupplier the socket address supplier to use for each connection attempt
+     * @param socketAddressProvider the socket address provider to use for each connection attempt cycle
+     * @param clientBootstrap the Netty bootstrap
+     * @param config the connection configuration
+     * @param handshakeAgent the handshake agent
+     * @param agents the protocol agents
+     */
+    public Session(SocketAddressProvider socketAddressProvider, Bootstrap clientBootstrap, NodeClientConfig config,
+                   HandshakeAgent handshakeAgent, Agent[] agents) {
+        this.socketAddressProvider = socketAddressProvider;
+        this.clientBootstrap = clientBootstrap;
+        this.config = config != null ? config : NodeClientConfig.defaultConfig();
+        this.shouldReconnect = new AtomicBoolean(this.config.isAutoReconnect());
+
+        this.handshakeAgent = handshakeAgent;
+        this.agents = agents;
+    }
+
+    /**
+     * Constructor with NodeClientConfig for configurable connection behavior.
+     *
+     * @param socketAddressSupplier the socket address supplier to use for each connection attempt cycle
      * @param clientBootstrap the Netty bootstrap
      * @param config the connection configuration
      * @param handshakeAgent the handshake agent
@@ -37,13 +58,7 @@ class Session implements Disposable {
      */
     public Session(Supplier<SocketAddress> socketAddressSupplier, Bootstrap clientBootstrap, NodeClientConfig config,
                    HandshakeAgent handshakeAgent, Agent[] agents) {
-        this.socketAddressSupplier = socketAddressSupplier;
-        this.clientBootstrap = clientBootstrap;
-        this.config = config != null ? config : NodeClientConfig.defaultConfig();
-        this.shouldReconnect = new AtomicBoolean(this.config.isAutoReconnect());
-
-        this.handshakeAgent = handshakeAgent;
-        this.agents = agents;
+        this(() -> List.of(socketAddressSupplier.get()), clientBootstrap, config, handshakeAgent, agents);
     }
 
     /**
@@ -85,23 +100,56 @@ class Session implements Disposable {
     public Disposable start() throws InterruptedException {
         //Create a new connectFuture
         ChannelFuture connectFuture = null;
-        long retriesUsed = 0;
-        // Always try to connect at least once, then retry only if shouldReconnect is true
+        long retryCyclesUsed = 0;
+        long attempts = 0;
+
         while (connectFuture == null) {
+            Exception lastFailure = null;
+            List<SocketAddress> socketAddresses = null;
+
             try {
-                SocketAddress socketAddress = socketAddressSupplier.get();
-                if (showConnectionLog())
-                    log.info("Connecting to {} (attempt {}, max retries: {})",
-                            socketAddress, retriesUsed + 1, config.getMaxRetryAttempts());
-                connectFuture = clientBootstrap.connect(socketAddress).sync();
-            } catch (Exception e) {
-                log.error("Connection failed", e);
-                if (!shouldRetry(retriesUsed)) {
-                    throw e;
+                socketAddresses = socketAddressProvider.get();
+                if (socketAddresses == null || socketAddresses.isEmpty()) {
+                    throw new IllegalStateException("No socket addresses available for connection");
                 }
-                retriesUsed++;
+            } catch (Exception e) {
+                lastFailure = e;
+                logAddressResolutionFailure(e);
+            }
+
+            if (socketAddresses != null) {
+                for (int i = 0; i < socketAddresses.size() && connectFuture == null; i++) {
+                    SocketAddress socketAddress = socketAddresses.get(i);
+                    try {
+                        attempts++;
+                        if (showConnectionLog())
+                            log.info("Connecting to {} (attempt {}, candidate {}/{}, max retries: {})",
+                                    socketAddress, attempts, i + 1, socketAddresses.size(),
+                                    config.getMaxRetryAttempts());
+                        connectFuture = clientBootstrap.connect(socketAddress).sync();
+                    } catch (InterruptedException e) {
+                        throw e;
+                    } catch (Exception e) {
+                        lastFailure = e;
+                        logConnectionFailure(socketAddress, e);
+                    }
+                }
+            }
+
+            if (connectFuture == null) {
+                if (!shouldRetry(retryCyclesUsed)) {
+                    logConnectionCycleFailure("Connection failed after exhausting socket address candidates",
+                            lastFailure);
+                    throwConnectionFailure(lastFailure);
+                }
+
+                retryCyclesUsed++;
                 Thread.sleep(config.getInitialRetryDelayMs());
-                log.debug("Trying to reconnect !!!");
+                if (lastFailure != null)
+                    log.warn("Connection cycle failed. Retrying after {} ms: {}", config.getInitialRetryDelayMs(),
+                            lastFailure.toString());
+                else
+                    log.debug("Trying to reconnect !!!");
             }
         }
 
@@ -185,6 +233,43 @@ class Session implements Disposable {
 
         int maxRetryAttempts = config.getMaxRetryAttempts();
         return maxRetryAttempts == Integer.MAX_VALUE || retriesUsed < maxRetryAttempts;
+    }
+
+    private void throwConnectionFailure(Exception failure) throws InterruptedException {
+        if (failure == null)
+            throw new IllegalStateException("Connection failed");
+
+        if (failure instanceof InterruptedException)
+            throw (InterruptedException) failure;
+
+        if (failure instanceof RuntimeException)
+            throw (RuntimeException) failure;
+
+        throw new RuntimeException(failure);
+    }
+
+    private void logConnectionFailure(SocketAddress socketAddress, Exception failure) {
+        if (log.isDebugEnabled()) {
+            log.warn("Connection failed for {}", socketAddress, failure);
+        } else {
+            log.warn("Connection failed for {}: {}", socketAddress, failure.toString());
+        }
+    }
+
+    private void logAddressResolutionFailure(Exception failure) {
+        if (log.isDebugEnabled()) {
+            log.warn("Address resolution failed", failure);
+        } else {
+            log.warn("Address resolution failed: {}", failure.toString());
+        }
+    }
+
+    private void logConnectionCycleFailure(String message, Exception failure) {
+        if (failure == null) {
+            log.error(message);
+        } else {
+            log.error(message, failure);
+        }
     }
 
     public void handshake() {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
@@ -9,13 +9,14 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 /**
  * This class tries to open the network connection. The session gets destroyed during disconnection event.
  */
 @Slf4j
 class Session implements Disposable {
-    private final SocketAddress socketAddress;
+    private final Supplier<SocketAddress> socketAddressSupplier;
     private final Bootstrap clientBootstrap;
     private Channel activeChannel;
     private final AtomicBoolean shouldReconnect;
@@ -28,6 +29,26 @@ class Session implements Disposable {
     /**
      * Constructor with NodeClientConfig for configurable connection behavior.
      *
+     * @param socketAddressSupplier the socket address supplier to use for each connection attempt
+     * @param clientBootstrap the Netty bootstrap
+     * @param config the connection configuration
+     * @param handshakeAgent the handshake agent
+     * @param agents the protocol agents
+     */
+    public Session(Supplier<SocketAddress> socketAddressSupplier, Bootstrap clientBootstrap, NodeClientConfig config,
+                   HandshakeAgent handshakeAgent, Agent[] agents) {
+        this.socketAddressSupplier = socketAddressSupplier;
+        this.clientBootstrap = clientBootstrap;
+        this.config = config != null ? config : NodeClientConfig.defaultConfig();
+        this.shouldReconnect = new AtomicBoolean(this.config.isAutoReconnect());
+
+        this.handshakeAgent = handshakeAgent;
+        this.agents = agents;
+    }
+
+    /**
+     * Constructor with NodeClientConfig for configurable connection behavior.
+     *
      * @param socketAddress the socket address to connect to
      * @param clientBootstrap the Netty bootstrap
      * @param config the connection configuration
@@ -36,13 +57,7 @@ class Session implements Disposable {
      */
     public Session(SocketAddress socketAddress, Bootstrap clientBootstrap, NodeClientConfig config,
                    HandshakeAgent handshakeAgent, Agent[] agents) {
-        this.socketAddress = socketAddress;
-        this.clientBootstrap = clientBootstrap;
-        this.config = config != null ? config : NodeClientConfig.defaultConfig();
-        this.shouldReconnect = new AtomicBoolean(this.config.isAutoReconnect());
-
-        this.handshakeAgent = handshakeAgent;
-        this.agents = agents;
+        this(() -> socketAddress, clientBootstrap, config, handshakeAgent, agents);
     }
 
     /**
@@ -55,7 +70,8 @@ class Session implements Disposable {
      * @deprecated Use {@link #Session(SocketAddress, Bootstrap, NodeClientConfig, HandshakeAgent, Agent[])} instead
      */
     @Deprecated
-    public Session(SocketAddress socketAddress, Bootstrap clientBootstrap, HandshakeAgent handshakeAgent, Agent[] agents) {
+    public Session(SocketAddress socketAddress, Bootstrap clientBootstrap, HandshakeAgent handshakeAgent,
+                   Agent[] agents) {
         this(socketAddress, clientBootstrap, NodeClientConfig.defaultConfig(), handshakeAgent, agents);
     }
 
@@ -69,21 +85,25 @@ class Session implements Disposable {
     public Disposable start() throws InterruptedException {
         //Create a new connectFuture
         ChannelFuture connectFuture = null;
+        long retriesUsed = 0;
         // Always try to connect at least once, then retry only if shouldReconnect is true
-        do {
+        while (connectFuture == null) {
             try {
+                SocketAddress socketAddress = socketAddressSupplier.get();
+                if (showConnectionLog())
+                    log.info("Connecting to {} (attempt {}, max retries: {})",
+                            socketAddress, retriesUsed + 1, config.getMaxRetryAttempts());
                 connectFuture = clientBootstrap.connect(socketAddress).sync();
             } catch (Exception e) {
                 log.error("Connection failed", e);
-                if (shouldReconnect.get()) {
-                    Thread.sleep(config.getInitialRetryDelayMs());
-                    log.debug("Trying to reconnect !!!");
-                } else {
-                    // If auto-reconnect is disabled, fail fast
+                if (!shouldRetry(retriesUsed)) {
                     throw e;
                 }
+                retriesUsed++;
+                Thread.sleep(config.getInitialRetryDelayMs());
+                log.debug("Trying to reconnect !!!");
             }
-        } while (connectFuture == null && shouldReconnect.get());
+        }
 
         handshakeAgent.reset();
         for (Agent agent: agents) {
@@ -157,6 +177,14 @@ class Session implements Disposable {
 
     public boolean shouldReconnect() {
         return shouldReconnect.get();
+    }
+
+    private boolean shouldRetry(long retriesUsed) {
+        if (!shouldReconnect.get())
+            return false;
+
+        int maxRetryAttempts = config.getMaxRetryAttempts();
+        return maxRetryAttempts == Integer.MAX_VALUE || retriesUsed < maxRetryAttempts;
     }
 
     public void handshake() {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/SocketAddressFamily.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/SocketAddressFamily.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.core.network;
+
+/**
+ * Controls address-family filtering and ordering for DNS resolved socket addresses.
+ */
+public enum SocketAddressFamily {
+    ANY,
+    IPV4_ONLY,
+    IPV6_ONLY,
+    IPV4_PREFERRED,
+    IPV6_PREFERRED
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/SocketAddressProvider.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/SocketAddressProvider.java
@@ -1,0 +1,9 @@
+package com.bloxbean.cardano.yaci.core.network;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+@FunctionalInterface
+interface SocketAddressProvider {
+    List<SocketAddress> get();
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/SocketAddressResolutionMode.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/SocketAddressResolutionMode.java
@@ -1,0 +1,16 @@
+package com.bloxbean.cardano.yaci.core.network;
+
+/**
+ * Controls how TCP node clients resolve socket addresses during connection attempts.
+ */
+public enum SocketAddressResolutionMode {
+    /**
+     * Create a fresh {@code InetSocketAddress} for each connection attempt and let the JVM choose the address.
+     */
+    STANDARD,
+
+    /**
+     * Resolve all DNS answers for each connection attempt and rotate across the returned addresses.
+     */
+    DNS_ROTATING
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClient.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClient.java
@@ -10,11 +10,16 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.InetAddress;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This is the main class to initialize single or multiple agents for Node-to-node mini-protocol and setup channel handlers to send / process
@@ -24,7 +29,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public class TCPNodeClient extends NodeClient {
     private String host;
     private int port;
-    private DnsRotatingSocketAddressSupplier socketAddressSupplier;
+    private DnsRotatingSocketAddressProvider socketAddressProvider;
 
     /**
      * Constructor with NodeClientConfig for configurable connection behavior.
@@ -40,7 +45,8 @@ public class TCPNodeClient extends NodeClient {
         super(config, handshakeAgent, agents);
         this.host = host;
         this.port = port;
-        this.socketAddressSupplier = new DnsRotatingSocketAddressSupplier(host, port);
+        this.socketAddressProvider = new DnsRotatingSocketAddressProvider(host, port,
+                getConfig().getSocketAddressFamily());
     }
 
     /**
@@ -57,7 +63,15 @@ public class TCPNodeClient extends NodeClient {
 
     @Override
     protected SocketAddress createSocketAddress() {
-        return socketAddressSupplier.get();
+        return new InetSocketAddress(host, port);
+    }
+
+    @Override
+    protected List<SocketAddress> createSocketAddressCandidates() {
+        if (getConfig().getSocketAddressResolutionMode() == SocketAddressResolutionMode.DNS_ROTATING)
+            return socketAddressProvider.get();
+
+        return super.createSocketAddressCandidates();
     }
 
     @Override
@@ -77,24 +91,88 @@ public class TCPNodeClient extends NodeClient {
         bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getConfig().getConnectionTimeoutMs());
     }
 
-    private static class DnsRotatingSocketAddressSupplier {
+    static class DnsRotatingSocketAddressProvider {
         private final String host;
         private final int port;
+        private final SocketAddressFamily socketAddressFamily;
+        private final InetAddressResolver addressResolver;
         private final AtomicInteger cursor = new AtomicInteger(ThreadLocalRandom.current().nextInt());
 
-        private DnsRotatingSocketAddressSupplier(String host, int port) {
-            this.host = host;
-            this.port = port;
+        DnsRotatingSocketAddressProvider(String host, int port, SocketAddressFamily socketAddressFamily) {
+            this(host, port, socketAddressFamily, InetAddress::getAllByName);
         }
 
-        public SocketAddress get() {
+        DnsRotatingSocketAddressProvider(String host, int port, SocketAddressFamily socketAddressFamily,
+                                         InetAddressResolver addressResolver) {
+            this.host = host;
+            this.port = port;
+            this.socketAddressFamily = socketAddressFamily != null ? socketAddressFamily : SocketAddressFamily.ANY;
+            this.addressResolver = addressResolver;
+        }
+
+        public List<SocketAddress> get() {
             try {
-                InetAddress[] addresses = InetAddress.getAllByName(host);
-                int index = Math.floorMod(cursor.getAndIncrement(), addresses.length);
-                return new InetSocketAddress(addresses[index], port);
+                List<InetAddress> addresses = selectAddresses(Arrays.asList(addressResolver.resolve(host)));
+                if (addresses.isEmpty()) {
+                    throw new IllegalStateException("Unable to resolve " + host + ":" + port
+                            + " with address family " + socketAddressFamily);
+                }
+
+                List<SocketAddress> socketAddresses = new ArrayList<>(addresses.size());
+                for (InetAddress address : addresses) {
+                    socketAddresses.add(new InetSocketAddress(address, port));
+                }
+                return socketAddresses;
             } catch (UnknownHostException e) {
                 throw new IllegalStateException("Unable to resolve " + host + ":" + port, e);
             }
         }
+
+        private List<InetAddress> selectAddresses(List<InetAddress> addresses) {
+            List<InetAddress> ipv4 = filterByFamily(addresses, Inet4Address.class);
+            List<InetAddress> ipv6 = filterByFamily(addresses, Inet6Address.class);
+            int start = cursor.getAndIncrement();
+
+            return switch (socketAddressFamily) {
+                case ANY -> rotate(addresses, start);
+                case IPV4_ONLY -> rotate(ipv4, start);
+                case IPV6_ONLY -> rotate(ipv6, start);
+                case IPV4_PREFERRED -> concatenate(rotate(ipv4, start), rotate(ipv6, start));
+                case IPV6_PREFERRED -> concatenate(rotate(ipv6, start), rotate(ipv4, start));
+            };
+        }
+
+        private <T extends InetAddress> List<InetAddress> filterByFamily(List<InetAddress> addresses,
+                                                                         Class<T> addressFamilyClass) {
+            List<InetAddress> filteredAddresses = new ArrayList<>();
+            for (InetAddress address : addresses) {
+                if (addressFamilyClass.isInstance(address)) {
+                    filteredAddresses.add(address);
+                }
+            }
+            return filteredAddresses;
+        }
+
+        private List<InetAddress> rotate(List<InetAddress> addresses, int start) {
+            if (addresses.size() <= 1)
+                return new ArrayList<>(addresses);
+
+            int index = Math.floorMod(start, addresses.size());
+            List<InetAddress> rotatedAddresses = new ArrayList<>(addresses.size());
+            rotatedAddresses.addAll(addresses.subList(index, addresses.size()));
+            rotatedAddresses.addAll(addresses.subList(0, index));
+            return rotatedAddresses;
+        }
+
+        private List<InetAddress> concatenate(List<InetAddress> first, List<InetAddress> second) {
+            List<InetAddress> addresses = new ArrayList<>(first.size() + second.size());
+            addresses.addAll(first);
+            addresses.addAll(second);
+            return addresses;
+        }
+    }
+
+    interface InetAddressResolver {
+        InetAddress[] resolve(String host) throws UnknownHostException;
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClient.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClient.java
@@ -9,8 +9,12 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import lombok.extern.slf4j.Slf4j;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * This is the main class to initialize single or multiple agents for Node-to-node mini-protocol and setup channel handlers to send / process
@@ -20,6 +24,7 @@ import java.net.SocketAddress;
 public class TCPNodeClient extends NodeClient {
     private String host;
     private int port;
+    private DnsRotatingSocketAddressSupplier socketAddressSupplier;
 
     /**
      * Constructor with NodeClientConfig for configurable connection behavior.
@@ -30,10 +35,12 @@ public class TCPNodeClient extends NodeClient {
      * @param handshakeAgent the handshake agent
      * @param agents the protocol agents
      */
-    public TCPNodeClient(String host, int port, NodeClientConfig config, HandshakeAgent handshakeAgent, Agent... agents) {
+    public TCPNodeClient(String host, int port, NodeClientConfig config, HandshakeAgent handshakeAgent,
+                         Agent... agents) {
         super(config, handshakeAgent, agents);
         this.host = host;
         this.port = port;
+        this.socketAddressSupplier = new DnsRotatingSocketAddressSupplier(host, port);
     }
 
     /**
@@ -50,7 +57,7 @@ public class TCPNodeClient extends NodeClient {
 
     @Override
     protected SocketAddress createSocketAddress() {
-        return new InetSocketAddress(host, port);
+        return socketAddressSupplier.get();
     }
 
     @Override
@@ -68,5 +75,26 @@ public class TCPNodeClient extends NodeClient {
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.option(ChannelOption.TCP_NODELAY, true);
         bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getConfig().getConnectionTimeoutMs());
+    }
+
+    private static class DnsRotatingSocketAddressSupplier {
+        private final String host;
+        private final int port;
+        private final AtomicInteger cursor = new AtomicInteger(ThreadLocalRandom.current().nextInt());
+
+        private DnsRotatingSocketAddressSupplier(String host, int port) {
+            this.host = host;
+            this.port = port;
+        }
+
+        public SocketAddress get() {
+            try {
+                InetAddress[] addresses = InetAddress.getAllByName(host);
+                int index = Math.floorMod(cursor.getAndIncrement(), addresses.length);
+                return new InetSocketAddress(addresses[index], port);
+            } catch (UnknownHostException e) {
+                throw new IllegalStateException("Unable to resolve " + host + ":" + port, e);
+            }
+        }
     }
 }

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfigTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfigTest.java
@@ -18,6 +18,10 @@ class NodeClientConfigTest {
         assertTrue(config.isEnableConnectionLogging(), "Connection logging should be enabled by default");
         assertEquals(30000, config.getConnectionTimeoutMs(), "Default connection timeout should be 30000ms");
         assertFalse(config.isPropagateStartupFailure(), "Startup failure propagation should be disabled by default");
+        assertEquals(SocketAddressResolutionMode.STANDARD, config.getSocketAddressResolutionMode(),
+                "Default socket address resolution mode should be STANDARD");
+        assertEquals(SocketAddressFamily.ANY, config.getSocketAddressFamily(),
+                "Default socket address family should be ANY");
     }
 
     @Test
@@ -30,6 +34,8 @@ class NodeClientConfigTest {
         assertEquals(Integer.MAX_VALUE, config.getMaxRetryAttempts());
         assertTrue(config.isEnableConnectionLogging());
         assertFalse(config.isPropagateStartupFailure());
+        assertEquals(SocketAddressResolutionMode.STANDARD, config.getSocketAddressResolutionMode());
+        assertEquals(SocketAddressFamily.ANY, config.getSocketAddressFamily());
     }
 
     @Test
@@ -52,12 +58,16 @@ class NodeClientConfigTest {
                 .initialRetryDelayMs(5000)
                 .maxRetryAttempts(3)
                 .enableConnectionLogging(false)
+                .socketAddressResolutionMode(SocketAddressResolutionMode.DNS_ROTATING)
+                .socketAddressFamily(SocketAddressFamily.IPV4_ONLY)
                 .build();
 
         assertFalse(config.isAutoReconnect());
         assertEquals(5000, config.getInitialRetryDelayMs());
         assertEquals(3, config.getMaxRetryAttempts());
         assertFalse(config.isEnableConnectionLogging());
+        assertEquals(SocketAddressResolutionMode.DNS_ROTATING, config.getSocketAddressResolutionMode());
+        assertEquals(SocketAddressFamily.IPV4_ONLY, config.getSocketAddressFamily());
     }
 
     @Test

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfigTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfigTest.java
@@ -17,6 +17,7 @@ class NodeClientConfigTest {
         assertEquals(Integer.MAX_VALUE, config.getMaxRetryAttempts(), "Default max retry attempts should be unlimited");
         assertTrue(config.isEnableConnectionLogging(), "Connection logging should be enabled by default");
         assertEquals(30000, config.getConnectionTimeoutMs(), "Default connection timeout should be 30000ms");
+        assertFalse(config.isPropagateStartupFailure(), "Startup failure propagation should be disabled by default");
     }
 
     @Test
@@ -28,6 +29,7 @@ class NodeClientConfigTest {
         assertEquals(8000, config.getInitialRetryDelayMs());
         assertEquals(Integer.MAX_VALUE, config.getMaxRetryAttempts());
         assertTrue(config.isEnableConnectionLogging());
+        assertFalse(config.isPropagateStartupFailure());
     }
 
     @Test

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/SessionTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/SessionTest.java
@@ -1,0 +1,124 @@
+package com.bloxbean.cardano.yaci.core.network;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgent;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SessionTest {
+
+    @Test
+    void startGetsFreshSocketAddressForEachRetryAttempt() throws InterruptedException {
+        Bootstrap bootstrap = mock(Bootstrap.class);
+        when(bootstrap.connect(any(SocketAddress.class))).thenThrow(new RuntimeException("connect failed"));
+
+        AtomicInteger supplierCalls = new AtomicInteger();
+        Supplier<SocketAddress> socketAddressSupplier = () -> {
+            supplierCalls.incrementAndGet();
+            return new InetSocketAddress("127.0.0.1", 3001);
+        };
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .initialRetryDelayMs(0)
+                .maxRetryAttempts(2)
+                .enableConnectionLogging(false)
+                .build();
+
+        Session session = new Session(socketAddressSupplier, bootstrap, config, null, new Agent[0]);
+
+        assertThrows(RuntimeException.class, session::start);
+
+        assertEquals(3, supplierCalls.get());
+        verify(bootstrap, times(3)).connect(any(SocketAddress.class));
+    }
+
+    @Test
+    void startDoesNotRetryWhenAutoReconnectIsDisabled() {
+        Bootstrap bootstrap = mock(Bootstrap.class);
+        when(bootstrap.connect(any(SocketAddress.class))).thenThrow(new RuntimeException("connect failed"));
+
+        AtomicInteger supplierCalls = new AtomicInteger();
+        Supplier<SocketAddress> socketAddressSupplier = () -> {
+            supplierCalls.incrementAndGet();
+            return new InetSocketAddress("127.0.0.1", 3001);
+        };
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .autoReconnect(false)
+                .initialRetryDelayMs(0)
+                .maxRetryAttempts(10)
+                .enableConnectionLogging(false)
+                .build();
+
+        Session session = new Session(socketAddressSupplier, bootstrap, config, null, new Agent[0]);
+
+        assertThrows(RuntimeException.class, session::start);
+
+        assertEquals(1, supplierCalls.get());
+        verify(bootstrap, times(1)).connect(any(SocketAddress.class));
+    }
+
+    @Test
+    void nodeClientStartPropagatesStartupFailureWhenConfigured() {
+        NodeClientConfig config = NodeClientConfig.builder()
+                .autoReconnect(false)
+                .enableConnectionLogging(false)
+                .propagateStartupFailure(true)
+                .build();
+
+        FailingNodeClient client = new FailingNodeClient(config);
+
+        try {
+            assertThrows(NodeClientException.class, client::start);
+            assertFalse(client.isRunning());
+            assertThrows(NodeClientException.class, client::start);
+            assertFalse(client.isRunning());
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    private static class FailingNodeClient extends NodeClient {
+        private FailingNodeClient(NodeClientConfig config) {
+            super(config, new HandshakeAgent(N2NVersionTableConstant.v4AndAbove(0)));
+        }
+
+        @Override
+        protected SocketAddress createSocketAddress() {
+            return new InetSocketAddress("127.0.0.1", 1);
+        }
+
+        @Override
+        protected EventLoopGroup configureEventLoopGroup() {
+            return new NioEventLoopGroup(1);
+        }
+
+        @Override
+        protected Class getChannelClass() {
+            return NioSocketChannel.class;
+        }
+
+        @Override
+        protected void configureChannel(Bootstrap bootstrap) {
+            throw new IllegalStateException("configure failed");
+        }
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/SessionTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/SessionTest.java
@@ -4,6 +4,8 @@ import com.bloxbean.cardano.yaci.core.protocol.Agent;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgent;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -11,11 +13,13 @@ import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -77,6 +81,88 @@ class SessionTest {
     }
 
     @Test
+    void startTriesNextCandidateWhenFirstCandidateFails() throws InterruptedException {
+        Bootstrap bootstrap = mock(Bootstrap.class);
+        ChannelFuture channelFuture = mockSuccessfulChannelFuture();
+        HandshakeAgent handshakeAgent = mock(HandshakeAgent.class);
+        when(handshakeAgent.isDone()).thenReturn(true);
+
+        SocketAddress first = new InetSocketAddress("127.0.0.1", 3001);
+        SocketAddress second = new InetSocketAddress("127.0.0.2", 3001);
+        when(bootstrap.connect(first)).thenThrow(new RuntimeException("first candidate failed"));
+        when(bootstrap.connect(second)).thenReturn(channelFuture);
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .autoReconnect(false)
+                .enableConnectionLogging(false)
+                .build();
+
+        Session session = new Session(() -> List.of(first, second), bootstrap, config, handshakeAgent, new Agent[0]);
+
+        assertSame(session, session.start());
+        verify(bootstrap, times(1)).connect(first);
+        verify(bootstrap, times(1)).connect(second);
+    }
+
+    @Test
+    void startTriesAllCandidatesOnceBeforeFailingWhenRetriesAreDisabled() {
+        Bootstrap bootstrap = mock(Bootstrap.class);
+        AtomicInteger providerCalls = new AtomicInteger();
+
+        SocketAddress first = new InetSocketAddress("127.0.0.1", 3001);
+        SocketAddress second = new InetSocketAddress("127.0.0.2", 3001);
+        when(bootstrap.connect(any(SocketAddress.class))).thenThrow(new RuntimeException("connect failed"));
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .autoReconnect(false)
+                .maxRetryAttempts(0)
+                .enableConnectionLogging(false)
+                .build();
+
+        Session session = new Session(() -> {
+            providerCalls.incrementAndGet();
+            return List.of(first, second);
+        }, bootstrap, config, null, new Agent[0]);
+
+        assertThrows(RuntimeException.class, session::start);
+        assertEquals(1, providerCalls.get());
+        verify(bootstrap, times(1)).connect(first);
+        verify(bootstrap, times(1)).connect(second);
+    }
+
+    @Test
+    void startRetriesWhenAddressResolutionFailsTransiently() throws InterruptedException {
+        Bootstrap bootstrap = mock(Bootstrap.class);
+        ChannelFuture channelFuture = mockSuccessfulChannelFuture();
+        HandshakeAgent handshakeAgent = mock(HandshakeAgent.class);
+        when(handshakeAgent.isDone()).thenReturn(true);
+
+        SocketAddress socketAddress = new InetSocketAddress("127.0.0.1", 3001);
+        when(bootstrap.connect(socketAddress)).thenReturn(channelFuture);
+
+        AtomicInteger providerCalls = new AtomicInteger();
+        SocketAddressProvider socketAddressProvider = () -> {
+            if (providerCalls.incrementAndGet() == 1) {
+                throw new IllegalStateException("temporary dns failure");
+            }
+            return List.of(socketAddress);
+        };
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .autoReconnect(true)
+                .initialRetryDelayMs(0)
+                .maxRetryAttempts(1)
+                .enableConnectionLogging(false)
+                .build();
+
+        Session session = new Session(socketAddressProvider, bootstrap, config, handshakeAgent, new Agent[0]);
+
+        assertSame(session, session.start());
+        assertEquals(2, providerCalls.get());
+        verify(bootstrap, times(1)).connect(socketAddress);
+    }
+
+    @Test
     void nodeClientStartPropagatesStartupFailureWhenConfigured() {
         NodeClientConfig config = NodeClientConfig.builder()
                 .autoReconnect(false)
@@ -91,6 +177,32 @@ class SessionTest {
             assertFalse(client.isRunning());
             assertThrows(NodeClientException.class, client::start);
             assertFalse(client.isRunning());
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    void nodeClientStartPropagatesStartupFailureAfterAllCandidatesFail() {
+        Bootstrap bootstrap = mock(Bootstrap.class);
+        SocketAddress first = new InetSocketAddress("127.0.0.1", 3001);
+        SocketAddress second = new InetSocketAddress("127.0.0.2", 3001);
+        when(bootstrap.connect(first)).thenThrow(new RuntimeException("first candidate failed"));
+        when(bootstrap.connect(second)).thenThrow(new RuntimeException("second candidate failed"));
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .autoReconnect(false)
+                .maxRetryAttempts(0)
+                .enableConnectionLogging(false)
+                .propagateStartupFailure(true)
+                .build();
+
+        CandidateFailingNodeClient client = new CandidateFailingNodeClient(config, bootstrap, List.of(first, second));
+
+        try {
+            assertThrows(NodeClientException.class, client::start);
+            verify(bootstrap, times(1)).connect(first);
+            verify(bootstrap, times(1)).connect(second);
         } finally {
             client.shutdown();
         }
@@ -120,5 +232,54 @@ class SessionTest {
         protected void configureChannel(Bootstrap bootstrap) {
             throw new IllegalStateException("configure failed");
         }
+    }
+
+    private static class CandidateFailingNodeClient extends NodeClient {
+        private final Bootstrap bootstrap;
+        private final List<SocketAddress> candidates;
+
+        private CandidateFailingNodeClient(NodeClientConfig config, Bootstrap bootstrap,
+                                           List<SocketAddress> candidates) {
+            super(config, mock(HandshakeAgent.class));
+            this.bootstrap = bootstrap;
+            this.candidates = candidates;
+        }
+
+        @Override
+        protected SocketAddress createSocketAddress() {
+            return candidates.get(0);
+        }
+
+        @Override
+        protected List<SocketAddress> createSocketAddressCandidates() {
+            return candidates;
+        }
+
+        @Override
+        protected Bootstrap createBootstrap() {
+            return bootstrap;
+        }
+
+        @Override
+        protected EventLoopGroup configureEventLoopGroup() {
+            return mock(EventLoopGroup.class);
+        }
+
+        @Override
+        protected Class getChannelClass() {
+            return NioSocketChannel.class;
+        }
+
+        @Override
+        protected void configureChannel(Bootstrap bootstrap) {
+        }
+    }
+
+    private ChannelFuture mockSuccessfulChannelFuture() throws InterruptedException {
+        ChannelFuture channelFuture = mock(ChannelFuture.class);
+        Channel channel = mock(Channel.class);
+        when(channelFuture.sync()).thenReturn(channelFuture);
+        when(channelFuture.channel()).thenReturn(channel);
+        return channelFuture;
     }
 }

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClientTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClientTest.java
@@ -1,0 +1,131 @@
+package com.bloxbean.cardano.yaci.core.network;
+
+import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgent;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
+import org.junit.jupiter.api.Test;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TCPNodeClientTest {
+
+    @Test
+    void standardModeCreatesFreshJvmSelectedSocketAddressForEachAttempt() {
+        InspectableTCPNodeClient client = new InspectableTCPNodeClient("127.0.0.1", 3001,
+                NodeClientConfig.defaultConfig());
+
+        SocketAddress first = client.socketAddressCandidates().get(0);
+        SocketAddress second = client.socketAddressCandidates().get(0);
+
+        assertEquals(first, second);
+        assertNotSame(first, second);
+    }
+
+    @Test
+    void standardModeDoesNotUseExplicitDnsRotationResolver() {
+        InspectableTCPNodeClient client = new InspectableTCPNodeClient("missing.yaci.invalid", 3001,
+                NodeClientConfig.defaultConfig());
+
+        InetSocketAddress socketAddress = assertDoesNotThrow(() ->
+                (InetSocketAddress) client.socketAddressCandidates().get(0));
+
+        assertEquals("missing.yaci.invalid", socketAddress.getHostString());
+        assertEquals(3001, socketAddress.getPort());
+    }
+
+    @Test
+    void dnsRotatingModeUsesExplicitDnsResolver() {
+        NodeClientConfig config = NodeClientConfig.builder()
+                .socketAddressResolutionMode(SocketAddressResolutionMode.DNS_ROTATING)
+                .build();
+        InspectableTCPNodeClient client = new InspectableTCPNodeClient("missing.yaci.invalid", 3001, config);
+
+        assertThrows(IllegalStateException.class, client::socketAddressCandidates);
+    }
+
+    @Test
+    void dnsRotatingWithIpv4OnlyExcludesIpv6Addresses() throws UnknownHostException {
+        TCPNodeClient.DnsRotatingSocketAddressProvider provider = provider(SocketAddressFamily.IPV4_ONLY,
+                address("2001:db8::1"), address("192.0.2.1"), address("198.51.100.1"));
+
+        List<SocketAddress> socketAddresses = provider.get();
+
+        assertEquals(2, socketAddresses.size());
+        for (SocketAddress socketAddress : socketAddresses) {
+            assertTrue(((InetSocketAddress) socketAddress).getAddress() instanceof Inet4Address);
+        }
+    }
+
+    @Test
+    void dnsRotatingWithIpv4PreferredOrdersIpv4BeforeIpv6() throws UnknownHostException {
+        TCPNodeClient.DnsRotatingSocketAddressProvider provider = provider(SocketAddressFamily.IPV4_PREFERRED,
+                address("2001:db8::1"), address("192.0.2.1"), address("2001:db8::2"), address("198.51.100.1"));
+
+        List<SocketAddress> socketAddresses = provider.get();
+
+        boolean seenIpv6 = false;
+        for (SocketAddress socketAddress : socketAddresses) {
+            InetAddress address = ((InetSocketAddress) socketAddress).getAddress();
+            if (address instanceof Inet6Address) {
+                seenIpv6 = true;
+            } else {
+                assertTrue(address instanceof Inet4Address);
+                assertTrue(!seenIpv6, "IPv4 address should not appear after IPv6 in IPV4_PREFERRED mode");
+            }
+        }
+    }
+
+    @Test
+    void dnsRotatingWithIpv4PreferredFallsBackToIpv6WhenNoIpv4Exists() throws UnknownHostException {
+        TCPNodeClient.DnsRotatingSocketAddressProvider provider = provider(SocketAddressFamily.IPV4_PREFERRED,
+                address("2001:db8::1"), address("2001:db8::2"));
+
+        List<SocketAddress> socketAddresses = provider.get();
+
+        assertEquals(2, socketAddresses.size());
+        for (SocketAddress socketAddress : socketAddresses) {
+            assertTrue(((InetSocketAddress) socketAddress).getAddress() instanceof Inet6Address);
+        }
+    }
+
+    @Test
+    void dnsRotatingWithIpv4OnlyFailsWhenNoIpv4Exists() throws UnknownHostException {
+        TCPNodeClient.DnsRotatingSocketAddressProvider provider = provider(SocketAddressFamily.IPV4_ONLY,
+                address("2001:db8::1"));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, provider::get);
+
+        assertTrue(exception.getMessage().contains("IPV4_ONLY"));
+    }
+
+    private static class InspectableTCPNodeClient extends TCPNodeClient {
+        private InspectableTCPNodeClient(String host, int port, NodeClientConfig config) {
+            super(host, port, config, new HandshakeAgent(N2NVersionTableConstant.v4AndAbove(0)));
+        }
+
+        private List<SocketAddress> socketAddressCandidates() {
+            return createSocketAddressCandidates();
+        }
+    }
+
+    private TCPNodeClient.DnsRotatingSocketAddressProvider provider(SocketAddressFamily socketAddressFamily,
+                                                                   InetAddress... addresses) {
+        return new TCPNodeClient.DnsRotatingSocketAddressProvider("relay.example", 3001, socketAddressFamily,
+                host -> addresses);
+    }
+
+    private InetAddress address(String address) throws UnknownHostException {
+        return InetAddress.getByName(address);
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,13 +14,13 @@ slf4j-reload4j="org.slf4j:slf4j-reload4j:2.0.11"
 
 lombok="org.projectlombok:lombok:1.18.44"
 
-junit-jupiter-api="org.junit.jupiter:junit-jupiter-api:5.8.1"
-junit-jupiter-engine="org.junit.jupiter:junit-jupiter-engine:5.8.1"
-junit-platform-launcher="org.junit.platform:junit-platform-launcher:1.8.1"
+junit-jupiter-api="org.junit.jupiter:junit-jupiter-api:5.13.4"
+junit-jupiter-engine="org.junit.jupiter:junit-jupiter-engine:5.13.4"
+junit-platform-launcher="org.junit.platform:junit-platform-launcher:1.13.4"
 harmcrest-library="org.hamcrest:hamcrest-library:2.2"
 
-mockito-inline="org.mockito:mockito-inline:3.7.7"
-mockito-junit-jupiter="org.mockito:mockito-junit-jupiter:3.7.7"
+mockito-core="org.mockito:mockito-core:5.23.0"
+mockito-junit-jupiter="org.mockito:mockito-junit-jupiter:5.23.0"
 assertj-core="org.assertj:assertj-core:3.21.0"
 
 reload4j="ch.qos.reload4j:reload4j:1.2.22"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-cardano-client-lib = "0.8.0-pre3"
+cardano-client-lib = "0.8.0-pre4"
 
 [libraries]
 cardano-client-core = { module = "com.bloxbean.cardano:cardano-client-core", version.ref = "cardano-client-lib" }

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
@@ -11,6 +11,7 @@ import com.bloxbean.cardano.yaci.core.model.byron.ByronBlockHead;
 import com.bloxbean.cardano.yaci.core.model.byron.ByronEbBlock;
 import com.bloxbean.cardano.yaci.core.model.byron.ByronEbHead;
 import com.bloxbean.cardano.yaci.core.model.byron.ByronMainBlock;
+import com.bloxbean.cardano.yaci.core.network.NodeClientConfig;
 import com.bloxbean.cardano.yaci.core.network.TCPNodeClient;
 import com.bloxbean.cardano.yaci.core.protocol.blockfetch.BlockfetchAgent;
 import com.bloxbean.cardano.yaci.core.protocol.blockfetch.BlockfetchAgentListener;
@@ -53,6 +54,7 @@ public class N2NPeerFetcher implements Fetcher<Block> {
     private final int port;
     private final VersionTable versionTable;
     private final Point wellKnownPoint;
+    private final NodeClientConfig nodeClientConfig;
 
     // Agents
     private HandshakeAgent handshakeAgent;
@@ -99,14 +101,32 @@ public class N2NPeerFetcher implements Fetcher<Block> {
     }
 
     /**
+     * Construct {@link N2NPeerFetcher} to sync the blockchain.
+     */
+    public N2NPeerFetcher(String host, int port, Point wellKnownPoint, long protocolMagic,
+                          NodeClientConfig nodeClientConfig) {
+        this(host, port, wellKnownPoint, N2NVersionTableConstant.v11AndAbove(protocolMagic), nodeClientConfig);
+    }
+
+    /**
      * Main constructor - fetcher syncs from the given wellKnownPoint
      * Application controls sync strategy by choosing the starting point
      */
     public N2NPeerFetcher(String host, int port, Point wellKnownPoint, VersionTable versionTable) {
+        this(host, port, wellKnownPoint, versionTable, NodeClientConfig.defaultConfig());
+    }
+
+    /**
+     * Main constructor - fetcher syncs from the given wellKnownPoint.
+     * Application controls sync strategy and connection policy.
+     */
+    public N2NPeerFetcher(String host, int port, Point wellKnownPoint, VersionTable versionTable,
+                          NodeClientConfig nodeClientConfig) {
         this.host = host;
         this.port = port;
         this.versionTable = versionTable;
         this.wellKnownPoint = wellKnownPoint;
+        this.nodeClientConfig = nodeClientConfig != null ? nodeClientConfig : NodeClientConfig.defaultConfig();
 
         init();
     }
@@ -121,7 +141,7 @@ public class N2NPeerFetcher implements Fetcher<Block> {
         blockFetchAgent.resetPoints(wellKnownPoint, wellKnownPoint);
         setupAgentListeners();
 
-        n2nClient = new TCPNodeClient(host, port, handshakeAgent, keepAliveAgent,
+        n2nClient = new TCPNodeClient(host, port, nodeClientConfig, handshakeAgent, keepAliveAgent,
                 chainSyncAgent, blockFetchAgent, txSubmissionAgent);
     }
 

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yaci.helper;
 
 import com.bloxbean.cardano.yaci.core.common.TxBodyType;
+import com.bloxbean.cardano.yaci.core.network.NodeClientConfig;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Tip;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.VersionTable;
@@ -28,41 +29,69 @@ public class PeerClient {
     private int port;
     private Point wellKnownPoint;
     private VersionTable versionTable;
+    private NodeClientConfig nodeClientConfig;
 
     private int txMaxQueueSize;
 
     private N2NPeerFetcher n2NPeerFetcher;
 
     /**
-     * Construct a BlockSync instance
+     * Construct a PeerClient instance
      * @param host Cardano node host
      * @param port Cardano node port
      * @param protocolMagic Protocol magic
      * @param wellKnownPoint A wellknown point
      */
     public PeerClient(String host, int port, long protocolMagic, Point wellKnownPoint) {
-        this(host, port, wellKnownPoint, N2NVersionTableConstant.v4AndAbove(protocolMagic));
+        this(host, port, wellKnownPoint, N2NVersionTableConstant.v11AndAbove(protocolMagic));
     }
 
     /**
-     * Construct a BlockSync instance
+     * Construct a PeerClient instance
+     * @param host Cardano node host
+     * @param port Cardano node port
+     * @param protocolMagic Protocol magic
+     * @param wellKnownPoint A wellknown point
+     * @param nodeClientConfig connection configuration
+     */
+    public PeerClient(String host, int port, long protocolMagic, Point wellKnownPoint,
+                      NodeClientConfig nodeClientConfig) {
+        this(host, port, wellKnownPoint, N2NVersionTableConstant.v11AndAbove(protocolMagic), nodeClientConfig);
+    }
+
+    /**
+     * Construct a PeerClient instance
      * @param host Cardano node host
      * @param port Cardano node port
      * @param wellKnownPoint A wellknown point
      * @param versionTable {@link VersionTable} instance
      */
     public PeerClient(String host, int port, Point wellKnownPoint, VersionTable versionTable) {
+        this(host, port, wellKnownPoint, versionTable, NodeClientConfig.defaultConfig());
+    }
+
+    /**
+     * Construct a PeerClient instance
+     * @param host Cardano node host
+     * @param port Cardano node port
+     * @param wellKnownPoint A wellknown point
+     * @param versionTable {@link VersionTable} instance
+     * @param nodeClientConfig connection configuration
+     */
+    public PeerClient(String host, int port, Point wellKnownPoint, VersionTable versionTable,
+                      NodeClientConfig nodeClientConfig) {
         this.host = host;
         this.port = port;
         this.wellKnownPoint = wellKnownPoint;
         this.versionTable = versionTable;
+        this.nodeClientConfig = nodeClientConfig != null ? nodeClientConfig : NodeClientConfig.defaultConfig();
     }
 
     public void connect(BlockChainDataListener blockChainDataListener, TxSubmissionListener txSubmissionListener) {
         if (n2NPeerFetcher != null && n2NPeerFetcher.isRunning())
-            throw new IllegalStateException("Already connected. Please call shutdown() before connecting again.");
+            throw new IllegalStateException("Already connected. Please call stop() before connecting again.");
 
-        n2NPeerFetcher = new N2NPeerFetcher(host, port, wellKnownPoint, versionTable);
+        n2NPeerFetcher = new N2NPeerFetcher(host, port, wellKnownPoint, versionTable, nodeClientConfig);
         if (txMaxQueueSize > 0)
             n2NPeerFetcher.setTxMaxQueueSize(txMaxQueueSize);
 


### PR DESCRIPTION
## Summary

  - Adds fresh DNS/socket address resolution for `TCPNodeClient` connect attempts.
  - Adds opt-in startup failure propagation via `NodeClientConfig`.
  - Wires `NodeClientConfig` through `PeerClient` and `N2NPeerFetcher`.
  - Changes `PeerClient` default N2N versions to `v11AndAbove`.
  - Updates Mockito/JUnit test dependencies for Java 25 compatibility.
  - Adds focused tests for retry address supplier behavior and startup failure propagation.

## Rationale

  Yano needs an external supervisor to fail over when a peer becomes unreachable or DNS rotates. Previously, startup/connect failures could be swallowed by `NodeClient.start()`, making the supervisor unaware of failures. This change lets Yano opt into fail-fast behavior without changing the default behavior for existing APIs such as `BlockSync`.
