### PR TITLE
Update N2N/N2C application-layer protocol handling

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/AgentFactory.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/AgentFactory.java
@@ -1,0 +1,13 @@
+package com.bloxbean.cardano.yaci.core.network.server;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+
+/**
+ * Factory for creating additional protocol agents per server session.
+ * Used to inject app-layer agents alongside the existing L1 agents.
+ * The channel is set automatically after creation.
+ */
+@FunctionalInterface
+public interface AgentFactory {
+    Agent<?> createAgent();
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/NodeServer.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/NodeServer.java
@@ -12,6 +12,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -25,17 +27,26 @@ public class NodeServer {
     private ChainState chainState;
     private TxSubmissionListener txSubmissionListener;
     private TxSubmissionConfig txSubmissionConfig;
+    private List<AgentFactory> agentFactories;
     private final static Map<Channel, NodeServerSession> sessions = new ConcurrentHashMap<>();
 
     public NodeServer(int port, VersionTable versionTable, ChainState chainState) {
         this(port, versionTable, chainState, null, null);
     }
 
-    public NodeServer(int port, VersionTable versionTable, ChainState chainState, TxSubmissionListener txSubmissionListener) {
+    public NodeServer(int port, VersionTable versionTable, ChainState chainState,
+                      TxSubmissionListener txSubmissionListener) {
         this(port, versionTable, chainState, txSubmissionListener, null);
     }
 
-    public NodeServer(int port, VersionTable versionTable, ChainState chainState, TxSubmissionListener txSubmissionListener, TxSubmissionConfig txSubmissionConfig) {
+    public NodeServer(int port, VersionTable versionTable, ChainState chainState,
+                      TxSubmissionListener txSubmissionListener, TxSubmissionConfig txSubmissionConfig) {
+        this(port, versionTable, chainState, txSubmissionListener, txSubmissionConfig, Collections.emptyList());
+    }
+
+    public NodeServer(int port, VersionTable versionTable, ChainState chainState,
+                      TxSubmissionListener txSubmissionListener, TxSubmissionConfig txSubmissionConfig,
+                      List<AgentFactory> agentFactories) {
         this.port = port;
         this.bossGroup = new NioEventLoopGroup(1);
         this.workerGroup = new NioEventLoopGroup();
@@ -43,6 +54,7 @@ public class NodeServer {
         this.chainState = chainState;
         this.txSubmissionListener = txSubmissionListener;
         this.txSubmissionConfig = txSubmissionConfig != null ? txSubmissionConfig : TxSubmissionConfig.createDefault();
+        this.agentFactories = agentFactories != null ? agentFactories : Collections.emptyList();
     }
 
     public void start() {
@@ -61,7 +73,9 @@ public class NodeServer {
                             log.info("Local address: {}", ch.localAddress());
 
                             try {
-                                NodeServerSession session = new NodeServerSession(ch, versionTable, chainState, txSubmissionListener, txSubmissionConfig);
+                                NodeServerSession session = new NodeServerSession(
+                                        ch, versionTable, chainState, txSubmissionListener,
+                                        txSubmissionConfig, agentFactories);
                                 sessions.put(ch, session);
                                 log.info("Created session for client: {}", ch.remoteAddress());
                             } catch (Exception e) {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/NodeServerSession.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/NodeServerSession.java
@@ -18,6 +18,10 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.timeout.IdleStateHandler;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 @Slf4j
 public class NodeServerSession {
     private final Channel clientChannel;
@@ -26,14 +30,23 @@ public class NodeServerSession {
     private final ChainState chainState;
     private final TxSubmissionListener txSubmissionListener;
     private final TxSubmissionConfig txSubmissionConfig;
+    private final List<AgentFactory> agentFactories;
 
     public NodeServerSession(Channel clientChannel, VersionTable versionTable, ChainState chainState,
                            TxSubmissionListener txSubmissionListener, TxSubmissionConfig txSubmissionConfig) {
+        this(clientChannel, versionTable, chainState, txSubmissionListener, txSubmissionConfig,
+                Collections.emptyList());
+    }
+
+    public NodeServerSession(Channel clientChannel, VersionTable versionTable, ChainState chainState,
+                           TxSubmissionListener txSubmissionListener, TxSubmissionConfig txSubmissionConfig,
+                           List<AgentFactory> agentFactories) {
         this.clientChannel = clientChannel;
         this.handshakeAgent = new HandshakeAgent(versionTable, false);
         this.chainState = chainState;
         this.txSubmissionListener = txSubmissionListener;
         this.txSubmissionConfig = txSubmissionConfig != null ? txSubmissionConfig : TxSubmissionConfig.createDefault();
+        this.agentFactories = agentFactories != null ? agentFactories : Collections.emptyList();
         this.agents = createAgents();
 
         setupPipeline();
@@ -62,13 +75,13 @@ public class NodeServerSession {
     }
 
     private Agent[] createAgents() {
-        // Initialize specific mini-protocol handlers (ChainSync, BlockFetch, etc.)
+        // Initialize L1 mini-protocol handlers
         ChainSyncServerAgent chainSyncAgent = new ChainSyncServerAgent(chainState);
         BlockFetchServerAgent blockFetchAgent = new BlockFetchServerAgent(chainState);
         TxSubmissionServerAgent txSubmissionAgent = new TxSubmissionServerAgent(txSubmissionConfig);
         KeepAliveServerAgent keepAliveAgent = new KeepAliveServerAgent();
 
-        // Set channels for agents
+        // Set channels for L1 agents
         chainSyncAgent.setChannel(clientChannel);
         blockFetchAgent.setChannel(clientChannel);
         txSubmissionAgent.setChannel(clientChannel);
@@ -79,13 +92,26 @@ public class NodeServerSession {
             txSubmissionAgent.addListener(txSubmissionListener);
         }
 
-        return new Agent[]{
-            chainSyncAgent,
-            blockFetchAgent,
-            txSubmissionAgent,
-            keepAliveAgent
-        };
+        List<Agent<?>> allAgents = new ArrayList<>();
+        allAgents.add(chainSyncAgent);
+        allAgents.add(blockFetchAgent);
+        allAgents.add(txSubmissionAgent);
+        allAgents.add(keepAliveAgent);
+
+        for (AgentFactory factory : agentFactories) {
+            try {
+                Agent<?> agent = factory.createAgent();
+                if (agent != null) {
+                    agent.setChannel(clientChannel);
+                    allAgents.add(agent);
+                    log.info("Added app-layer agent: {} (protocol {})",
+                            agent.getClass().getSimpleName(), agent.getProtocolId());
+                }
+            } catch (Exception e) {
+                log.warn("Failed to create agent from factory: {}", e.getMessage());
+            }
+        }
+
+        return allAgents.toArray(new Agent[0]);
     }
 }
-
-

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/Agent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/Agent.java
@@ -94,7 +94,7 @@ public abstract class Agent<T extends AgentListener> {
 
         // Check the base protocol ID without the response flag
         int baseProtocolId = protocolWithFlag & 0x7FFF;
-        if (baseProtocolId < 0 || baseProtocolId > 100) {
+        if (baseProtocolId < 0 || baseProtocolId > 199) {
             log.error("🚨 Suspicious protocol ID: {} (0x{}) (base: {} 0x{})",
                      protocolWithFlag, Integer.toHexString(protocolWithFlag),
                      baseProtocolId, Integer.toHexString(baseProtocolId));
@@ -243,6 +243,14 @@ public abstract class Agent<T extends AgentListener> {
 
     public Channel getChannel() {
         return channel;
+    }
+
+    /**
+     * Returns true if the underlying Netty channel is non-null and currently active.
+     */
+    public boolean isChannelActive() {
+        Channel ch = this.channel;
+        return ch != null && ch.isActive();
     }
 
     /**

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/model/AppMessage.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/model/AppMessage.java
@@ -1,0 +1,55 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.model;
+
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+/**
+ * Full application message envelope for gossip protocols.
+ * <p>
+ * CBOR: [messageId(bstr), messageBody(bstr), authMethod(uint), authProof(bstr), topicId(tstr), expiresAt(uint)]
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class AppMessage {
+    private final byte[] messageId;
+    private final byte[] messageBody;
+    private final int authMethod;
+    private final byte[] authProof;
+    private final String topicId;
+    private final long expiresAt;
+
+    public int getSize() {
+        return messageBody != null ? messageBody.length : 0;
+    }
+
+    public String getMessageIdHex() {
+        return HexUtil.encodeHexString(messageId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AppMessage that = (AppMessage) o;
+        return Arrays.equals(messageId, that.messageId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(messageId);
+    }
+
+    @Override
+    public String toString() {
+        return "AppMessage{id=" + getMessageIdHex()
+                + ", topic=" + topicId
+                + ", size=" + getSize()
+                + ", auth=" + authMethod
+                + ", expiresAt=" + expiresAt + "}";
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/model/AppMessageId.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/model/AppMessageId.java
@@ -1,0 +1,35 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.model;
+
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+/**
+ * ID + size tuple for gossip protocol (mirrors TxId pattern).
+ */
+@Getter
+@AllArgsConstructor
+public class AppMessageId {
+    private final byte[] messageId;
+    private final int size;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AppMessageId that = (AppMessageId) o;
+        return Arrays.equals(messageId, that.messageId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(messageId);
+    }
+
+    @Override
+    public String toString() {
+        return HexUtil.encodeHexString(messageId);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/model/AuthMethod.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/model/AuthMethod.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.model;
+
+import lombok.Getter;
+
+@Getter
+public enum AuthMethod {
+    OPEN(0),
+    PERMISSIONED(1),
+    SPO_KES(2),
+    DELEGATED(3);
+
+    private final int value;
+
+    AuthMethod(int value) {
+        this.value = value;
+    }
+
+    public static AuthMethod fromValue(int value) {
+        for (AuthMethod method : values()) {
+            if (method.value == value) return method;
+        }
+        throw new IllegalArgumentException("Unknown auth method: " + value);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyAgent.java
@@ -1,0 +1,78 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.messages.*;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Client-side agent for Protocol 102 (Local App Message Notification).
+ * Blocking/non-blocking consumption of messages from the node.
+ */
+@Slf4j
+public class LocalAppMsgNotifyAgent extends Agent<LocalAppMsgNotifyListener> {
+    private boolean shutDown;
+    private boolean useBlocking;
+
+    public LocalAppMsgNotifyAgent() {
+        this(true);
+    }
+
+    public LocalAppMsgNotifyAgent(boolean useBlocking) {
+        super(true); // Client agent
+        this.useBlocking = useBlocking;
+        this.currentState = LocalAppMsgNotifyState.Idle;
+    }
+
+    @Override
+    public int getProtocolId() {
+        return 102;
+    }
+
+    @Override
+    public boolean isDone() {
+        return currentState == LocalAppMsgNotifyState.Done;
+    }
+
+    @Override
+    protected Message buildNextMessage() {
+        if (shutDown)
+            return new MsgClientDone();
+
+        if (currentState == LocalAppMsgNotifyState.Idle) {
+            return new MsgRequestMessages(useBlocking);
+        }
+        return null;
+    }
+
+    @Override
+    protected void processResponse(Message message) {
+        if (message == null) return;
+
+        if (message instanceof MsgReplyMessagesNonBlocking) {
+            var reply = (MsgReplyMessagesNonBlocking) message;
+            log.debug("Received {} messages (non-blocking, hasMore={})",
+                    reply.getMessages().size(), reply.isHasMore());
+            getAgentListeners().forEach(l ->
+                    l.onMessagesReceived(reply.getMessages(), reply.isHasMore()));
+        } else if (message instanceof MsgReplyMessagesBlocking) {
+            var reply = (MsgReplyMessagesBlocking) message;
+            log.debug("Received {} messages (blocking)", reply.getMessages().size());
+            getAgentListeners().forEach(l ->
+                    l.onMessagesReceived(reply.getMessages(), false));
+        }
+    }
+
+    public void setUseBlocking(boolean useBlocking) {
+        this.useBlocking = useBlocking;
+    }
+
+    @Override
+    public void reset() {
+        this.currentState = LocalAppMsgNotifyState.Idle;
+    }
+
+    public void shutdown() {
+        this.shutDown = true;
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyListener.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyListener.java
@@ -1,0 +1,10 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify;
+
+import com.bloxbean.cardano.yaci.core.protocol.AgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+
+import java.util.List;
+
+public interface LocalAppMsgNotifyListener extends AgentListener {
+    default void onMessagesReceived(List<AppMessage> messages, boolean hasMore) {}
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyState.java
@@ -1,0 +1,62 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.messages.*;
+
+public enum LocalAppMsgNotifyState implements LocalAppMsgNotifyStateBase {
+    Idle {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgRequestMessages) {
+                return ((MsgRequestMessages) message).isBlocking()
+                        ? BusyBlocking : BusyNonBlocking;
+            } else if (message instanceof MsgClientDone) {
+                return Done;
+            }
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
+        }
+    },
+    BusyNonBlocking {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgReplyMessagesNonBlocking)
+                return Idle;
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
+        }
+    },
+    BusyBlocking {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgReplyMessagesBlocking)
+                return Idle;
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
+        }
+    },
+    Done {
+        @Override
+        public State nextState(Message message) {
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyStateBase.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyStateBase.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.serializers.LocalAppMsgNotifySerializers.*;
+
+public interface LocalAppMsgNotifyStateBase extends State {
+    Logger log = LoggerFactory.getLogger(LocalAppMsgNotifyStateBase.class);
+
+    default Message handleInbound(byte[] bytes) {
+        try {
+            DataItem di = CborSerializationUtil.deserializeOne(bytes);
+            Array array = (Array) di;
+            int id = ((UnsignedInteger) array.getDataItems().get(0)).getValue().intValue();
+            switch (id) {
+                case 0:
+                    return MsgRequestMessagesSerializer.INSTANCE.deserialize(bytes);
+                case 1:
+                    return MsgReplyMessagesNonBlockingSerializer.INSTANCE.deserialize(bytes);
+                case 2:
+                    return MsgReplyMessagesBlockingSerializer.INSTANCE.deserialize(bytes);
+                case 3:
+                    return MsgClientDoneSerializer.INSTANCE.deserialize(bytes);
+                default:
+                    throw new RuntimeException(String.format("Invalid local app msg notify id: %d", id));
+            }
+        } catch (Exception e) {
+            log.error("LocalAppMsgNotify parsing error", e);
+            log.error("Data: {}", HexUtil.encodeHexString(bytes));
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/messages/MsgClientDone.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/messages/MsgClientDone.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.serializers.LocalAppMsgNotifySerializers;
+
+public class MsgClientDone implements Message {
+
+    @Override
+    public byte[] serialize() {
+        return LocalAppMsgNotifySerializers.MsgClientDoneSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/messages/MsgReplyMessagesBlocking.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/messages/MsgReplyMessagesBlocking.java
@@ -1,0 +1,20 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.serializers.LocalAppMsgNotifySerializers;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MsgReplyMessagesBlocking implements Message {
+    private final List<AppMessage> messages;
+
+    @Override
+    public byte[] serialize() {
+        return LocalAppMsgNotifySerializers.MsgReplyMessagesBlockingSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/messages/MsgReplyMessagesNonBlocking.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/messages/MsgReplyMessagesNonBlocking.java
@@ -1,0 +1,21 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.serializers.LocalAppMsgNotifySerializers;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MsgReplyMessagesNonBlocking implements Message {
+    private final List<AppMessage> messages;
+    private final boolean hasMore;
+
+    @Override
+    public byte[] serialize() {
+        return LocalAppMsgNotifySerializers.MsgReplyMessagesNonBlockingSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/messages/MsgRequestMessages.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/messages/MsgRequestMessages.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.serializers.LocalAppMsgNotifySerializers;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MsgRequestMessages implements Message {
+    private boolean blocking;
+
+    @Override
+    public byte[] serialize() {
+        return LocalAppMsgNotifySerializers.MsgRequestMessagesSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/serializers/LocalAppMsgNotifySerializers.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/serializers/LocalAppMsgNotifySerializers.java
@@ -1,0 +1,139 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.serializers;
+
+import co.nstant.in.cbor.model.*;
+import com.bloxbean.cardano.client.exception.CborRuntimeException;
+import com.bloxbean.cardano.yaci.core.protocol.Serializer;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.messages.*;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LocalAppMsgNotifySerializers {
+
+    // Tag 0: MsgRequestMessages [0, isBlocking]
+    public enum MsgRequestMessagesSerializer implements Serializer<MsgRequestMessages> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgRequestMessages msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(0));
+            array.add(msg.isBlocking() ? SimpleValue.TRUE : SimpleValue.FALSE);
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgRequestMessages deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            java.util.List<DataItem> items = array.getDataItems();
+            int label = ((UnsignedInteger) items.get(0)).getValue().intValue();
+            if (label != 0)
+                throw new CborRuntimeException("Invalid MsgRequestMessages label: " + label);
+            boolean blocking = items.get(1) == SimpleValue.TRUE;
+            return new MsgRequestMessages(blocking);
+        }
+    }
+
+    // Tag 1: MsgReplyMessagesNonBlocking [1, [msgs], hasMore]
+    public enum MsgReplyMessagesNonBlockingSerializer implements Serializer<MsgReplyMessagesNonBlocking> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgReplyMessagesNonBlocking msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(1));
+
+            Array msgsArray = new Array();
+            msgsArray.setChunked(true);
+            if (msg.getMessages() != null) {
+                for (AppMessage appMsg : msg.getMessages()) {
+                    msgsArray.add(AppMsgSubmissionSerializers.serializeAppMessage(appMsg));
+                }
+            }
+            msgsArray.add(SimpleValue.BREAK);
+            array.add(msgsArray);
+            array.add(msg.isHasMore() ? SimpleValue.TRUE : SimpleValue.FALSE);
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgReplyMessagesNonBlocking deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            List<DataItem> items = array.getDataItems();
+            int label = ((UnsignedInteger) items.get(0)).getValue().intValue();
+            if (label != 1)
+                throw new CborRuntimeException("Invalid MsgReplyMessagesNonBlocking label: " + label);
+
+            Array msgsArray = (Array) items.get(1);
+            List<AppMessage> messages = new ArrayList<>();
+            for (DataItem msgDI : msgsArray.getDataItems()) {
+                if (msgDI instanceof Special) break;
+                messages.add(AppMsgSubmissionSerializers.deserializeAppMessage((Array) msgDI));
+            }
+            boolean hasMore = items.get(2) == SimpleValue.TRUE;
+            return new MsgReplyMessagesNonBlocking(messages, hasMore);
+        }
+    }
+
+    // Tag 2: MsgReplyMessagesBlocking [2, [msgs]]
+    public enum MsgReplyMessagesBlockingSerializer implements Serializer<MsgReplyMessagesBlocking> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgReplyMessagesBlocking msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(2));
+
+            Array msgsArray = new Array();
+            msgsArray.setChunked(true);
+            if (msg.getMessages() != null) {
+                for (AppMessage appMsg : msg.getMessages()) {
+                    msgsArray.add(AppMsgSubmissionSerializers.serializeAppMessage(appMsg));
+                }
+            }
+            msgsArray.add(SimpleValue.BREAK);
+            array.add(msgsArray);
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgReplyMessagesBlocking deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            List<DataItem> items = array.getDataItems();
+            int label = ((UnsignedInteger) items.get(0)).getValue().intValue();
+            if (label != 2)
+                throw new CborRuntimeException("Invalid MsgReplyMessagesBlocking label: " + label);
+
+            Array msgsArray = (Array) items.get(1);
+            List<AppMessage> messages = new ArrayList<>();
+            for (DataItem msgDI : msgsArray.getDataItems()) {
+                if (msgDI instanceof Special) break;
+                messages.add(AppMsgSubmissionSerializers.deserializeAppMessage((Array) msgDI));
+            }
+            return new MsgReplyMessagesBlocking(messages);
+        }
+    }
+
+    // Tag 3: MsgClientDone [3]
+    public enum MsgClientDoneSerializer implements Serializer<MsgClientDone> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgClientDone msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(3));
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgClientDone deserialize(byte[] bytes) {
+            DataItem di = CborSerializationUtil.deserializeOne(bytes);
+            int key = ((UnsignedInteger) ((Array) di).getDataItems().get(0)).getValue().intValue();
+            if (key == 3) return new MsgClientDone();
+            throw new CborRuntimeException("Invalid MsgClientDone label: " + key);
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitAgent.java
@@ -1,0 +1,86 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Client-side agent for Protocol 101 (Local App Message Submit).
+ * Simple request-response: submit a message, get accept/reject.
+ */
+@Slf4j
+public class LocalAppMsgSubmitAgent extends Agent<LocalAppMsgSubmitListener> {
+    private boolean shutDown;
+    private final Queue<AppMessage> submitQueue;
+    private final Queue<AppMessage> pendingQueue;
+
+    public LocalAppMsgSubmitAgent() {
+        super(true);
+        this.submitQueue = new ConcurrentLinkedQueue<>();
+        this.pendingQueue = new ConcurrentLinkedQueue<>();
+        this.currentState = LocalAppMsgSubmitState.Idle;
+    }
+
+    @Override
+    public int getProtocolId() {
+        return 101;
+    }
+
+    @Override
+    public boolean isDone() {
+        return currentState == LocalAppMsgSubmitState.Done;
+    }
+
+    @Override
+    protected synchronized Message buildNextMessage() {
+        if (shutDown)
+            return new MsgDone();
+
+        if (currentState == LocalAppMsgSubmitState.Idle) {
+            AppMessage msg = submitQueue.poll();
+            if (msg != null) {
+                pendingQueue.add(msg);
+                return new MsgSubmitMessage(msg);
+            } else if (shutDown) {
+                return new MsgDone();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected synchronized void processResponse(Message message) {
+        if (message == null) return;
+
+        AppMessage pending = pendingQueue.poll();
+
+        if (message instanceof MsgAcceptMessage) {
+            log.debug("Message accepted");
+            getAgentListeners().forEach(l -> l.messageAccepted(pending, (MsgAcceptMessage) message));
+        } else if (message instanceof MsgRejectMessage) {
+            MsgRejectMessage reject = (MsgRejectMessage) message;
+            log.debug("Message rejected: {} - {}", reject.getReason(), reject.getDetail());
+            getAgentListeners().forEach(l -> l.messageRejected(pending, reject));
+        }
+    }
+
+    public void submitMessage(AppMessage message) {
+        submitQueue.add(message);
+    }
+
+    @Override
+    public synchronized void reset() {
+        this.currentState = LocalAppMsgSubmitState.Idle;
+        this.submitQueue.clear();
+        this.pendingQueue.clear();
+    }
+
+    public void shutdown() {
+        this.shutDown = true;
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitListener.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitListener.java
@@ -1,0 +1,11 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit;
+
+import com.bloxbean.cardano.yaci.core.protocol.AgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages.MsgAcceptMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages.MsgRejectMessage;
+
+public interface LocalAppMsgSubmitListener extends AgentListener {
+    default void messageAccepted(AppMessage message, MsgAcceptMessage accept) {}
+    default void messageRejected(AppMessage message, MsgRejectMessage reject) {}
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitState.java
@@ -1,0 +1,47 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages.*;
+
+public enum LocalAppMsgSubmitState implements LocalAppMsgSubmitStateBase {
+    Idle {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgSubmitMessage)
+                return Busy;
+            else if (message instanceof MsgDone)
+                return Done;
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
+        }
+    },
+    Busy {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgAcceptMessage || message instanceof MsgRejectMessage)
+                return Idle;
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
+        }
+    },
+    Done {
+        @Override
+        public State nextState(Message message) {
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitStateBase.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitStateBase.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.serializers.LocalAppMsgSubmitSerializers.*;
+
+public interface LocalAppMsgSubmitStateBase extends State {
+    Logger log = LoggerFactory.getLogger(LocalAppMsgSubmitStateBase.class);
+
+    default Message handleInbound(byte[] bytes) {
+        try {
+            DataItem di = CborSerializationUtil.deserializeOne(bytes);
+            Array array = (Array) di;
+            int id = ((UnsignedInteger) array.getDataItems().get(0)).getValue().intValue();
+            switch (id) {
+                case 0:
+                    return MsgSubmitMessageSerializer.INSTANCE.deserialize(bytes);
+                case 1:
+                    return MsgAcceptMessageSerializer.INSTANCE.deserialize(bytes);
+                case 2:
+                    return MsgRejectMessageSerializer.INSTANCE.deserialize(bytes);
+                case 3:
+                    return MsgDoneSerializer.INSTANCE.deserialize(bytes);
+                default:
+                    throw new RuntimeException(String.format("Invalid local app msg submit id: %d", id));
+            }
+        } catch (Exception e) {
+            log.error("LocalAppMsgSubmit parsing error", e);
+            log.error("Data: {}", HexUtil.encodeHexString(bytes));
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/MsgAcceptMessage.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/MsgAcceptMessage.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.serializers.LocalAppMsgSubmitSerializers;
+
+public class MsgAcceptMessage implements Message {
+
+    @Override
+    public byte[] serialize() {
+        return LocalAppMsgSubmitSerializers.MsgAcceptMessageSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/MsgDone.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/MsgDone.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.serializers.LocalAppMsgSubmitSerializers;
+
+public class MsgDone implements Message {
+
+    @Override
+    public byte[] serialize() {
+        return LocalAppMsgSubmitSerializers.MsgDoneSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/MsgRejectMessage.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/MsgRejectMessage.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.serializers.LocalAppMsgSubmitSerializers;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MsgRejectMessage implements Message {
+    private RejectReason reason;
+    private String detail;
+
+    public MsgRejectMessage(RejectReason reason) {
+        this(reason, "");
+    }
+
+    @Override
+    public byte[] serialize() {
+        return LocalAppMsgSubmitSerializers.MsgRejectMessageSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/MsgSubmitMessage.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/MsgSubmitMessage.java
@@ -1,0 +1,18 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.serializers.LocalAppMsgSubmitSerializers;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MsgSubmitMessage implements Message {
+    private final AppMessage appMessage;
+
+    @Override
+    public byte[] serialize() {
+        return LocalAppMsgSubmitSerializers.MsgSubmitMessageSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/RejectReason.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/messages/RejectReason.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages;
+
+import lombok.Getter;
+
+@Getter
+public enum RejectReason {
+    INVALID(0),
+    ALREADY_RECEIVED(1),
+    EXPIRED(2),
+    OTHER(3);
+
+    private final int value;
+
+    RejectReason(int value) {
+        this.value = value;
+    }
+
+    public static RejectReason fromValue(int value) {
+        for (RejectReason r : values()) {
+            if (r.value == value) return r;
+        }
+        return OTHER;
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/serializers/LocalAppMsgSubmitSerializers.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/serializers/LocalAppMsgSubmitSerializers.java
@@ -1,0 +1,103 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.serializers;
+
+import co.nstant.in.cbor.model.*;
+import com.bloxbean.cardano.client.exception.CborRuntimeException;
+import com.bloxbean.cardano.yaci.core.protocol.Serializer;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages.*;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+
+import java.util.List;
+
+public class LocalAppMsgSubmitSerializers {
+
+    // Tag 0: MsgSubmitMessage [0, appMessage]
+    public enum MsgSubmitMessageSerializer implements Serializer<MsgSubmitMessage> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgSubmitMessage msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(0));
+            array.add(AppMsgSubmissionSerializers.serializeAppMessage(msg.getAppMessage()));
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgSubmitMessage deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            List<DataItem> items = array.getDataItems();
+            int label = ((UnsignedInteger) items.get(0)).getValue().intValue();
+            if (label != 0)
+                throw new CborRuntimeException("Invalid MsgSubmitMessage label: " + label);
+            var appMessage = AppMsgSubmissionSerializers.deserializeAppMessage((Array) items.get(1));
+            return new MsgSubmitMessage(appMessage);
+        }
+    }
+
+    // Tag 1: MsgAcceptMessage [1]
+    public enum MsgAcceptMessageSerializer implements Serializer<MsgAcceptMessage> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgAcceptMessage msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(1));
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgAcceptMessage deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            int label = ((UnsignedInteger) array.getDataItems().get(0)).getValue().intValue();
+            if (label == 1) return new MsgAcceptMessage();
+            throw new CborRuntimeException("Invalid MsgAcceptMessage label: " + label);
+        }
+    }
+
+    // Tag 2: MsgRejectMessage [2, reasonCode, detail]
+    public enum MsgRejectMessageSerializer implements Serializer<MsgRejectMessage> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgRejectMessage msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(2));
+            array.add(new UnsignedInteger(msg.getReason().getValue()));
+            array.add(new UnicodeString(msg.getDetail() != null ? msg.getDetail() : ""));
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgRejectMessage deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            List<DataItem> items = array.getDataItems();
+            int label = ((UnsignedInteger) items.get(0)).getValue().intValue();
+            if (label != 2)
+                throw new CborRuntimeException("Invalid MsgRejectMessage label: " + label);
+            int reasonCode = ((UnsignedInteger) items.get(1)).getValue().intValue();
+            String detail = ((UnicodeString) items.get(2)).getString();
+            return new MsgRejectMessage(RejectReason.fromValue(reasonCode), detail);
+        }
+    }
+
+    // Tag 3: MsgDone [3]
+    public enum MsgDoneSerializer implements Serializer<MsgDone> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgDone msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(3));
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgDone deserialize(byte[] bytes) {
+            DataItem di = CborSerializationUtil.deserializeOne(bytes);
+            int key = ((UnsignedInteger) ((Array) di).getDataItems().get(0)).getValue().intValue();
+            if (key == 3) return new MsgDone();
+            throw new CborRuntimeException("Invalid MsgDone label: " + key);
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionAgent.java
@@ -1,0 +1,211 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessageId;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.*;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import io.netty.channel.Channel;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Client-side agent for Protocol 100 (App Message Submission).
+ * Maintains a queue of pending messages and responds to server requests
+ * for message IDs and bodies.
+ */
+@Slf4j
+public class AppMsgSubmissionAgent extends Agent<AppMsgSubmissionListener> {
+    private static final int DEFAULT_MAX_QUEUE_SIZE = 1000;
+
+    private final ConcurrentLinkedQueue<AppMessage> pendingMessages;
+    private final ConcurrentLinkedQueue<byte[]> pendingIds;
+    private final ConcurrentLinkedQueue<byte[]> requestedIds;
+    private final int maxQueueSize;
+
+    public AppMsgSubmissionAgent() {
+        this(DEFAULT_MAX_QUEUE_SIZE);
+    }
+
+    public AppMsgSubmissionAgent(int maxQueueSize) {
+        super(true); // Client agent
+        this.currentState = AppMsgSubmissionState.Init;
+        this.pendingMessages = new ConcurrentLinkedQueue<>();
+        this.pendingIds = new ConcurrentLinkedQueue<>();
+        this.requestedIds = new ConcurrentLinkedQueue<>();
+        this.maxQueueSize = maxQueueSize;
+    }
+
+    @Override
+    public int getProtocolId() {
+        return 100;
+    }
+
+    @Override
+    public Message buildNextMessage() {
+        switch ((AppMsgSubmissionState) currentState) {
+            case Init:
+                return new MsgInit();
+            case MessageIdsBlocking:
+                // In blocking mode, hold agency until we have actual message IDs to report.
+                // Don't rely solely on pendingIds — it may have stale entries (IDs whose
+                // messages were already delivered and removed from pendingMessages).
+                // enqueueMessage() will trigger sendNextMessage() when new messages arrive.
+                if (pendingMessages.isEmpty()) {
+                    pendingIds.clear(); // Clean up stale IDs
+                    return null;
+                }
+                return buildReplyMessageIds();
+            case MessageIdsNonBlocking:
+                return buildReplyMessageIds();
+            case Messages:
+                return buildReplyMessages();
+            default:
+                return null;
+        }
+    }
+
+    private MsgReplyMessageIds buildReplyMessageIds() {
+        MsgReplyMessageIds reply = new MsgReplyMessageIds();
+        if (!pendingIds.isEmpty()) {
+            pendingIds.stream()
+                    .flatMap(id -> findMessage(id).stream())
+                    .forEach(msg -> reply.addMessageId(
+                            new AppMessageId(msg.getMessageId(), msg.getSize())));
+            log.info("Sending {} message ID(s) to peer", reply.getMessageIds().size());
+        }
+        return reply;
+    }
+
+    private MsgReplyMessages buildReplyMessages() {
+        MsgReplyMessages reply = new MsgReplyMessages();
+        if (!requestedIds.isEmpty()) {
+            requestedIds.forEach(id ->
+                    findMessage(id).ifPresent(reply::addMessage));
+            // Remove delivered messages
+            requestedIds.forEach(this::removeMessage);
+            requestedIds.clear();
+            log.info("Sending {} message(s) to peer", reply.getMessages().size());
+        }
+        return reply;
+    }
+
+    @Override
+    public void processResponse(Message message) {
+        if (message == null) return;
+
+        if (message instanceof MsgInit) {
+            log.debug("Received MsgInit");
+        } else if (message instanceof MsgRequestMessageIds) {
+            handleRequestMessageIds((MsgRequestMessageIds) message);
+        } else if (message instanceof MsgRequestMessages) {
+            handleRequestMessages((MsgRequestMessages) message);
+        }
+    }
+
+    private void handleRequestMessageIds(MsgRequestMessageIds request) {
+        if (log.isDebugEnabled())
+            log.debug("RequestMessageIds - blocking: {}, ack: {}, req: {}",
+                    request.isBlocking(), request.getAckCount(), request.getReqCount());
+
+        // Process acknowledgments
+        removeAcknowledged(request.getAckCount());
+
+        // Fill pending IDs up to requested count
+        int toAdd = request.getReqCount() - pendingIds.size();
+        if (toAdd > 0) {
+            pendingMessages.stream()
+                    .map(AppMessage::getMessageId)
+                    .filter(id -> !containsId(pendingIds, id))
+                    .limit(toAdd)
+                    .forEach(pendingIds::add);
+        }
+
+        getAgentListeners().forEach(l -> l.handleRequestMessageIds(request));
+    }
+
+    private void handleRequestMessages(MsgRequestMessages request) {
+        requestedIds.clear();
+        requestedIds.addAll(request.getMessageIds());
+        getAgentListeners().forEach(l -> l.handleRequestMessages(request));
+    }
+
+    private void removeAcknowledged(int count) {
+        if (count <= 0) return;
+        int removed = Math.min(count, pendingIds.size());
+        for (int i = 0; i < removed; i++) {
+            byte[] id = pendingIds.poll();
+            if (id != null) removeMessage(id);
+        }
+        if (count > removed)
+            log.warn("Ack count {} exceeded pendingIds size {}", count, removed);
+        log.info("Peer acknowledged {} message(s), remaining in queue: {}", removed, pendingMessages.size());
+    }
+
+    /**
+     * Enqueue a message for submission to peers.
+     *
+     * @return true if enqueued, false if rejected (queue full or duplicate)
+     */
+    public boolean enqueueMessage(AppMessage message) {
+        boolean shouldWake;
+        synchronized (this) {
+            if (pendingMessages.size() >= maxQueueSize) {
+                log.warn("Message queue full ({}/{}), rejecting: {}",
+                        pendingMessages.size(), maxQueueSize, message.getMessageIdHex());
+                return false;
+            }
+            if (pendingMessages.stream().anyMatch(m -> Arrays.equals(m.getMessageId(), message.getMessageId()))) {
+                return false; // duplicate
+            }
+            pendingMessages.add(message);
+            shouldWake = AppMsgSubmissionState.MessageIdsBlocking.equals(currentState);
+            if (shouldWake) {
+                pendingIds.add(message.getMessageId());
+            }
+        }
+        log.info("Message enqueued: {}, total in queue: {}", message.getMessageIdHex(), pendingMessages.size());
+        if (shouldWake) {
+            Channel ch = getChannel();
+            if (ch != null && ch.isActive()) {
+                ch.eventLoop().execute(this::sendNextMessage);
+            }
+        }
+        return true;
+    }
+
+    public int getQueueSize() {
+        return pendingMessages.size();
+    }
+
+    @Override
+    public boolean isDone() {
+        return currentState == AppMsgSubmissionState.Done;
+    }
+
+    @Override
+    public void reset() {
+        pendingMessages.clear();
+        pendingIds.clear();
+        requestedIds.clear();
+        this.currentState = AppMsgSubmissionState.Init;
+    }
+
+    private Optional<AppMessage> findMessage(byte[] messageId) {
+        return pendingMessages.stream()
+                .filter(m -> Arrays.equals(m.getMessageId(), messageId))
+                .findFirst();
+    }
+
+    private void removeMessage(byte[] messageId) {
+        pendingMessages.removeIf(m -> Arrays.equals(m.getMessageId(), messageId));
+    }
+
+    private boolean containsId(ConcurrentLinkedQueue<byte[]> queue, byte[] id) {
+        return queue.stream().anyMatch(existing -> Arrays.equals(existing, id));
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionAgent.java
@@ -26,6 +26,7 @@ public class AppMsgSubmissionAgent extends Agent<AppMsgSubmissionListener> {
     private final ConcurrentLinkedQueue<byte[]> pendingIds;
     private final ConcurrentLinkedQueue<byte[]> requestedIds;
     private final int maxQueueSize;
+    private volatile int requestedMessageIdWindow;
 
     public AppMsgSubmissionAgent() {
         this(DEFAULT_MAX_QUEUE_SIZE);
@@ -73,6 +74,7 @@ public class AppMsgSubmissionAgent extends Agent<AppMsgSubmissionListener> {
         MsgReplyMessageIds reply = new MsgReplyMessageIds();
         if (!pendingIds.isEmpty()) {
             pendingIds.stream()
+                    .limit(requestedMessageIdWindow)
                     .flatMap(id -> findMessage(id).stream())
                     .forEach(msg -> reply.addMessageId(
                             new AppMessageId(msg.getMessageId(), msg.getSize())));
@@ -115,15 +117,10 @@ public class AppMsgSubmissionAgent extends Agent<AppMsgSubmissionListener> {
         // Process acknowledgments
         removeAcknowledged(request.getAckCount());
 
+        requestedMessageIdWindow = Math.max(0, request.getReqCount());
+
         // Fill pending IDs up to requested count
-        int toAdd = request.getReqCount() - pendingIds.size();
-        if (toAdd > 0) {
-            pendingMessages.stream()
-                    .map(AppMessage::getMessageId)
-                    .filter(id -> !containsId(pendingIds, id))
-                    .limit(toAdd)
-                    .forEach(pendingIds::add);
-        }
+        fillPendingIdsUpToWindow();
 
         getAgentListeners().forEach(l -> l.handleRequestMessageIds(request));
     }
@@ -164,8 +161,10 @@ public class AppMsgSubmissionAgent extends Agent<AppMsgSubmissionListener> {
             }
             pendingMessages.add(message);
             shouldWake = AppMsgSubmissionState.MessageIdsBlocking.equals(currentState);
-            if (shouldWake) {
+            if (shouldWake && hasPendingIdCapacity()) {
                 pendingIds.add(message.getMessageId());
+            } else {
+                shouldWake = false;
             }
         }
         log.info("Message enqueued: {}, total in queue: {}", message.getMessageIdHex(), pendingMessages.size());
@@ -192,6 +191,7 @@ public class AppMsgSubmissionAgent extends Agent<AppMsgSubmissionListener> {
         pendingMessages.clear();
         pendingIds.clear();
         requestedIds.clear();
+        requestedMessageIdWindow = 0;
         this.currentState = AppMsgSubmissionState.Init;
     }
 
@@ -207,5 +207,21 @@ public class AppMsgSubmissionAgent extends Agent<AppMsgSubmissionListener> {
 
     private boolean containsId(ConcurrentLinkedQueue<byte[]> queue, byte[] id) {
         return queue.stream().anyMatch(existing -> Arrays.equals(existing, id));
+    }
+
+    private void fillPendingIdsUpToWindow() {
+        int toAdd = requestedMessageIdWindow - pendingIds.size();
+        if (toAdd <= 0)
+            return;
+
+        pendingMessages.stream()
+                .map(AppMessage::getMessageId)
+                .filter(id -> !containsId(pendingIds, id))
+                .limit(toAdd)
+                .forEach(pendingIds::add);
+    }
+
+    private boolean hasPendingIdCapacity() {
+        return pendingIds.size() < requestedMessageIdWindow;
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionConfig.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionConfig.java
@@ -1,0 +1,45 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@Builder
+@Slf4j
+public class AppMsgSubmissionConfig {
+
+    @Builder.Default
+    private final int batchSize = 10;
+
+    @Builder.Default
+    private final boolean useBlockingMode = true;
+
+    @Builder.Default
+    private final int maxMessageSize = 65536; // 64KB max per message
+
+    public static AppMsgSubmissionConfig createDefault() {
+        return AppMsgSubmissionConfig.builder().build();
+    }
+
+    public static AppMsgSubmissionConfig withBatchSize(int batchSize) {
+        return AppMsgSubmissionConfig.builder().batchSize(batchSize).build();
+    }
+
+    public static AppMsgSubmissionConfig createTestConfig() {
+        return AppMsgSubmissionConfig.builder().batchSize(3).build();
+    }
+
+    public void validate() {
+        if (batchSize <= 0)
+            log.warn("AppMsgSubmissionConfig: batchSize must be positive, got: {}", batchSize);
+        if (batchSize > 10)
+            log.warn("AppMsgSubmissionConfig: batchSize ({}) exceeds recommended limit of 10", batchSize);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("AppMsgSubmissionConfig{batchSize=%d, blockingMode=%s, maxMessageSize=%d}",
+                batchSize, useBlockingMode, maxMessageSize);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionConfig.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionConfig.java
@@ -18,6 +18,9 @@ public class AppMsgSubmissionConfig {
     @Builder.Default
     private final int maxMessageSize = 65536; // 64KB max per message
 
+    @Builder.Default
+    private final int processedMessageIdCacheSize = 10000;
+
     public static AppMsgSubmissionConfig createDefault() {
         return AppMsgSubmissionConfig.builder().build();
     }
@@ -35,11 +38,15 @@ public class AppMsgSubmissionConfig {
             log.warn("AppMsgSubmissionConfig: batchSize must be positive, got: {}", batchSize);
         if (batchSize > 10)
             log.warn("AppMsgSubmissionConfig: batchSize ({}) exceeds recommended limit of 10", batchSize);
+        if (processedMessageIdCacheSize <= 0)
+            log.warn("AppMsgSubmissionConfig: processedMessageIdCacheSize must be positive, got: {}",
+                    processedMessageIdCacheSize);
     }
 
     @Override
     public String toString() {
-        return String.format("AppMsgSubmissionConfig{batchSize=%d, blockingMode=%s, maxMessageSize=%d}",
-                batchSize, useBlockingMode, maxMessageSize);
+        return String.format("AppMsgSubmissionConfig{batchSize=%d, blockingMode=%s, maxMessageSize=%d, "
+                        + "processedMessageIdCacheSize=%d}",
+                batchSize, useBlockingMode, maxMessageSize, processedMessageIdCacheSize);
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionListener.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionListener.java
@@ -1,0 +1,15 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import com.bloxbean.cardano.yaci.core.protocol.AgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.*;
+
+public interface AppMsgSubmissionListener extends AgentListener {
+
+    // Client-side methods (handling requests from server)
+    default void handleRequestMessageIds(MsgRequestMessageIds request) {}
+    default void handleRequestMessages(MsgRequestMessages request) {}
+
+    // Server-side methods (handling replies from client)
+    default void handleReplyMessageIds(MsgReplyMessageIds reply) {}
+    default void handleReplyMessages(MsgReplyMessages reply) {}
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgent.java
@@ -1,0 +1,242 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessageId;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.*;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import lombok.extern.slf4j.Slf4j;
+
+import io.netty.channel.Channel;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Server-side agent for Protocol 100 (App Message Submission).
+ * Pulls messages from connected clients using a blocking request pattern.
+ * Maintains FIFO queue, dedup set, and ack/req window tracking.
+ */
+@Slf4j
+public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener> {
+
+    private static final int MAX_UNACKNOWLEDGED = 10;
+    private static final int DEFAULT_BATCH_SIZE = 10;
+
+    private final Queue<AppMessageId> outstandingMessageIds = new ConcurrentLinkedQueue<>();
+    private final AtomicInteger pendingAcknowledgments = new AtomicInteger(0);
+    private final Set<String> seenMessageIds = new HashSet<>();
+    private volatile Message pendingRequest;
+    private final AppMsgSubmissionConfig config;
+
+    public AppMsgSubmissionServerAgent() {
+        this(AppMsgSubmissionConfig.createDefault());
+    }
+
+    public AppMsgSubmissionServerAgent(AppMsgSubmissionConfig config) {
+        super(false); // Server agent
+        this.config = config;
+        this.currentState = AppMsgSubmissionState.Init;
+    }
+
+    @Override
+    public int getProtocolId() {
+        return 100;
+    }
+
+    @Override
+    public Message buildNextMessage() {
+        log.debug("buildNextMessage() - state: {}, hasAgency: {}, pendingRequest: {}",
+                currentState, hasAgency(),
+                pendingRequest != null ? pendingRequest.getClass().getSimpleName() : "null");
+
+        if (currentState == AppMsgSubmissionState.Idle && pendingRequest != null) {
+            if (getChannel() == null) {
+                // Test mode
+                Message toSend = pendingRequest;
+                pendingRequest = null;
+                return toSend;
+            } else if (getChannel().isActive()) {
+                Message toSend = pendingRequest;
+                pendingRequest = null;
+                log.info("Sending {}", toSend.getClass().getSimpleName());
+                return toSend;
+            } else {
+                log.debug("Channel not active, keeping pendingRequest");
+                return null;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void processResponse(Message message) {
+        if (message == null) return;
+
+        log.debug("Processing: {} in state: {}", message.getClass().getSimpleName(), currentState);
+
+        if (message instanceof MsgInit) {
+            handleInit();
+        } else if (message instanceof MsgReplyMessageIds) {
+            handleReplyMessageIds((MsgReplyMessageIds) message);
+        } else if (message instanceof MsgReplyMessages) {
+            handleReplyMessages((MsgReplyMessages) message);
+        } else {
+            log.warn("Unexpected message type: {}", message.getClass().getSimpleName());
+        }
+    }
+
+    private void handleInit() {
+        log.info("Received MsgInit from client");
+        sendInitialBlockingRequest();
+    }
+
+    private void handleReplyMessageIds(MsgReplyMessageIds reply) {
+        log.info("Received ReplyMessageIds with {} IDs", reply.getMessageIds().size());
+
+        if (reply.getMessageIds().isEmpty()) {
+            log.debug("No messages available from peer, will retry after delay");
+            Channel ch = getChannel();
+            if (ch != null && ch.isActive()) {
+                ch.eventLoop().schedule(() -> {
+                    sendNextBlockingRequest();
+                    if (hasAgency()) {
+                        sendNextMessage();
+                    }
+                }, 1, TimeUnit.SECONDS);
+            }
+            return;
+        }
+
+        for (AppMessageId mid : reply.getMessageIds()) {
+            String idStr = HexUtil.encodeHexString(mid.getMessageId());
+            if (!seenMessageIds.contains(idStr)) {
+                outstandingMessageIds.offer(mid);
+                seenMessageIds.add(idStr);
+                log.debug("Added message ID to queue: {} (size: {} bytes)", idStr, mid.getSize());
+            }
+        }
+
+        getAgentListeners().forEach(l -> l.handleReplyMessageIds(reply));
+
+        if (!outstandingMessageIds.isEmpty()) {
+            requestMessageBodies();
+        } else {
+            // All IDs were already seen (deduped) — ack and continue polling
+            log.debug("All {} message IDs already seen, sending next blocking request", reply.getMessageIds().size());
+            pendingAcknowledgments.addAndGet(reply.getMessageIds().size());
+            sendNextBlockingRequest();
+        }
+    }
+
+    private void handleReplyMessages(MsgReplyMessages reply) {
+        log.info("Received ReplyMessages with {} messages", reply.getMessages().size());
+
+        for (AppMessage msg : reply.getMessages()) {
+            AppMessageId processedId = outstandingMessageIds.poll();
+            if (processedId != null) {
+                pendingAcknowledgments.incrementAndGet();
+                log.debug("Processed message, pending acks: {}", pendingAcknowledgments.get());
+            }
+        }
+
+        getAgentListeners().forEach(l -> l.handleReplyMessages(reply));
+
+        if (outstandingMessageIds.isEmpty()) {
+            log.info("All messages processed, sending next blocking request");
+            sendNextBlockingRequest();
+        }
+    }
+
+    private void sendInitialBlockingRequest() {
+        short ack = 0;
+        short req = (short) Math.min(config.getBatchSize(), MAX_UNACKNOWLEDGED);
+        log.info("Sending initial blocking request: ack={}, req={}", ack, req);
+        requestMessageIds(ack, req, true);
+    }
+
+    private void sendNextBlockingRequest() {
+        short ack = (short) Math.min(pendingAcknowledgments.getAndSet(0), Short.MAX_VALUE);
+        short req = (short) Math.min(config.getBatchSize(), MAX_UNACKNOWLEDGED);
+        log.info("Sending next blocking request: ack={}, req={}", ack, req);
+        requestMessageIds(ack, req, true);
+    }
+
+    private void requestMessageIds(short ack, short req, boolean blocking) {
+        if (currentState != AppMsgSubmissionState.Idle) {
+            log.warn("Cannot request message IDs in state: {}", currentState);
+            return;
+        }
+
+        MsgRequestMessageIds request = new MsgRequestMessageIds(blocking, ack, req);
+        this.pendingRequest = request;
+
+        if (hasAgency()) {
+            if (getChannel() != null && getChannel().isActive()) {
+                sendNextMessage();
+            }
+        }
+    }
+
+    private void requestMessageBodies() {
+        if (currentState != AppMsgSubmissionState.Idle) {
+            log.warn("Cannot request message bodies in state: {}", currentState);
+            return;
+        }
+
+        MsgRequestMessages request = new MsgRequestMessages();
+        for (AppMessageId mid : outstandingMessageIds) {
+            request.addMessageId(mid.getMessageId());
+        }
+        log.info("Requesting {} message bodies", request.getMessageIds().size());
+
+        this.pendingRequest = request;
+
+        if (hasAgency() && getChannel() != null && getChannel().isActive()) {
+            sendNextMessage();
+        }
+    }
+
+    @Override
+    public boolean isDone() {
+        return currentState == AppMsgSubmissionState.Done;
+    }
+
+    @Override
+    public void reset() {
+        outstandingMessageIds.clear();
+        seenMessageIds.clear();
+        pendingAcknowledgments.set(0);
+        pendingRequest = null;
+        this.currentState = AppMsgSubmissionState.Init;
+    }
+
+    @Override
+    public void shutdown() {
+        log.info("Shutting down AppMsgSubmissionServerAgent");
+        reset();
+    }
+
+    public int getReceivedMessageIdCount() {
+        return seenMessageIds.size();
+    }
+
+    public boolean hasReceivedMessageId(String hexId) {
+        return seenMessageIds.contains(hexId);
+    }
+
+    public int getOutstandingMessageCount() {
+        return outstandingMessageIds.size();
+    }
+
+    public int getPendingAcknowledgments() {
+        return pendingAcknowledgments.get();
+    }
+
+    public AppMsgSubmissionConfig getConfig() {
+        return config;
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgent.java
@@ -32,6 +32,7 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
     private final Set<String> processedMessageIds;
     private volatile Message pendingRequest;
     private final AppMsgSubmissionConfig config;
+    private volatile int requestedMessageIdCount;
 
     public AppMsgSubmissionServerAgent() {
         this(AppMsgSubmissionConfig.createDefault());
@@ -47,6 +48,14 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
     @Override
     public int getProtocolId() {
         return 100;
+    }
+
+    @Override
+    public void sendRequest(Message message) {
+        if (message instanceof MsgRequestMessageIds) {
+            requestedMessageIdCount = Math.max(0, ((MsgRequestMessageIds) message).getReqCount());
+        }
+        super.sendRequest(message);
     }
 
     @Override
@@ -113,7 +122,13 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
             return;
         }
 
+        int processedReplyIds = 0;
         for (AppMessageId mid : reply.getMessageIds()) {
+            if (processedReplyIds >= requestedMessageIdCount) {
+                log.warn("Peer replied with more app message IDs than requested; ignoring extra ID(s)");
+                break;
+            }
+
             String idStr = HexUtil.encodeHexString(mid.getMessageId());
             if (!processedMessageIds.contains(idStr) && !outstandingMessageIdSet.contains(idStr)) {
                 outstandingMessageIds.offer(mid);
@@ -123,6 +138,7 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
                 pendingAcknowledgments.incrementAndGet();
                 log.debug("Skipping already processed or in-flight message ID: {}", idStr);
             }
+            processedReplyIds++;
         }
 
         getAgentListeners().forEach(l -> l.handleReplyMessageIds(reply));
@@ -139,25 +155,41 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
     private void handleReplyMessages(MsgReplyMessages reply) {
         log.info("Received ReplyMessages with {} messages", reply.getMessages().size());
 
+        Map<String, AppMessage> replyByMessageId = new HashMap<>();
         for (AppMessage msg : reply.getMessages()) {
             String messageId = HexUtil.encodeHexString(msg.getMessageId());
-            if (removeOutstandingMessageId(messageId)) {
-                processedMessageIds.add(messageId);
-                pendingAcknowledgments.incrementAndGet();
-                log.debug("Processed message {}, pending acks: {}", messageId, pendingAcknowledgments.get());
+            if (outstandingMessageIdSet.contains(messageId)) {
+                replyByMessageId.put(messageId, msg);
             } else {
                 log.debug("Ignoring unsolicited or duplicate message body: {}", messageId);
             }
         }
 
+        List<AppMessage> acceptedMessages = new ArrayList<>();
+        while (!outstandingMessageIds.isEmpty()) {
+            AppMessageId outstandingId = outstandingMessageIds.peek();
+            String messageId = HexUtil.encodeHexString(outstandingId.getMessageId());
+            AppMessage msg = replyByMessageId.get(messageId);
+            if (msg == null)
+                break;
+
+            if (removeOutstandingMessageId(messageId)) {
+                processedMessageIds.add(messageId);
+                pendingAcknowledgments.incrementAndGet();
+                acceptedMessages.add(msg);
+                log.debug("Processed message {}, pending acks: {}", messageId, pendingAcknowledgments.get());
+            }
+        }
+
         if (!outstandingMessageIds.isEmpty()) {
-            log.warn("Peer replied with fewer app messages than requested; dropping {} unresolved message ID(s)",
+            log.warn("Peer replied with missing or out-of-order app messages; dropping {} unresolved message ID(s)",
                     outstandingMessageIds.size());
             outstandingMessageIds.clear();
             outstandingMessageIdSet.clear();
         }
 
-        getAgentListeners().forEach(l -> l.handleReplyMessages(reply));
+        MsgReplyMessages acceptedReply = new MsgReplyMessages(acceptedMessages);
+        getAgentListeners().forEach(l -> l.handleReplyMessages(acceptedReply));
 
         log.info("Message reply processed, sending next blocking request");
         sendNextBlockingRequest();
@@ -184,6 +216,7 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
         }
 
         MsgRequestMessageIds request = new MsgRequestMessageIds(blocking, ack, req);
+        requestedMessageIdCount = Math.max(0, req);
         this.pendingRequest = request;
 
         if (hasAgency()) {
@@ -222,6 +255,7 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
         outstandingMessageIds.clear();
         outstandingMessageIdSet.clear();
         processedMessageIds.clear();
+        requestedMessageIdCount = 0;
         pendingAcknowledgments.set(0);
         pendingRequest = null;
         this.currentState = AppMsgSubmissionState.Init;

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgent.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Server-side agent for Protocol 100 (App Message Submission).
  * Pulls messages from connected clients using a blocking request pattern.
- * Maintains FIFO queue, dedup set, and ack/req window tracking.
+ * Maintains FIFO queue, bounded processed-id cache, and ack/req window tracking.
  */
 @Slf4j
 public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener> {
@@ -27,8 +27,9 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
     private static final int DEFAULT_BATCH_SIZE = 10;
 
     private final Queue<AppMessageId> outstandingMessageIds = new ConcurrentLinkedQueue<>();
+    private final Set<String> outstandingMessageIdSet = new HashSet<>();
     private final AtomicInteger pendingAcknowledgments = new AtomicInteger(0);
-    private final Set<String> seenMessageIds = new HashSet<>();
+    private final Set<String> processedMessageIds;
     private volatile Message pendingRequest;
     private final AppMsgSubmissionConfig config;
 
@@ -39,6 +40,7 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
     public AppMsgSubmissionServerAgent(AppMsgSubmissionConfig config) {
         super(false); // Server agent
         this.config = config;
+        this.processedMessageIds = createBoundedMessageIdCache(config.getProcessedMessageIdCacheSize());
         this.currentState = AppMsgSubmissionState.Init;
     }
 
@@ -113,10 +115,13 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
 
         for (AppMessageId mid : reply.getMessageIds()) {
             String idStr = HexUtil.encodeHexString(mid.getMessageId());
-            if (!seenMessageIds.contains(idStr)) {
+            if (!processedMessageIds.contains(idStr) && !outstandingMessageIdSet.contains(idStr)) {
                 outstandingMessageIds.offer(mid);
-                seenMessageIds.add(idStr);
+                outstandingMessageIdSet.add(idStr);
                 log.debug("Added message ID to queue: {} (size: {} bytes)", idStr, mid.getSize());
+            } else {
+                pendingAcknowledgments.incrementAndGet();
+                log.debug("Skipping already processed or in-flight message ID: {}", idStr);
             }
         }
 
@@ -125,9 +130,8 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
         if (!outstandingMessageIds.isEmpty()) {
             requestMessageBodies();
         } else {
-            // All IDs were already seen (deduped) — ack and continue polling
-            log.debug("All {} message IDs already seen, sending next blocking request", reply.getMessageIds().size());
-            pendingAcknowledgments.addAndGet(reply.getMessageIds().size());
+            log.debug("All {} message IDs were already processed or in-flight; sending next blocking request",
+                    reply.getMessageIds().size());
             sendNextBlockingRequest();
         }
     }
@@ -136,19 +140,27 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
         log.info("Received ReplyMessages with {} messages", reply.getMessages().size());
 
         for (AppMessage msg : reply.getMessages()) {
-            AppMessageId processedId = outstandingMessageIds.poll();
-            if (processedId != null) {
+            String messageId = HexUtil.encodeHexString(msg.getMessageId());
+            if (removeOutstandingMessageId(messageId)) {
+                processedMessageIds.add(messageId);
                 pendingAcknowledgments.incrementAndGet();
-                log.debug("Processed message, pending acks: {}", pendingAcknowledgments.get());
+                log.debug("Processed message {}, pending acks: {}", messageId, pendingAcknowledgments.get());
+            } else {
+                log.debug("Ignoring unsolicited or duplicate message body: {}", messageId);
             }
+        }
+
+        if (!outstandingMessageIds.isEmpty()) {
+            log.warn("Peer replied with fewer app messages than requested; dropping {} unresolved message ID(s)",
+                    outstandingMessageIds.size());
+            outstandingMessageIds.clear();
+            outstandingMessageIdSet.clear();
         }
 
         getAgentListeners().forEach(l -> l.handleReplyMessages(reply));
 
-        if (outstandingMessageIds.isEmpty()) {
-            log.info("All messages processed, sending next blocking request");
-            sendNextBlockingRequest();
-        }
+        log.info("Message reply processed, sending next blocking request");
+        sendNextBlockingRequest();
     }
 
     private void sendInitialBlockingRequest() {
@@ -208,7 +220,8 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
     @Override
     public void reset() {
         outstandingMessageIds.clear();
-        seenMessageIds.clear();
+        outstandingMessageIdSet.clear();
+        processedMessageIds.clear();
         pendingAcknowledgments.set(0);
         pendingRequest = null;
         this.currentState = AppMsgSubmissionState.Init;
@@ -221,11 +234,11 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
     }
 
     public int getReceivedMessageIdCount() {
-        return seenMessageIds.size();
+        return processedMessageIds.size();
     }
 
     public boolean hasReceivedMessageId(String hexId) {
-        return seenMessageIds.contains(hexId);
+        return processedMessageIds.contains(hexId);
     }
 
     public int getOutstandingMessageCount() {
@@ -238,5 +251,25 @@ public class AppMsgSubmissionServerAgent extends Agent<AppMsgSubmissionListener>
 
     public AppMsgSubmissionConfig getConfig() {
         return config;
+    }
+
+    private Set<String> createBoundedMessageIdCache(int maxSize) {
+        final int boundedMaxSize = Math.max(1, maxSize);
+        return Collections.synchronizedSet(Collections.newSetFromMap(
+                new LinkedHashMap<String, Boolean>(boundedMaxSize, 0.75f, false) {
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<String, Boolean> eldest) {
+                        return size() > boundedMaxSize;
+                    }
+                }));
+    }
+
+    private boolean removeOutstandingMessageId(String messageId) {
+        if (!outstandingMessageIdSet.remove(messageId))
+            return false;
+
+        outstandingMessageIds.removeIf(mid ->
+                messageId.equals(HexUtil.encodeHexString(mid.getMessageId())));
+        return true;
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionState.java
@@ -1,0 +1,90 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.*;
+
+public enum AppMsgSubmissionState implements AppMsgSubmissionStateBase {
+    Init {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgInit)
+                return Idle;
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
+        }
+    },
+    Idle {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgRequestMessageIds) {
+                return ((MsgRequestMessageIds) message).isBlocking()
+                        ? MessageIdsBlocking : MessageIdsNonBlocking;
+            } else if (message instanceof MsgRequestMessages) {
+                return Messages;
+            } else if (message instanceof MsgDone) {
+                return Done;
+            }
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
+        }
+    },
+    MessageIdsBlocking {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgReplyMessageIds)
+                return Idle;
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
+        }
+    },
+    MessageIdsNonBlocking {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgReplyMessageIds)
+                return Idle;
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
+        }
+    },
+    Messages {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgReplyMessages)
+                return Idle;
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
+        }
+    },
+    Done {
+        @Override
+        public State nextState(Message message) {
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionStateBase.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionStateBase.java
@@ -1,0 +1,45 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers.*;
+
+public interface AppMsgSubmissionStateBase extends State {
+    Logger log = LoggerFactory.getLogger(AppMsgSubmissionStateBase.class);
+
+    default Message handleInbound(byte[] bytes) {
+        try {
+            DataItem di = CborSerializationUtil.deserializeOne(bytes);
+            Array array = (Array) di;
+            int id = ((UnsignedInteger) array.getDataItems().get(0)).getValue().intValue();
+            switch (id) {
+                case 0:
+                    return MsgInitSerializer.INSTANCE.deserialize(bytes);
+                case 1:
+                    return MsgRequestMessageIdsSerializer.INSTANCE.deserialize(bytes);
+                case 2:
+                    return MsgReplyMessageIdsSerializer.INSTANCE.deserialize(bytes);
+                case 3:
+                    return MsgRequestMessagesSerializer.INSTANCE.deserialize(bytes);
+                case 4:
+                    return MsgReplyMessagesSerializer.INSTANCE.deserialize(bytes);
+                case 5:
+                    return MsgDoneSerializer.INSTANCE.deserialize(bytes);
+                default:
+                    throw new RuntimeException(String.format("Invalid app msg submission msg id: %d", id));
+            }
+        } catch (Exception e) {
+            log.error("AppMsgSubmission parsing error", e);
+            log.error("Data: {}", HexUtil.encodeHexString(bytes));
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgDone.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgDone.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers;
+
+public class MsgDone implements Message {
+
+    @Override
+    public byte[] serialize() {
+        return AppMsgSubmissionSerializers.MsgDoneSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgInit.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgInit.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers;
+
+public class MsgInit implements Message {
+
+    @Override
+    public byte[] serialize() {
+        return AppMsgSubmissionSerializers.MsgInitSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgReplyMessageIds.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgReplyMessageIds.java
@@ -1,0 +1,35 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessageId;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class MsgReplyMessageIds implements Message {
+    private final List<AppMessageId> messageIds;
+
+    public MsgReplyMessageIds() {
+        this.messageIds = new ArrayList<>();
+    }
+
+    public MsgReplyMessageIds(List<AppMessageId> messageIds) {
+        this.messageIds = messageIds != null ? messageIds : new ArrayList<>();
+    }
+
+    public void addMessageId(byte[] messageId, int size) {
+        messageIds.add(new AppMessageId(messageId, size));
+    }
+
+    public void addMessageId(AppMessageId appMessageId) {
+        messageIds.add(appMessageId);
+    }
+
+    @Override
+    public byte[] serialize() {
+        return AppMsgSubmissionSerializers.MsgReplyMessageIdsSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgReplyMessages.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgReplyMessages.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class MsgReplyMessages implements Message {
+    private final List<AppMessage> messages;
+
+    public MsgReplyMessages() {
+        this.messages = new ArrayList<>();
+    }
+
+    public MsgReplyMessages(List<AppMessage> messages) {
+        this.messages = messages != null ? messages : new ArrayList<>();
+    }
+
+    public void addMessage(AppMessage appMessage) {
+        messages.add(appMessage);
+    }
+
+    @Override
+    public byte[] serialize() {
+        return AppMsgSubmissionSerializers.MsgReplyMessagesSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgRequestMessageIds.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgRequestMessageIds.java
@@ -1,0 +1,23 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MsgRequestMessageIds implements Message {
+    private boolean blocking;
+    private short ackCount;
+    private short reqCount;
+
+    @Override
+    public byte[] serialize() {
+        return AppMsgSubmissionSerializers.MsgRequestMessageIdsSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgRequestMessages.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/messages/MsgRequestMessages.java
@@ -1,0 +1,30 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class MsgRequestMessages implements Message {
+    private final List<byte[]> messageIds;
+
+    public MsgRequestMessages() {
+        this.messageIds = new ArrayList<>();
+    }
+
+    public MsgRequestMessages(List<byte[]> messageIds) {
+        this.messageIds = messageIds != null ? messageIds : new ArrayList<>();
+    }
+
+    public void addMessageId(byte[] messageId) {
+        messageIds.add(messageId);
+    }
+
+    @Override
+    public byte[] serialize() {
+        return AppMsgSubmissionSerializers.MsgRequestMessagesSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/serializers/AppMsgSubmissionSerializers.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/serializers/AppMsgSubmissionSerializers.java
@@ -1,0 +1,242 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers;
+
+import co.nstant.in.cbor.model.*;
+import com.bloxbean.cardano.client.exception.CborRuntimeException;
+import com.bloxbean.cardano.yaci.core.protocol.Serializer;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessageId;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.*;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class AppMsgSubmissionSerializers {
+
+    // Tag 0: MsgInit
+    public enum MsgInitSerializer implements Serializer<MsgInit> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgInit object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(0));
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgInit deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            int label = ((UnsignedInteger) array.getDataItems().get(0)).getValue().intValue();
+            if (label == 0)
+                return new MsgInit();
+            throw new CborRuntimeException("Invalid MsgInit label: " + label);
+        }
+    }
+
+    // Tag 1: MsgRequestMessageIds [1, isBlocking, ack, req]
+    public enum MsgRequestMessageIdsSerializer implements Serializer<MsgRequestMessageIds> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgRequestMessageIds msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(1));
+            array.add(msg.isBlocking() ? SimpleValue.TRUE : SimpleValue.FALSE);
+            array.add(new UnsignedInteger(msg.getAckCount()));
+            array.add(new UnsignedInteger(msg.getReqCount()));
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgRequestMessageIds deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            List<DataItem> items = array.getDataItems();
+            int label = ((UnsignedInteger) items.get(0)).getValue().intValue();
+            if (label != 1)
+                throw new CborRuntimeException("Invalid MsgRequestMessageIds label: " + label);
+            boolean blocking = items.get(1) == SimpleValue.TRUE;
+            short ack = ((UnsignedInteger) items.get(2)).getValue().shortValue();
+            short req = ((UnsignedInteger) items.get(3)).getValue().shortValue();
+            return new MsgRequestMessageIds(blocking, ack, req);
+        }
+    }
+
+    // Tag 2: MsgReplyMessageIds [2, [[messageId, size], ...]]
+    public enum MsgReplyMessageIdsSerializer implements Serializer<MsgReplyMessageIds> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgReplyMessageIds msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(2));
+
+            Array pairs = new Array();
+            pairs.setChunked(true);
+            if (msg.getMessageIds() != null) {
+                for (AppMessageId mid : msg.getMessageIds()) {
+                    Array pair = new Array();
+                    pair.add(new ByteString(mid.getMessageId()));
+                    pair.add(new UnsignedInteger(mid.getSize()));
+                    pairs.add(pair);
+                }
+            }
+            pairs.add(SimpleValue.BREAK);
+            array.add(pairs);
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgReplyMessageIds deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            List<DataItem> items = array.getDataItems();
+            int label = ((UnsignedInteger) items.get(0)).getValue().intValue();
+            if (label != 2)
+                throw new CborRuntimeException("Invalid MsgReplyMessageIds label: " + label);
+
+            Array pairsArray = (Array) items.get(1);
+            List<AppMessageId> messageIds = new ArrayList<>();
+            for (DataItem pairDI : pairsArray.getDataItems()) {
+                if (pairDI instanceof Special) break;
+                Array pair = (Array) pairDI;
+                byte[] msgId = ((ByteString) pair.getDataItems().get(0)).getBytes();
+                int size = ((UnsignedInteger) pair.getDataItems().get(1)).getValue().intValue();
+                messageIds.add(new AppMessageId(msgId, size));
+            }
+            return new MsgReplyMessageIds(messageIds);
+        }
+    }
+
+    // Tag 3: MsgRequestMessages [3, [messageId, ...]]
+    public enum MsgRequestMessagesSerializer implements Serializer<MsgRequestMessages> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgRequestMessages msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(3));
+
+            Array idsArray = new Array();
+            idsArray.setChunked(true);
+            if (msg.getMessageIds() != null) {
+                for (byte[] id : msg.getMessageIds()) {
+                    idsArray.add(new ByteString(id));
+                }
+            }
+            idsArray.add(Special.BREAK);
+            array.add(idsArray);
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgRequestMessages deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            List<DataItem> items = array.getDataItems();
+            int label = ((UnsignedInteger) items.get(0)).getValue().intValue();
+            if (label != 3)
+                throw new CborRuntimeException("Invalid MsgRequestMessages label: " + label);
+
+            Array idsArray = (Array) items.get(1);
+            List<byte[]> messageIds = new ArrayList<>();
+            for (DataItem idDI : idsArray.getDataItems()) {
+                if (idDI instanceof Special) break;
+                messageIds.add(((ByteString) idDI).getBytes());
+            }
+            return new MsgRequestMessages(messageIds);
+        }
+    }
+
+    // Tag 4: MsgReplyMessages [4, [appMessage, ...]]
+    public enum MsgReplyMessagesSerializer implements Serializer<MsgReplyMessages> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgReplyMessages msg) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(4));
+
+            Array msgsArray = new Array();
+            msgsArray.setChunked(true);
+            if (msg.getMessages() != null) {
+                for (AppMessage appMsg : msg.getMessages()) {
+                    msgsArray.add(serializeAppMessage(appMsg));
+                }
+            }
+            msgsArray.add(SimpleValue.BREAK);
+            array.add(msgsArray);
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgReplyMessages deserializeDI(DataItem di) {
+            Array array = (Array) di;
+            List<DataItem> items = array.getDataItems();
+            int label = ((UnsignedInteger) items.get(0)).getValue().intValue();
+            if (label != 4)
+                throw new CborRuntimeException("Invalid MsgReplyMessages label: " + label);
+
+            Array msgsArray = (Array) items.get(1);
+            List<AppMessage> messages = new ArrayList<>();
+            for (DataItem msgDI : msgsArray.getDataItems()) {
+                if (msgDI instanceof Special) break;
+                messages.add(deserializeAppMessage((Array) msgDI));
+            }
+            return new MsgReplyMessages(messages);
+        }
+    }
+
+    // Tag 5: MsgDone [5]
+    public enum MsgDoneSerializer implements Serializer<MsgDone> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgDone object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(5));
+            return CborSerializationUtil.serialize(array);
+        }
+
+        @Override
+        public MsgDone deserialize(byte[] bytes) {
+            DataItem di = CborSerializationUtil.deserializeOne(bytes);
+            int key = ((UnsignedInteger) ((Array) di).getDataItems().get(0)).getValue().intValue();
+            if (key == 5)
+                return new MsgDone();
+            throw new CborRuntimeException("Invalid MsgDone label: " + key);
+        }
+    }
+
+    // AppMessage CBOR:
+    // [messageId(bstr), messageBody(bstr), authMethod(uint), authProof(bstr), topicId(tstr), expiresAt(uint)]
+    public static Array serializeAppMessage(AppMessage msg) {
+        Array arr = new Array();
+        arr.add(new ByteString(msg.getMessageId()));
+        arr.add(new ByteString(msg.getMessageBody()));
+        arr.add(new UnsignedInteger(msg.getAuthMethod()));
+        arr.add(new ByteString(msg.getAuthProof() != null ? msg.getAuthProof() : new byte[0]));
+        arr.add(new UnicodeString(msg.getTopicId() != null ? msg.getTopicId() : ""));
+        arr.add(new UnsignedInteger(msg.getExpiresAt()));
+        return arr;
+    }
+
+    public static AppMessage deserializeAppMessage(Array arr) {
+        List<DataItem> items = arr.getDataItems();
+        byte[] messageId = ((ByteString) items.get(0)).getBytes();
+        byte[] messageBody = ((ByteString) items.get(1)).getBytes();
+        int authMethod = ((UnsignedInteger) items.get(2)).getValue().intValue();
+        byte[] authProof = ((ByteString) items.get(3)).getBytes();
+        String topicId = ((UnicodeString) items.get(4)).getString();
+        long expiresAt = ((UnsignedInteger) items.get(5)).getValue().longValue();
+
+        return AppMessage.builder()
+                .messageId(messageId)
+                .messageBody(messageBody)
+                .authMethod(authMethod)
+                .authProof(authProof)
+                .topicId(topicId)
+                .expiresAt(expiresAt)
+                .build();
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/util/N2NVersionTableConstant.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/util/N2NVersionTableConstant.java
@@ -32,6 +32,33 @@ public class N2NVersionTableConstant {
         return versionNumber >= PROTOCOL_V100;
     }
 
+    public static boolean hasAppLayerVersion(VersionTable versionTable) {
+        return versionTable != null && versionTable.getVersionDataMap().keySet().stream()
+                .anyMatch(N2NVersionTableConstant::isAppLayerVersion);
+    }
+
+    public static VersionTable withAppLayer(VersionTable versionTable) {
+        if (versionTable == null)
+            throw new IllegalArgumentException("Version table is required");
+
+        Map<Long, VersionData> versionTableMap = new HashMap<>(versionTable.getVersionDataMap());
+        if (versionTableMap.keySet().stream().anyMatch(N2NVersionTableConstant::isAppLayerVersion))
+            return new VersionTable(versionTableMap);
+
+        VersionData appVersionData = versionTableMap.get(PROTOCOL_V15);
+        if (appVersionData == null) {
+            appVersionData = versionTableMap.entrySet().stream()
+                    .filter(entry -> entry.getKey() < PROTOCOL_V100)
+                    .max(Map.Entry.comparingByKey())
+                    .map(Map.Entry::getValue)
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "No node-to-node version data available for app-layer V100"));
+        }
+
+        versionTableMap.put(PROTOCOL_V100, appVersionData);
+        return new VersionTable(versionTableMap);
+    }
+
     public static VersionTable v4AndAbove(long networkMagic) {
         N2NVersionData versionData = new N2NVersionData(networkMagic, true);
 

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/util/N2NVersionTableConstant.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/util/N2NVersionTableConstant.java
@@ -20,6 +20,17 @@ public class N2NVersionTableConstant {
     public final static long PROTOCOL_V13 = 13;
     public final static long PROTOCOL_V14 = 14;
     public final static long PROTOCOL_V15 = 15; //srv support
+    public final static long PROTOCOL_V100 = 100;
+
+    /**
+     * Check if the negotiated version supports app-layer protocols (Protocol 100+).
+     *
+     * @param versionNumber the negotiated version from handshake
+     * @return true if the version supports app-layer protocols
+     */
+    public static boolean isAppLayerVersion(long versionNumber) {
+        return versionNumber >= PROTOCOL_V100;
+    }
 
     public static VersionTable v4AndAbove(long networkMagic) {
         N2NVersionData versionData = new N2NVersionData(networkMagic, true);
@@ -45,7 +56,8 @@ public class N2NVersionTableConstant {
         return v11AndAbove(networkMagic, true, 0, false);
     }
 
-    public static VersionTable v11AndAbove(long networkMagic, boolean initiatorOnlyDiffusionMode, int peerSharing, boolean query) {
+    public static VersionTable v11AndAbove(long networkMagic, boolean initiatorOnlyDiffusionMode,
+                                           int peerSharing, boolean query) {
         N2NVersionData versionData = new N2NVersionData(networkMagic, initiatorOnlyDiffusionMode, peerSharing, query);
 
         Map<Long, VersionData> versionTableMap = new HashMap<>();
@@ -54,6 +66,30 @@ public class N2NVersionTableConstant {
         versionTableMap.put(PROTOCOL_V13, versionData);
         versionTableMap.put(PROTOCOL_V14, versionData);
         versionTableMap.put(PROTOCOL_V15, versionData);
+
+        return new VersionTable(versionTableMap);
+    }
+
+    /**
+     * Version table for Yaci nodes that support app-layer protocols.
+     * Includes V100 for app-layer capability signaling. When connecting to Cardano nodes,
+     * V100 is ignored and the highest mutually supported Cardano node-to-node version is negotiated.
+     */
+    public static VersionTable v11AndAboveWithAppLayer(long networkMagic) {
+        return v11AndAboveWithAppLayer(networkMagic, true, 0, false);
+    }
+
+    public static VersionTable v11AndAboveWithAppLayer(long networkMagic, boolean initiatorOnlyDiffusionMode,
+                                                       int peerSharing, boolean query) {
+        N2NVersionData versionData = new N2NVersionData(networkMagic, initiatorOnlyDiffusionMode, peerSharing, query);
+
+        Map<Long, VersionData> versionTableMap = new HashMap<>();
+        versionTableMap.put(PROTOCOL_V11, versionData);
+        versionTableMap.put(PROTOCOL_V12, versionData);
+        versionTableMap.put(PROTOCOL_V13, versionData);
+        versionTableMap.put(PROTOCOL_V14, versionData);
+        versionTableMap.put(PROTOCOL_V15, versionData);
+        versionTableMap.put(PROTOCOL_V100, versionData);
 
         return new VersionTable(versionTableMap);
     }

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/notify/LocalAppMsgNotifyTest.java
@@ -1,0 +1,137 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify;
+
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.messages.*;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.notify.serializers.LocalAppMsgNotifySerializers;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalAppMsgNotifyTest {
+
+    // --- Serializer roundtrip tests ---
+
+    @Test
+    void msgRequestMessages_blocking_roundtrip() {
+        MsgRequestMessages msg = new MsgRequestMessages(true);
+        byte[] bytes = msg.serialize();
+        MsgRequestMessages deserialized =
+                LocalAppMsgNotifySerializers.MsgRequestMessagesSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.isBlocking()).isTrue();
+    }
+
+    @Test
+    void msgRequestMessages_nonBlocking_roundtrip() {
+        MsgRequestMessages msg = new MsgRequestMessages(false);
+        byte[] bytes = msg.serialize();
+        MsgRequestMessages deserialized =
+                LocalAppMsgNotifySerializers.MsgRequestMessagesSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.isBlocking()).isFalse();
+    }
+
+    @Test
+    void msgReplyMessagesNonBlocking_roundtrip() {
+        var msg = new MsgReplyMessagesNonBlocking(List.of(testMessage()), true);
+        byte[] bytes = msg.serialize();
+        var deserialized =
+                LocalAppMsgNotifySerializers.MsgReplyMessagesNonBlockingSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.getMessages()).hasSize(1);
+        assertThat(deserialized.isHasMore()).isTrue();
+        assertThat(deserialized.getMessages().get(0).getTopicId()).isEqualTo("notify-topic");
+    }
+
+    @Test
+    void msgReplyMessagesBlocking_roundtrip() {
+        var msg = new MsgReplyMessagesBlocking(List.of(testMessage()));
+        byte[] bytes = msg.serialize();
+        var deserialized = LocalAppMsgNotifySerializers.MsgReplyMessagesBlockingSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.getMessages()).hasSize(1);
+    }
+
+    @Test
+    void msgClientDone_roundtrip() {
+        MsgClientDone msg = new MsgClientDone();
+        byte[] bytes = msg.serialize();
+        MsgClientDone deserialized = LocalAppMsgNotifySerializers.MsgClientDoneSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized).isNotNull();
+    }
+
+    @Test
+    void stateBase_handlesAllMessageTypes() {
+        LocalAppMsgNotifyStateBase stateBase = LocalAppMsgNotifyState.Idle;
+
+        assertThat(stateBase.handleInbound(new MsgRequestMessages(true).serialize()))
+                .isInstanceOf(MsgRequestMessages.class);
+        assertThat(stateBase.handleInbound(new MsgReplyMessagesNonBlocking(List.of(), false).serialize()))
+                .isInstanceOf(MsgReplyMessagesNonBlocking.class);
+        assertThat(stateBase.handleInbound(new MsgReplyMessagesBlocking(List.of()).serialize()))
+                .isInstanceOf(MsgReplyMessagesBlocking.class);
+        assertThat(stateBase.handleInbound(new MsgClientDone().serialize()))
+                .isInstanceOf(MsgClientDone.class);
+    }
+
+    // --- Agent state machine tests ---
+
+    @Test
+    void agent_initialState() {
+        LocalAppMsgNotifyAgent agent = new LocalAppMsgNotifyAgent();
+        assertThat(agent.getCurrentState()).isEqualTo(LocalAppMsgNotifyState.Idle);
+        assertThat(agent.getProtocolId()).isEqualTo(102);
+        assertThat(agent.hasAgency()).isTrue();
+    }
+
+    @Test
+    void agent_blockingFlow() {
+        LocalAppMsgNotifyAgent agent = new LocalAppMsgNotifyAgent(true);
+
+        // Client requests (blocking)
+        var request = agent.buildNextMessage();
+        assertThat(request).isInstanceOf(MsgRequestMessages.class);
+        assertThat(((MsgRequestMessages) request).isBlocking()).isTrue();
+
+        agent.sendRequest(request);
+        assertThat(agent.getCurrentState()).isEqualTo(LocalAppMsgNotifyState.BusyBlocking);
+        assertThat(agent.hasAgency()).isFalse();
+
+        // Server replies
+        AtomicReference<List<AppMessage>> received = new AtomicReference<>();
+        agent.addListener(new LocalAppMsgNotifyListener() {
+            @Override
+            public void onMessagesReceived(List<AppMessage> messages, boolean hasMore) {
+                received.set(messages);
+            }
+        });
+
+        agent.receiveResponse(new MsgReplyMessagesBlocking(List.of(testMessage())));
+        assertThat(agent.getCurrentState()).isEqualTo(LocalAppMsgNotifyState.Idle);
+        assertThat(received.get()).hasSize(1);
+    }
+
+    @Test
+    void agent_nonBlockingFlow() {
+        LocalAppMsgNotifyAgent agent = new LocalAppMsgNotifyAgent(false);
+
+        var request = agent.buildNextMessage();
+        assertThat(((MsgRequestMessages) request).isBlocking()).isFalse();
+
+        agent.sendRequest(request);
+        assertThat(agent.getCurrentState()).isEqualTo(LocalAppMsgNotifyState.BusyNonBlocking);
+
+        agent.receiveResponse(new MsgReplyMessagesNonBlocking(List.of(), true));
+        assertThat(agent.getCurrentState()).isEqualTo(LocalAppMsgNotifyState.Idle);
+    }
+
+    private AppMessage testMessage() {
+        return AppMessage.builder()
+                .messageId(new byte[]{7, 8, 9})
+                .messageBody(new byte[]{10})
+                .authMethod(0)
+                .authProof(new byte[0])
+                .topicId("notify-topic")
+                .expiresAt(0)
+                .build();
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2c/submit/LocalAppMsgSubmitTest.java
@@ -1,0 +1,116 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit;
+
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.messages.*;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2c.submit.serializers.LocalAppMsgSubmitSerializers;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalAppMsgSubmitTest {
+
+    // --- Serializer roundtrip tests ---
+
+    @Test
+    void msgSubmitMessage_roundtrip() {
+        AppMessage appMsg = testMessage();
+        MsgSubmitMessage msg = new MsgSubmitMessage(appMsg);
+        byte[] bytes = msg.serialize();
+
+        MsgSubmitMessage deserialized =
+                LocalAppMsgSubmitSerializers.MsgSubmitMessageSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.getAppMessage().getMessageId()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(deserialized.getAppMessage().getTopicId()).isEqualTo("test");
+    }
+
+    @Test
+    void msgAcceptMessage_roundtrip() {
+        MsgAcceptMessage msg = new MsgAcceptMessage();
+        byte[] bytes = msg.serialize();
+        MsgAcceptMessage deserialized =
+                LocalAppMsgSubmitSerializers.MsgAcceptMessageSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized).isNotNull();
+    }
+
+    @Test
+    void msgRejectMessage_roundtrip() {
+        MsgRejectMessage msg = new MsgRejectMessage(RejectReason.EXPIRED, "TTL exceeded");
+        byte[] bytes = msg.serialize();
+        MsgRejectMessage deserialized =
+                LocalAppMsgSubmitSerializers.MsgRejectMessageSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.getReason()).isEqualTo(RejectReason.EXPIRED);
+        assertThat(deserialized.getDetail()).isEqualTo("TTL exceeded");
+    }
+
+    @Test
+    void msgDone_roundtrip() {
+        MsgDone msg = new MsgDone();
+        byte[] bytes = msg.serialize();
+        MsgDone deserialized = LocalAppMsgSubmitSerializers.MsgDoneSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized).isNotNull();
+    }
+
+    @Test
+    void stateBase_handlesAllMessageTypes() {
+        LocalAppMsgSubmitStateBase stateBase = LocalAppMsgSubmitState.Idle;
+
+        assertThat(stateBase.handleInbound(new MsgSubmitMessage(testMessage()).serialize()))
+                .isInstanceOf(MsgSubmitMessage.class);
+        assertThat(stateBase.handleInbound(new MsgAcceptMessage().serialize()))
+                .isInstanceOf(MsgAcceptMessage.class);
+        assertThat(stateBase.handleInbound(new MsgRejectMessage(RejectReason.INVALID, "bad").serialize()))
+                .isInstanceOf(MsgRejectMessage.class);
+        assertThat(stateBase.handleInbound(new MsgDone().serialize()))
+                .isInstanceOf(MsgDone.class);
+    }
+
+    // --- Agent state machine tests ---
+
+    @Test
+    void agent_initialState() {
+        LocalAppMsgSubmitAgent agent = new LocalAppMsgSubmitAgent();
+        assertThat(agent.getCurrentState()).isEqualTo(LocalAppMsgSubmitState.Idle);
+        assertThat(agent.getProtocolId()).isEqualTo(101);
+        assertThat(agent.hasAgency()).isTrue(); // Client has agency in Idle
+    }
+
+    @Test
+    void agent_submitFlow() {
+        LocalAppMsgSubmitAgent agent = new LocalAppMsgSubmitAgent();
+        agent.submitMessage(testMessage());
+
+        // Build submit message
+        var msg = agent.buildNextMessage();
+        assertThat(msg).isInstanceOf(MsgSubmitMessage.class);
+
+        // Transition to Busy
+        agent.sendRequest(msg);
+        assertThat(agent.getCurrentState()).isEqualTo(LocalAppMsgSubmitState.Busy);
+        assertThat(agent.hasAgency()).isFalse();
+
+        // Server accepts
+        agent.receiveResponse(new MsgAcceptMessage());
+        assertThat(agent.getCurrentState()).isEqualTo(LocalAppMsgSubmitState.Idle);
+    }
+
+    @Test
+    void agent_rejectFlow() {
+        LocalAppMsgSubmitAgent agent = new LocalAppMsgSubmitAgent();
+        agent.submitMessage(testMessage());
+
+        agent.sendRequest(agent.buildNextMessage());
+        agent.receiveResponse(new MsgRejectMessage(RejectReason.ALREADY_RECEIVED));
+        assertThat(agent.getCurrentState()).isEqualTo(LocalAppMsgSubmitState.Idle);
+    }
+
+    private AppMessage testMessage() {
+        return AppMessage.builder()
+                .messageId(new byte[]{1, 2, 3})
+                .messageBody(new byte[]{10, 20})
+                .authMethod(0)
+                .authProof(new byte[0])
+                .topicId("test")
+                .expiresAt(0)
+                .build();
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgGossipIntegrationTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgGossipIntegrationTest.java
@@ -1,0 +1,206 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import com.bloxbean.cardano.yaci.core.network.TCPNodeClient;
+import com.bloxbean.cardano.yaci.core.network.server.AgentFactory;
+import com.bloxbean.cardano.yaci.core.network.server.NodeServer;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.MsgRequestMessageIds;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.MsgRequestMessages;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.MsgReplyMessageIds;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.MsgReplyMessages;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgent;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.Reason;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
+import com.bloxbean.cardano.yaci.core.storage.ChainState;
+import com.bloxbean.cardano.yaci.core.storage.ChainTip;
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test: starts a real server with AppMsgSubmissionServerAgent,
+ * connects a client with AppMsgSubmissionAgent carrying messages,
+ * and verifies the pull-based gossip protocol transfers messages end-to-end.
+ */
+@Slf4j
+class AppMsgGossipIntegrationTest {
+
+    private static final int TEST_PORT = 23457;
+    private static final long TEST_MAGIC = 42;
+
+    @Test
+    @Timeout(30)
+    void testClientToServerMessageGossip() throws Exception {
+        // --- Server-side: NodeServer with app-layer agent factory ---
+        List<AppMessage> serverReceivedMessages = new CopyOnWriteArrayList<>();
+        CountDownLatch messagesReceivedLatch = new CountDownLatch(2); // expect 2 messages
+
+        AppMsgSubmissionConfig serverConfig = AppMsgSubmissionConfig.builder()
+                .batchSize(10)
+                .useBlockingMode(true)
+                .build();
+
+        AgentFactory appMsgFactory = () -> {
+            AppMsgSubmissionServerAgent serverAgent = new AppMsgSubmissionServerAgent(serverConfig);
+            serverAgent.addListener(new AppMsgSubmissionListener() {
+                @Override
+                public void handleReplyMessageIds(MsgReplyMessageIds reply) {
+                    log.info("Server received {} message IDs", reply.getMessageIds().size());
+                }
+
+                @Override
+                public void handleReplyMessages(MsgReplyMessages reply) {
+                    log.info("Server received {} messages", reply.getMessages().size());
+                    for (AppMessage msg : reply.getMessages()) {
+                        serverReceivedMessages.add(msg);
+                        messagesReceivedLatch.countDown();
+                        log.info("Server received message: id={}, topic={}, body-size={}",
+                                msg.getMessageIdHex(), msg.getTopicId(), msg.getMessageBody().length);
+                    }
+                }
+            });
+            return serverAgent;
+        };
+
+        NodeServer server = new NodeServer(TEST_PORT,
+                N2NVersionTableConstant.v11AndAboveWithAppLayer(TEST_MAGIC, false, 0, false),
+                new MinimalChainState(),
+                null, null,
+                List.of(appMsgFactory));
+
+        Thread serverThread = new Thread(server::start);
+        serverThread.setDaemon(true);
+        serverThread.start();
+        Thread.sleep(1500); // Wait for server to start
+
+        try {
+            // --- Client-side: connect with AppMsgSubmissionAgent containing messages ---
+            AppMsgSubmissionAgent clientAgent = new AppMsgSubmissionAgent();
+
+            // Wire up the client listener to drive the protocol forward
+            // (same pattern as N2NPeerFetcher does for TxSubmissionAgent)
+            clientAgent.addListener(new AppMsgSubmissionListener() {
+                @Override
+                public void handleRequestMessageIds(MsgRequestMessageIds request) {
+                    clientAgent.sendNextMessage();
+                }
+
+                @Override
+                public void handleRequestMessages(MsgRequestMessages request) {
+                    clientAgent.sendNextMessage();
+                }
+
+                @Override
+                public void handleReplyMessageIds(MsgReplyMessageIds reply) {}
+
+                @Override
+                public void handleReplyMessages(MsgReplyMessages reply) {}
+            });
+
+            // Enqueue messages before connecting
+            AppMessage msg1 = AppMessage.builder()
+                    .messageId(new byte[]{0x01, 0x02, 0x03, 0x04})
+                    .messageBody("Hello from client - message 1".getBytes())
+                    .authMethod(0)
+                    .authProof(new byte[0])
+                    .topicId("test-topic")
+                    .expiresAt(0)
+                    .build();
+            AppMessage msg2 = AppMessage.builder()
+                    .messageId(new byte[]{0x05, 0x06, 0x07, 0x08})
+                    .messageBody("Hello from client - message 2".getBytes())
+                    .authMethod(0)
+                    .authProof(new byte[0])
+                    .topicId("test-topic")
+                    .expiresAt(0)
+                    .build();
+            HandshakeAgent handshakeAgent = new HandshakeAgent(
+                    N2NVersionTableConstant.v11AndAboveWithAppLayer(TEST_MAGIC, false, 0, false), true);
+
+            AtomicBoolean handshakeOk = new AtomicBoolean(false);
+            CountDownLatch handshakeLatch = new CountDownLatch(1);
+
+            handshakeAgent.addListener(new HandshakeAgentListener() {
+                @Override
+                public void handshakeOk() {
+                    log.info("Client handshake OK - enqueuing messages and sending MsgInit");
+                    handshakeOk.set(true);
+                    // Enqueue messages AFTER handshake (reset() clears pending queue during connect)
+                    clientAgent.enqueueMessage(msg1);
+                    clientAgent.enqueueMessage(msg2);
+                    handshakeLatch.countDown();
+                    // Start app-message protocol after handshake
+                    clientAgent.sendNextMessage();
+                }
+
+                @Override
+                public void handshakeError(Reason reason) {
+                    log.error("Client handshake failed: {}", reason);
+                    handshakeLatch.countDown();
+                }
+            });
+
+            TCPNodeClient client = new TCPNodeClient("localhost", TEST_PORT,
+                    handshakeAgent, clientAgent);
+            client.start();
+
+            // Wait for handshake
+            assertThat(handshakeLatch.await(10, TimeUnit.SECONDS)).isTrue();
+            assertThat(handshakeOk.get()).isTrue();
+
+            // Wait for messages to be pulled by server
+            boolean received = messagesReceivedLatch.await(15, TimeUnit.SECONDS);
+
+            client.shutdown();
+
+            // Verify
+            assertThat(received).as("Server should have received 2 messages").isTrue();
+            assertThat(serverReceivedMessages).hasSize(2);
+            assertThat(serverReceivedMessages.get(0).getTopicId()).isEqualTo("test-topic");
+            assertThat(new String(serverReceivedMessages.get(0).getMessageBody()))
+                    .isEqualTo("Hello from client - message 1");
+            assertThat(new String(serverReceivedMessages.get(1).getMessageBody()))
+                    .isEqualTo("Hello from client - message 2");
+
+            log.info("App message gossip integration test passed!");
+
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    /**
+     * Minimal ChainState for a server that only handles app-layer messaging.
+     */
+    private static class MinimalChainState implements ChainState {
+        @Override public void storeBlock(byte[] blockHash, Long blockNumber, Long slot, byte[] block) {}
+        @Override public byte[] getBlock(byte[] blockHash) { return null; }
+        @Override public boolean hasBlock(byte[] blockHash) { return false; }
+        @Override public void storeBlockHeader(byte[] blockHash, Long blockNumber, Long slot, byte[] blockHeader) {}
+        @Override public byte[] getBlockHeader(byte[] blockHash) { return null; }
+        @Override public byte[] getBlockByNumber(Long blockNumber) { return null; }
+        @Override public byte[] getBlockHeaderByNumber(Long blockNumber) { return null; }
+        @Override public Point findNextBlock(Point currentPoint) { return null; }
+        @Override public Point findNextBlockHeader(Point currentPoint) { return null; }
+        @Override public List<Point> findBlocksInRange(Point from, Point to) { return Collections.emptyList(); }
+        @Override public Point findLastPointAfterNBlocks(Point from, long batchSize) { return null; }
+        @Override public boolean hasPoint(Point point) { return false; }
+        @Override public Point getFirstBlock() { return null; }
+        @Override public Long getBlockNumberBySlot(Long slot) { return null; }
+        @Override public Long getSlotByBlockNumber(Long blockNumber) { return null; }
+        @Override public void rollbackTo(Long slot) {}
+        @Override public ChainTip getTip() { return null; }
+        @Override public ChainTip getHeaderTip() { return null; }
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionAgentTest.java
@@ -1,0 +1,152 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppMsgSubmissionAgentTest {
+
+    private AppMsgSubmissionAgent agent;
+
+    @BeforeEach
+    void setUp() {
+        agent = new AppMsgSubmissionAgent(100);
+    }
+
+    @Test
+    void testInitialState() {
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Init);
+        assertThat(agent.getProtocolId()).isEqualTo(100);
+        assertThat(agent.isDone()).isFalse();
+        assertThat(agent.getQueueSize()).isEqualTo(0);
+    }
+
+    @Test
+    void testClientHasAgencyInInit() {
+        assertThat(agent.hasAgency()).isTrue();
+
+        // buildNextMessage should return MsgInit
+        var msg = agent.buildNextMessage();
+        assertThat(msg).isInstanceOf(MsgInit.class);
+    }
+
+    @Test
+    void testInitTransitionsToIdle() {
+        // Client sends MsgInit
+        agent.sendRequest(new MsgInit());
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Idle);
+        // In Idle, server has agency
+        assertThat(agent.hasAgency()).isFalse();
+    }
+
+    @Test
+    void testEnqueueMessage() {
+        AppMessage msg = createTestMessage(new byte[]{1, 2, 3}, "test-topic");
+        assertThat(agent.enqueueMessage(msg)).isTrue();
+        assertThat(agent.getQueueSize()).isEqualTo(1);
+    }
+
+    @Test
+    void testEnqueueDuplicateRejected() {
+        AppMessage msg1 = createTestMessage(new byte[]{1, 2, 3}, "test");
+        AppMessage msg2 = createTestMessage(new byte[]{1, 2, 3}, "test"); // same ID
+        assertThat(agent.enqueueMessage(msg1)).isTrue();
+        assertThat(agent.enqueueMessage(msg2)).isFalse();
+        assertThat(agent.getQueueSize()).isEqualTo(1);
+    }
+
+    @Test
+    void testEnqueueOverflowRejected() {
+        AppMsgSubmissionAgent smallAgent = new AppMsgSubmissionAgent(2);
+        assertThat(smallAgent.enqueueMessage(createTestMessage(new byte[]{1}, "t"))).isTrue();
+        assertThat(smallAgent.enqueueMessage(createTestMessage(new byte[]{2}, "t"))).isTrue();
+        assertThat(smallAgent.enqueueMessage(createTestMessage(new byte[]{3}, "t"))).isFalse();
+        assertThat(smallAgent.getQueueSize()).isEqualTo(2);
+    }
+
+    @Test
+    void testRequestMessageIdsFlow() {
+        // Enqueue messages
+        agent.enqueueMessage(createTestMessage(new byte[]{1}, "t"));
+        agent.enqueueMessage(createTestMessage(new byte[]{2}, "t"));
+
+        // Move to Idle
+        agent.sendRequest(new MsgInit());
+
+        // Server requests message IDs
+        MsgRequestMessageIds request = new MsgRequestMessageIds(true, (short) 0, (short) 5);
+        agent.receiveResponse(request);
+
+        // Agent should be in MessageIdsBlocking, with agency
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.MessageIdsBlocking);
+        assertThat(agent.hasAgency()).isTrue();
+
+        // buildNextMessage should return ReplyMessageIds
+        var reply = agent.buildNextMessage();
+        assertThat(reply).isInstanceOf(MsgReplyMessageIds.class);
+        MsgReplyMessageIds replyIds = (MsgReplyMessageIds) reply;
+        assertThat(replyIds.getMessageIds()).hasSize(2);
+    }
+
+    @Test
+    void testRequestMessagesFlow() {
+        agent.enqueueMessage(createTestMessage(new byte[]{1}, "t"));
+        agent.sendRequest(new MsgInit());
+
+        // Server requests IDs
+        agent.receiveResponse(new MsgRequestMessageIds(true, (short) 0, (short) 5));
+        agent.sendRequest(agent.buildNextMessage()); // Send ReplyMessageIds
+
+        // Server requests message bodies
+        agent.receiveResponse(new MsgRequestMessages(List.of(new byte[]{1})));
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Messages);
+
+        var reply = agent.buildNextMessage();
+        assertThat(reply).isInstanceOf(MsgReplyMessages.class);
+        MsgReplyMessages replyMsgs = (MsgReplyMessages) reply;
+        assertThat(replyMsgs.getMessages()).hasSize(1);
+        assertThat(replyMsgs.getMessages().get(0).getTopicId()).isEqualTo("t");
+    }
+
+    @Test
+    void testAcknowledgmentRemovesFromQueue() {
+        agent.enqueueMessage(createTestMessage(new byte[]{1}, "t"));
+        agent.enqueueMessage(createTestMessage(new byte[]{2}, "t"));
+        agent.sendRequest(new MsgInit());
+
+        // First request
+        agent.receiveResponse(new MsgRequestMessageIds(true, (short) 0, (short) 5));
+        agent.sendRequest(agent.buildNextMessage());
+
+        // Ack 1, request more
+        agent.receiveResponse(new MsgRequestMessageIds(false, (short) 1, (short) 5));
+        assertThat(agent.getQueueSize()).isEqualTo(1); // One was ack'd and removed
+    }
+
+    @Test
+    void testResetClearsState() {
+        agent.enqueueMessage(createTestMessage(new byte[]{1}, "t"));
+        agent.sendRequest(new MsgInit());
+
+        agent.reset();
+
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Init);
+        assertThat(agent.getQueueSize()).isEqualTo(0);
+    }
+
+    private AppMessage createTestMessage(byte[] id, String topic) {
+        return AppMessage.builder()
+                .messageId(id)
+                .messageBody(new byte[]{10, 20, 30})
+                .authMethod(0)
+                .authProof(new byte[0])
+                .topicId(topic)
+                .expiresAt(0)
+                .build();
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionAgentTest.java
@@ -94,6 +94,35 @@ class AppMsgSubmissionAgentTest {
     }
 
     @Test
+    void testRequestMessageIdsRespectsRequestWindow() {
+        agent.enqueueMessage(createTestMessage(new byte[]{1}, "t"));
+        agent.enqueueMessage(createTestMessage(new byte[]{2}, "t"));
+        agent.enqueueMessage(createTestMessage(new byte[]{3}, "t"));
+        agent.sendRequest(new MsgInit());
+
+        agent.receiveResponse(new MsgRequestMessageIds(true, (short) 0, (short) 2));
+
+        var reply = agent.buildNextMessage();
+
+        assertThat(reply).isInstanceOf(MsgReplyMessageIds.class);
+        assertThat(((MsgReplyMessageIds) reply).getMessageIds()).hasSize(2);
+    }
+
+    @Test
+    void testBlockingEnqueueDoesNotExceedRequestWindow() {
+        agent.sendRequest(new MsgInit());
+        agent.receiveResponse(new MsgRequestMessageIds(true, (short) 0, (short) 1));
+
+        assertThat(agent.enqueueMessage(createTestMessage(new byte[]{1}, "t"))).isTrue();
+        assertThat(agent.enqueueMessage(createTestMessage(new byte[]{2}, "t"))).isTrue();
+
+        var reply = agent.buildNextMessage();
+
+        assertThat(reply).isInstanceOf(MsgReplyMessageIds.class);
+        assertThat(((MsgReplyMessageIds) reply).getMessageIds()).hasSize(1);
+    }
+
+    @Test
     void testRequestMessagesFlow() {
         agent.enqueueMessage(createTestMessage(new byte[]{1}, "t"));
         agent.sendRequest(new MsgInit());

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionSerializersTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionSerializersTest.java
@@ -1,0 +1,183 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.*;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.serializers.AppMsgSubmissionSerializers;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppMsgSubmissionSerializersTest {
+
+    @Test
+    void msgInit_roundtrip() {
+        MsgInit msg = new MsgInit();
+        byte[] bytes = msg.serialize();
+
+        MsgInit deserialized = AppMsgSubmissionSerializers.MsgInitSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized).isNotNull();
+    }
+
+    @Test
+    void msgRequestMessageIds_roundtrip() {
+        MsgRequestMessageIds msg = new MsgRequestMessageIds(true, (short) 5, (short) 10);
+        byte[] bytes = msg.serialize();
+
+        MsgRequestMessageIds deserialized =
+                AppMsgSubmissionSerializers.MsgRequestMessageIdsSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.isBlocking()).isTrue();
+        assertThat(deserialized.getAckCount()).isEqualTo((short) 5);
+        assertThat(deserialized.getReqCount()).isEqualTo((short) 10);
+    }
+
+    @Test
+    void msgRequestMessageIds_nonBlocking_roundtrip() {
+        MsgRequestMessageIds msg = new MsgRequestMessageIds(false, (short) 0, (short) 3);
+        byte[] bytes = msg.serialize();
+
+        MsgRequestMessageIds deserialized =
+                AppMsgSubmissionSerializers.MsgRequestMessageIdsSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.isBlocking()).isFalse();
+        assertThat(deserialized.getAckCount()).isEqualTo((short) 0);
+        assertThat(deserialized.getReqCount()).isEqualTo((short) 3);
+    }
+
+    @Test
+    void msgReplyMessageIds_roundtrip() {
+        MsgReplyMessageIds msg = new MsgReplyMessageIds();
+        msg.addMessageId(new byte[]{1, 2, 3, 4}, 100);
+        msg.addMessageId(new byte[]{5, 6, 7, 8}, 200);
+        byte[] bytes = msg.serialize();
+
+        MsgReplyMessageIds deserialized =
+                AppMsgSubmissionSerializers.MsgReplyMessageIdsSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.getMessageIds()).hasSize(2);
+        assertThat(deserialized.getMessageIds().get(0).getMessageId()).isEqualTo(new byte[]{1, 2, 3, 4});
+        assertThat(deserialized.getMessageIds().get(0).getSize()).isEqualTo(100);
+        assertThat(deserialized.getMessageIds().get(1).getMessageId()).isEqualTo(new byte[]{5, 6, 7, 8});
+        assertThat(deserialized.getMessageIds().get(1).getSize()).isEqualTo(200);
+    }
+
+    @Test
+    void msgReplyMessageIds_empty_roundtrip() {
+        MsgReplyMessageIds msg = new MsgReplyMessageIds();
+        byte[] bytes = msg.serialize();
+
+        MsgReplyMessageIds deserialized =
+                AppMsgSubmissionSerializers.MsgReplyMessageIdsSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.getMessageIds()).isEmpty();
+    }
+
+    @Test
+    void msgRequestMessages_roundtrip() {
+        MsgRequestMessages msg = new MsgRequestMessages();
+        msg.addMessageId(new byte[]{1, 2, 3});
+        msg.addMessageId(new byte[]{4, 5, 6});
+        byte[] bytes = msg.serialize();
+
+        MsgRequestMessages deserialized =
+                AppMsgSubmissionSerializers.MsgRequestMessagesSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.getMessageIds()).hasSize(2);
+        assertThat(deserialized.getMessageIds().get(0)).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(deserialized.getMessageIds().get(1)).isEqualTo(new byte[]{4, 5, 6});
+    }
+
+    @Test
+    void msgReplyMessages_roundtrip() {
+        AppMessage appMsg = AppMessage.builder()
+                .messageId(new byte[]{10, 20, 30})
+                .messageBody(new byte[]{1, 2, 3, 4, 5})
+                .authMethod(0)
+                .authProof(new byte[]{99})
+                .topicId("test-topic")
+                .expiresAt(1700000000L)
+                .build();
+
+        MsgReplyMessages msg = new MsgReplyMessages();
+        msg.addMessage(appMsg);
+        byte[] bytes = msg.serialize();
+
+        MsgReplyMessages deserialized =
+                AppMsgSubmissionSerializers.MsgReplyMessagesSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.getMessages()).hasSize(1);
+
+        AppMessage result = deserialized.getMessages().get(0);
+        assertThat(result.getMessageId()).isEqualTo(new byte[]{10, 20, 30});
+        assertThat(result.getMessageBody()).isEqualTo(new byte[]{1, 2, 3, 4, 5});
+        assertThat(result.getAuthMethod()).isEqualTo(0);
+        assertThat(result.getAuthProof()).isEqualTo(new byte[]{99});
+        assertThat(result.getTopicId()).isEqualTo("test-topic");
+        assertThat(result.getExpiresAt()).isEqualTo(1700000000L);
+    }
+
+    @Test
+    void msgReplyMessages_multipleMessages_roundtrip() {
+        AppMessage msg1 = AppMessage.builder()
+                .messageId(new byte[]{1})
+                .messageBody(new byte[]{11})
+                .authMethod(0)
+                .authProof(new byte[0])
+                .topicId("topic-a")
+                .expiresAt(0L)
+                .build();
+
+        AppMessage msg2 = AppMessage.builder()
+                .messageId(new byte[]{2})
+                .messageBody(new byte[]{22, 33})
+                .authMethod(1)
+                .authProof(new byte[]{88})
+                .topicId("topic-b")
+                .expiresAt(9999999999L)
+                .build();
+
+        MsgReplyMessages msg = new MsgReplyMessages(List.of(msg1, msg2));
+        byte[] bytes = msg.serialize();
+
+        MsgReplyMessages deserialized =
+                AppMsgSubmissionSerializers.MsgReplyMessagesSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized.getMessages()).hasSize(2);
+        assertThat(deserialized.getMessages().get(0).getTopicId()).isEqualTo("topic-a");
+        assertThat(deserialized.getMessages().get(1).getTopicId()).isEqualTo("topic-b");
+    }
+
+    @Test
+    void msgDone_roundtrip() {
+        MsgDone msg = new MsgDone();
+        byte[] bytes = msg.serialize();
+
+        MsgDone deserialized = AppMsgSubmissionSerializers.MsgDoneSerializer.INSTANCE.deserialize(bytes);
+        assertThat(deserialized).isNotNull();
+    }
+
+    @Test
+    void stateBase_handlesAllMessageTypes() {
+        // Verify the state base can dispatch all message types
+        AppMsgSubmissionStateBase stateBase = AppMsgSubmissionState.Init;
+
+        // MsgInit (tag 0)
+        byte[] initBytes = new MsgInit().serialize();
+        assertThat(stateBase.handleInbound(initBytes)).isInstanceOf(MsgInit.class);
+
+        // MsgRequestMessageIds (tag 1)
+        byte[] reqIdsBytes = new MsgRequestMessageIds(true, (short) 0, (short) 5).serialize();
+        assertThat(stateBase.handleInbound(reqIdsBytes)).isInstanceOf(MsgRequestMessageIds.class);
+
+        // MsgReplyMessageIds (tag 2)
+        byte[] replyIdsBytes = new MsgReplyMessageIds().serialize();
+        assertThat(stateBase.handleInbound(replyIdsBytes)).isInstanceOf(MsgReplyMessageIds.class);
+
+        // MsgRequestMessages (tag 3)
+        byte[] reqMsgsBytes = new MsgRequestMessages().serialize();
+        assertThat(stateBase.handleInbound(reqMsgsBytes)).isInstanceOf(MsgRequestMessages.class);
+
+        // MsgReplyMessages (tag 4)
+        byte[] replyMsgsBytes = new MsgReplyMessages().serialize();
+        assertThat(stateBase.handleInbound(replyMsgsBytes)).isInstanceOf(MsgReplyMessages.class);
+
+        // MsgDone (tag 5)
+        byte[] doneBytes = new MsgDone().serialize();
+        assertThat(stateBase.handleInbound(doneBytes)).isInstanceOf(MsgDone.class);
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgentTest.java
@@ -1,0 +1,216 @@
+package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
+
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessageId;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.*;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppMsgSubmissionServerAgentTest {
+
+    private AppMsgSubmissionServerAgent agent;
+
+    @BeforeEach
+    void setUp() {
+        agent = new AppMsgSubmissionServerAgent(AppMsgSubmissionConfig.createDefault());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (agent != null) agent.shutdown();
+    }
+
+    @Test
+    void testInitialState() {
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Init);
+        assertThat(agent.getProtocolId()).isEqualTo(100);
+        assertThat(agent.isDone()).isFalse();
+        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(0);
+    }
+
+    @Test
+    void testServerAgencyInIdleState() {
+        // Init state - client has agency
+        assertThat(agent.hasAgency()).isFalse();
+
+        // Process Init -> move to Idle
+        agent.receiveResponse(new MsgInit());
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Idle);
+
+        // In Idle state, server has agency
+        assertThat(agent.hasAgency()).isTrue();
+    }
+
+    @Test
+    void testInitTriggersBlockingRequest() {
+        agent.receiveResponse(new MsgInit());
+
+        // After init, server should have a pending blocking request
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Idle);
+        assertThat(agent.hasAgency()).isTrue();
+
+        // buildNextMessage should return the blocking request
+        var nextMsg = agent.buildNextMessage();
+        assertThat(nextMsg).isInstanceOf(MsgRequestMessageIds.class);
+
+        MsgRequestMessageIds request = (MsgRequestMessageIds) nextMsg;
+        assertThat(request.isBlocking()).isTrue();
+        assertThat(request.getAckCount()).isEqualTo((short) 0);
+        assertThat(request.getReqCount()).isEqualTo((short) 10);
+    }
+
+    @Test
+    void testReplyMessageIdsProcessing() {
+        agent.receiveResponse(new MsgInit());
+
+        // Simulate server sending blocking request and transitioning to MessageIdsBlocking
+        MsgRequestMessageIds request = new MsgRequestMessageIds(true, (short) 0, (short) 10);
+        agent.sendRequest(request);
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.MessageIdsBlocking);
+
+        // Track listener calls
+        AtomicReference<MsgReplyMessageIds> receivedReply = new AtomicReference<>();
+        agent.addListener(new AppMsgSubmissionListener() {
+            @Override
+            public void handleReplyMessageIds(MsgReplyMessageIds reply) {
+                receivedReply.set(reply);
+            }
+        });
+
+        // Client sends reply
+        MsgReplyMessageIds reply = new MsgReplyMessageIds();
+        reply.addMessageId(new byte[]{1, 2, 3}, 100);
+        reply.addMessageId(new byte[]{4, 5, 6}, 200);
+        agent.receiveResponse(reply);
+
+        // Verify state
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Idle);
+        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(2);
+        assertThat(agent.getOutstandingMessageCount()).isEqualTo(2);
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{1, 2, 3}))).isTrue();
+
+        // Listener called
+        assertThat(receivedReply.get()).isNotNull();
+        assertThat(receivedReply.get().getMessageIds()).hasSize(2);
+    }
+
+    @Test
+    void testDeduplicationOnReplyMessageIds() {
+        agent.receiveResponse(new MsgInit());
+
+        // Send blocking request -> MessageIdsBlocking
+        agent.sendRequest(new MsgRequestMessageIds(true, (short) 0, (short) 10));
+
+        // Reply with duplicate IDs
+        MsgReplyMessageIds reply1 = new MsgReplyMessageIds();
+        reply1.addMessageId(new byte[]{1, 2, 3}, 100);
+        agent.receiveResponse(reply1);
+
+        // Send another blocking request
+        agent.sendRequest(new MsgRequestMessageIds(true, (short) 0, (short) 10));
+
+        // Reply with same ID
+        MsgReplyMessageIds reply2 = new MsgReplyMessageIds();
+        reply2.addMessageId(new byte[]{1, 2, 3}, 100);
+        reply2.addMessageId(new byte[]{7, 8, 9}, 300);
+        agent.receiveResponse(reply2);
+
+        // Only unique IDs should be tracked
+        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(2);
+    }
+
+    @Test
+    void testReplyMessagesProcessing() {
+        agent.receiveResponse(new MsgInit());
+
+        // Send blocking request -> get message IDs
+        agent.sendRequest(new MsgRequestMessageIds(true, (short) 0, (short) 10));
+
+        MsgReplyMessageIds replyIds = new MsgReplyMessageIds();
+        replyIds.addMessageId(new byte[]{1, 2}, 50);
+        agent.receiveResponse(replyIds);
+        assertThat(agent.getOutstandingMessageCount()).isEqualTo(1);
+
+        // Server requests message bodies
+        agent.sendRequest(new MsgRequestMessages(List.of(new byte[]{1, 2})));
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Messages);
+
+        // Track listener
+        AtomicReference<MsgReplyMessages> receivedMsgs = new AtomicReference<>();
+        agent.addListener(new AppMsgSubmissionListener() {
+            @Override
+            public void handleReplyMessages(MsgReplyMessages reply) {
+                receivedMsgs.set(reply);
+            }
+        });
+
+        // Client replies with full messages
+        MsgReplyMessages replyMsgs = new MsgReplyMessages();
+        replyMsgs.addMessage(AppMessage.builder()
+                .messageId(new byte[]{1, 2})
+                .messageBody(new byte[]{10, 20, 30})
+                .authMethod(0)
+                .authProof(new byte[0])
+                .topicId("test")
+                .expiresAt(0)
+                .build());
+        agent.receiveResponse(replyMsgs);
+
+        // Verify
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Idle);
+        assertThat(agent.getOutstandingMessageCount()).isEqualTo(0);
+        // Ack count is consumed by sendNextBlockingRequest() which fires after all messages processed
+        assertThat(agent.getPendingAcknowledgments()).isEqualTo(0);
+        assertThat(receivedMsgs.get()).isNotNull();
+        assertThat(receivedMsgs.get().getMessages()).hasSize(1);
+
+        // The next blocking request should carry the ack count
+        var nextMsg = agent.buildNextMessage();
+        assertThat(nextMsg).isInstanceOf(MsgRequestMessageIds.class);
+        assertThat(((MsgRequestMessageIds) nextMsg).getAckCount()).isEqualTo((short) 1);
+    }
+
+    @Test
+    void testResetClearsState() {
+        agent.receiveResponse(new MsgInit());
+
+        agent.sendRequest(new MsgRequestMessageIds(true, (short) 0, (short) 10));
+        MsgReplyMessageIds reply = new MsgReplyMessageIds();
+        reply.addMessageId(new byte[]{1}, 10);
+        agent.receiveResponse(reply);
+
+        agent.reset();
+
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Init);
+        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(0);
+        assertThat(agent.getOutstandingMessageCount()).isEqualTo(0);
+        assertThat(agent.getPendingAcknowledgments()).isEqualTo(0);
+    }
+
+    @Test
+    void testEmptyReplyMessageIdsSendsNextBlockingRequest() {
+        agent.receiveResponse(new MsgInit());
+
+        // Send blocking request
+        agent.sendRequest(new MsgRequestMessageIds(true, (short) 0, (short) 10));
+
+        // Reply with no messages
+        agent.receiveResponse(new MsgReplyMessageIds());
+
+        // Agent should be back in Idle with a pending blocking request
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Idle);
+        assertThat(agent.hasAgency()).isTrue();
+
+        // Next message should be another blocking request
+        var nextMsg = agent.buildNextMessage();
+        assertThat(nextMsg).isInstanceOf(MsgRequestMessageIds.class);
+        assertThat(((MsgRequestMessageIds) nextMsg).isBlocking()).isTrue();
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgentTest.java
@@ -103,6 +103,26 @@ class AppMsgSubmissionServerAgentTest {
     }
 
     @Test
+    void testReplyMessageIdsDoesNotExceedRequestWindow() {
+        agent.receiveResponse(new MsgInit());
+
+        agent.sendRequest(new MsgRequestMessageIds(true, (short) 0, (short) 1));
+
+        MsgReplyMessageIds reply = new MsgReplyMessageIds();
+        reply.addMessageId(new byte[]{1}, 10);
+        reply.addMessageId(new byte[]{2}, 10);
+        agent.receiveResponse(reply);
+
+        assertThat(agent.getOutstandingMessageCount()).isEqualTo(1);
+
+        Message nextMsg = agent.buildNextMessage();
+        assertThat(nextMsg).isInstanceOf(MsgRequestMessages.class);
+        List<byte[]> requestedIds = ((MsgRequestMessages) nextMsg).getMessageIds();
+        assertThat(requestedIds).hasSize(1);
+        assertThat(requestedIds.get(0)).containsExactly((byte) 1);
+    }
+
+    @Test
     void testDeduplicationAfterMessageBodyReceived() {
         agent.receiveResponse(new MsgInit());
 
@@ -221,7 +241,7 @@ class AppMsgSubmissionServerAgentTest {
     }
 
     @Test
-    void testPartialReplyMessagesDoesNotBlockNextBatch() {
+    void testOutOfOrderReplyMessagesAreNotAcknowledged() {
         agent.receiveResponse(new MsgInit());
         sendPendingMessageIdRequest();
 
@@ -241,7 +261,32 @@ class AppMsgSubmissionServerAgentTest {
         assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Idle);
         assertThat(agent.getOutstandingMessageCount()).isEqualTo(0);
         assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{1}))).isFalse();
-        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{2}))).isTrue();
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{2}))).isFalse();
+
+        Message nextMsg = agent.buildNextMessage();
+        assertThat(nextMsg).isInstanceOf(MsgRequestMessageIds.class);
+        assertThat(((MsgRequestMessageIds) nextMsg).getAckCount()).isEqualTo((short) 0);
+    }
+
+    @Test
+    void testPrefixPartialReplyMessagesAckOnlyAcceptedPrefix() {
+        agent.receiveResponse(new MsgInit());
+        sendPendingMessageIdRequest();
+
+        MsgReplyMessageIds replyIds = new MsgReplyMessageIds();
+        replyIds.addMessageId(new byte[]{1}, 10);
+        replyIds.addMessageId(new byte[]{2}, 10);
+        agent.receiveResponse(replyIds);
+
+        sendPendingMessageBodyRequest();
+
+        MsgReplyMessages partialReply = new MsgReplyMessages();
+        partialReply.addMessage(createTestMessage(new byte[]{1}));
+        agent.receiveResponse(partialReply);
+
+        assertThat(agent.getOutstandingMessageCount()).isEqualTo(0);
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{1}))).isTrue();
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{2}))).isFalse();
 
         Message nextMsg = agent.buildNextMessage();
         assertThat(nextMsg).isInstanceOf(MsgRequestMessageIds.class);

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/appmsg/n2n/AppMsgSubmissionServerAgentTest.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n;
 
+import com.bloxbean.cardano.yaci.core.protocol.Message;
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessageId;
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.*;
@@ -92,9 +93,9 @@ class AppMsgSubmissionServerAgentTest {
 
         // Verify state
         assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Idle);
-        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(2);
+        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(0);
         assertThat(agent.getOutstandingMessageCount()).isEqualTo(2);
-        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{1, 2, 3}))).isTrue();
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{1, 2, 3}))).isFalse();
 
         // Listener called
         assertThat(receivedReply.get()).isNotNull();
@@ -102,28 +103,32 @@ class AppMsgSubmissionServerAgentTest {
     }
 
     @Test
-    void testDeduplicationOnReplyMessageIds() {
+    void testDeduplicationAfterMessageBodyReceived() {
         agent.receiveResponse(new MsgInit());
 
-        // Send blocking request -> MessageIdsBlocking
-        agent.sendRequest(new MsgRequestMessageIds(true, (short) 0, (short) 10));
+        sendPendingMessageIdRequest();
 
-        // Reply with duplicate IDs
         MsgReplyMessageIds reply1 = new MsgReplyMessageIds();
         reply1.addMessageId(new byte[]{1, 2, 3}, 100);
         agent.receiveResponse(reply1);
 
-        // Send another blocking request
-        agent.sendRequest(new MsgRequestMessageIds(true, (short) 0, (short) 10));
+        sendPendingMessageBodyRequest();
+        MsgReplyMessages messages1 = new MsgReplyMessages();
+        messages1.addMessage(createTestMessage(new byte[]{1, 2, 3}));
+        agent.receiveResponse(messages1);
 
-        // Reply with same ID
+        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(1);
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{1, 2, 3}))).isTrue();
+
+        sendPendingMessageIdRequest();
+
         MsgReplyMessageIds reply2 = new MsgReplyMessageIds();
         reply2.addMessageId(new byte[]{1, 2, 3}, 100);
         reply2.addMessageId(new byte[]{7, 8, 9}, 300);
         agent.receiveResponse(reply2);
 
-        // Only unique IDs should be tracked
-        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(2);
+        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(1);
+        assertThat(agent.getOutstandingMessageCount()).isEqualTo(1);
     }
 
     @Test
@@ -170,6 +175,7 @@ class AppMsgSubmissionServerAgentTest {
         assertThat(agent.getPendingAcknowledgments()).isEqualTo(0);
         assertThat(receivedMsgs.get()).isNotNull();
         assertThat(receivedMsgs.get().getMessages()).hasSize(1);
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{1, 2}))).isTrue();
 
         // The next blocking request should carry the ack count
         var nextMsg = agent.buildNextMessage();
@@ -212,5 +218,89 @@ class AppMsgSubmissionServerAgentTest {
         var nextMsg = agent.buildNextMessage();
         assertThat(nextMsg).isInstanceOf(MsgRequestMessageIds.class);
         assertThat(((MsgRequestMessageIds) nextMsg).isBlocking()).isTrue();
+    }
+
+    @Test
+    void testPartialReplyMessagesDoesNotBlockNextBatch() {
+        agent.receiveResponse(new MsgInit());
+        sendPendingMessageIdRequest();
+
+        MsgReplyMessageIds replyIds = new MsgReplyMessageIds();
+        replyIds.addMessageId(new byte[]{1}, 10);
+        replyIds.addMessageId(new byte[]{2}, 10);
+        agent.receiveResponse(replyIds);
+        assertThat(agent.getOutstandingMessageCount()).isEqualTo(2);
+
+        MsgRequestMessages bodyRequest = sendPendingMessageBodyRequest();
+        assertThat(bodyRequest.getMessageIds()).hasSize(2);
+
+        MsgReplyMessages partialReply = new MsgReplyMessages();
+        partialReply.addMessage(createTestMessage(new byte[]{2}));
+        agent.receiveResponse(partialReply);
+
+        assertThat(agent.getCurrentState()).isEqualTo(AppMsgSubmissionState.Idle);
+        assertThat(agent.getOutstandingMessageCount()).isEqualTo(0);
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{1}))).isFalse();
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{2}))).isTrue();
+
+        Message nextMsg = agent.buildNextMessage();
+        assertThat(nextMsg).isInstanceOf(MsgRequestMessageIds.class);
+        assertThat(((MsgRequestMessageIds) nextMsg).getAckCount()).isEqualTo((short) 1);
+    }
+
+    @Test
+    void testProcessedMessageIdCacheIsBounded() {
+        agent = new AppMsgSubmissionServerAgent(AppMsgSubmissionConfig.builder()
+                .processedMessageIdCacheSize(2)
+                .build());
+
+        agent.receiveResponse(new MsgInit());
+        completeMessage(new byte[]{1});
+        completeMessage(new byte[]{2});
+        completeMessage(new byte[]{3});
+
+        assertThat(agent.getReceivedMessageIdCount()).isEqualTo(2);
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{1}))).isFalse();
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{2}))).isTrue();
+        assertThat(agent.hasReceivedMessageId(HexUtil.encodeHexString(new byte[]{3}))).isTrue();
+    }
+
+    private MsgRequestMessageIds sendPendingMessageIdRequest() {
+        Message nextMsg = agent.buildNextMessage();
+        assertThat(nextMsg).isInstanceOf(MsgRequestMessageIds.class);
+        agent.sendRequest(nextMsg);
+        return (MsgRequestMessageIds) nextMsg;
+    }
+
+    private MsgRequestMessages sendPendingMessageBodyRequest() {
+        Message nextMsg = agent.buildNextMessage();
+        assertThat(nextMsg).isInstanceOf(MsgRequestMessages.class);
+        agent.sendRequest(nextMsg);
+        return (MsgRequestMessages) nextMsg;
+    }
+
+    private void completeMessage(byte[] messageId) {
+        sendPendingMessageIdRequest();
+
+        MsgReplyMessageIds replyIds = new MsgReplyMessageIds();
+        replyIds.addMessageId(messageId, 10);
+        agent.receiveResponse(replyIds);
+
+        sendPendingMessageBodyRequest();
+
+        MsgReplyMessages replyMessages = new MsgReplyMessages();
+        replyMessages.addMessage(createTestMessage(messageId));
+        agent.receiveResponse(replyMessages);
+    }
+
+    private AppMessage createTestMessage(byte[] messageId) {
+        return AppMessage.builder()
+                .messageId(messageId)
+                .messageBody(new byte[]{10, 20, 30})
+                .authMethod(0)
+                .authProof(new byte[0])
+                .topicId("test")
+                .expiresAt(0)
+                .build();
     }
 }

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/AppProtocolManager.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/AppProtocolManager.java
@@ -1,0 +1,90 @@
+package com.bloxbean.cardano.yaci.helper;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.AppMsgSubmissionAgent;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.AppMsgSubmissionListener;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Manages app-layer protocols (Protocol 100+) for a peer connection.
+ * The AppMsgSubmissionAgent is always created internally. Callers signal intent
+ * via {@link #enableAppMsg()}; actual activation only happens if the peer also
+ * negotiates V100 during handshake (two-level check).
+ */
+@Slf4j
+public class AppProtocolManager {
+    private final AppMsgSubmissionAgent appMsgAgent = new AppMsgSubmissionAgent();
+    private boolean appMsgEnabled = false;
+
+    /**
+     * Signal intent to use the AppMsgSubmission protocol.
+     * The agent is only activated after handshake if the peer also supports V100.
+     */
+    public void enableAppMsg() {
+        this.appMsgEnabled = true;
+    }
+
+    public boolean isAppMsgEnabled() {
+        return appMsgEnabled;
+    }
+
+    public Optional<AppMsgSubmissionAgent> getAppMsgSubmissionAgent() {
+        return Optional.of(appMsgAgent);
+    }
+
+    /**
+     * Get all app agents to include in the connection agent list.
+     */
+    public List<Agent<?>> getAgents() {
+        return List.of(appMsgAgent);
+    }
+
+    /**
+     * Wire listeners on the internal app agent. Called once during init.
+     * The client inbound handler does NOT auto-call sendNextMessage(),
+     * so the listener must trigger replies after each server request.
+     */
+    public void setupListeners() {
+        appMsgAgent.addListener(new AppMsgSubmissionListener() {
+            @Override
+            public void handleRequestMessageIds(
+                    com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.MsgRequestMessageIds request) {
+                appMsgAgent.sendNextMessage();
+            }
+
+            @Override
+            public void handleRequestMessages(
+                    com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.messages.MsgRequestMessages request) {
+                appMsgAgent.sendNextMessage();
+            }
+        });
+        log.info("AppMsgSubmission listener wired for internal app agent");
+    }
+
+    /**
+     * Enable app protocols if the negotiated version supports them AND
+     * the caller has signalled intent via {@link #enableAppMsg()}.
+     * Called after handshake completes.
+     * @param acceptVersion the negotiated version from handshake
+     */
+    public void onHandshakeComplete(AcceptVersion acceptVersion) {
+        if (!appMsgEnabled) return;  // caller didn't enable it
+        if (acceptVersion == null) return;
+        if (!N2NVersionTableConstant.isAppLayerVersion(acceptVersion.getVersionNumber())) {
+            log.info("Peer negotiated V{} — app-layer protocols not activated",
+                    acceptVersion.getVersionNumber());
+            return;
+        }
+        activateAppMsgSubmission();
+    }
+
+    private void activateAppMsgSubmission() {
+        appMsgAgent.sendNextMessage();  // sends MsgInit
+        log.info("AppMsgSubmission protocol activated (MsgInit sent)");
+    }
+}

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/AppProtocolManager.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/AppProtocolManager.java
@@ -7,19 +7,19 @@ import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Manages app-layer protocols (Protocol 100+) for a peer connection.
- * The AppMsgSubmissionAgent is always created internally. Callers signal intent
- * via {@link #enableAppMsg()}; actual activation only happens if the peer also
- * negotiates V100 during handshake (two-level check).
+ * Callers signal intent via {@link #enableAppMsg()}; the agent is added to a
+ * connection only when enabled and activated only when the peer negotiates V100.
  */
 @Slf4j
 public class AppProtocolManager {
     private final AppMsgSubmissionAgent appMsgAgent = new AppMsgSubmissionAgent();
     private boolean appMsgEnabled = false;
+    private boolean listenersSetup = false;
 
     /**
      * Signal intent to use the AppMsgSubmission protocol.
@@ -33,14 +33,17 @@ public class AppProtocolManager {
         return appMsgEnabled;
     }
 
-    public Optional<AppMsgSubmissionAgent> getAppMsgSubmissionAgent() {
-        return Optional.of(appMsgAgent);
+    public AppMsgSubmissionAgent getAppMsgSubmissionAgent() {
+        return appMsgAgent;
     }
 
     /**
-     * Get all app agents to include in the connection agent list.
+     * Get app agents to include in the connection agent list.
+     * Returns an empty list unless app messaging is explicitly enabled.
      */
     public List<Agent<?>> getAgents() {
+        if (!appMsgEnabled)
+            return Collections.emptyList();
         return List.of(appMsgAgent);
     }
 
@@ -50,6 +53,9 @@ public class AppProtocolManager {
      * so the listener must trigger replies after each server request.
      */
     public void setupListeners() {
+        if (listenersSetup)
+            return;
+
         appMsgAgent.addListener(new AppMsgSubmissionListener() {
             @Override
             public void handleRequestMessageIds(
@@ -63,6 +69,7 @@ public class AppProtocolManager {
                 appMsgAgent.sendNextMessage();
             }
         });
+        listenersSetup = true;
         log.info("AppMsgSubmission listener wired for internal app agent");
     }
 
@@ -84,6 +91,7 @@ public class AppProtocolManager {
     }
 
     private void activateAppMsgSubmission() {
+        setupListeners();
         appMsgAgent.sendNextMessage();  // sends MsgInit
         log.info("AppMsgSubmission protocol activated (MsgInit sent)");
     }

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
@@ -12,6 +12,7 @@ import com.bloxbean.cardano.yaci.core.model.byron.ByronEbBlock;
 import com.bloxbean.cardano.yaci.core.model.byron.ByronEbHead;
 import com.bloxbean.cardano.yaci.core.model.byron.ByronMainBlock;
 import com.bloxbean.cardano.yaci.core.network.TCPNodeClient;
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
 import com.bloxbean.cardano.yaci.core.protocol.blockfetch.BlockfetchAgent;
 import com.bloxbean.cardano.yaci.core.protocol.blockfetch.BlockfetchAgentListener;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
@@ -30,6 +31,8 @@ import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.RequestTxs;
 import com.bloxbean.cardano.yaci.helper.api.Fetcher;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -64,6 +67,9 @@ public class N2NPeerFetcher implements Fetcher<Block> {
 
     // Tx submission queue size (0 = use agent default)
     private int txMaxQueueSize;
+
+    // App protocol manager (handles Protocol 100+ agents)
+    private AppProtocolManager appProtocolManager;
 
     // Keep alive tracking
     private int lastKeepAliveResponseCookie = 0;
@@ -103,10 +109,19 @@ public class N2NPeerFetcher implements Fetcher<Block> {
      * Application controls sync strategy by choosing the starting point
      */
     public N2NPeerFetcher(String host, int port, Point wellKnownPoint, VersionTable versionTable) {
+        this(host, port, wellKnownPoint, versionTable, new AppProtocolManager());
+    }
+
+    /**
+     * Constructor with an externally-provided AppProtocolManager.
+     */
+    public N2NPeerFetcher(String host, int port, Point wellKnownPoint, VersionTable versionTable,
+                          AppProtocolManager appProtocolManager) {
         this.host = host;
         this.port = port;
         this.versionTable = versionTable;
         this.wellKnownPoint = wellKnownPoint;
+        this.appProtocolManager = appProtocolManager;
 
         init();
     }
@@ -120,9 +135,12 @@ public class N2NPeerFetcher implements Fetcher<Block> {
 
         blockFetchAgent.resetPoints(wellKnownPoint, wellKnownPoint);
         setupAgentListeners();
+        appProtocolManager.setupListeners();
 
-        n2nClient = new TCPNodeClient(host, port, handshakeAgent, keepAliveAgent,
-                chainSyncAgent, blockFetchAgent, txSubmissionAgent);
+        List<Agent<?>> allAgents = new ArrayList<>(List.of(
+                keepAliveAgent, chainSyncAgent, blockFetchAgent, txSubmissionAgent));
+        allAgents.addAll(appProtocolManager.getAgents());
+        n2nClient = new TCPNodeClient(host, port, handshakeAgent, allAgents.toArray(new Agent<?>[0]));
     }
 
     private void setupAgentListeners() {
@@ -136,6 +154,8 @@ public class N2NPeerFetcher implements Fetcher<Block> {
 
                 //We don't need to start chain sync here, as it will be started by the application
                 //by invoking startXXX() methods.
+                appProtocolManager.onHandshakeComplete(handshakeAgent.getProtocolVersion());
+
                 if (firstTimeHandshake) {
                     firstTimeHandshake = false;
                     log.info("First time handshake completed. Waiting for explicit sync start.");
@@ -517,6 +537,13 @@ public class N2NPeerFetcher implements Fetcher<Block> {
 
     public void enableTxSubmission() {
         txSubmissionAgent.sendNextMessage();
+    }
+
+    /**
+     * Get the app protocol manager for external access.
+     */
+    public AppProtocolManager getAppProtocolManager() {
+        return appProtocolManager;
     }
 
     // ========================================

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
@@ -135,7 +135,6 @@ public class N2NPeerFetcher implements Fetcher<Block> {
 
         blockFetchAgent.resetPoints(wellKnownPoint, wellKnownPoint);
         setupAgentListeners();
-        appProtocolManager.setupListeners();
 
         List<Agent<?>> allAgents = new ArrayList<>(List.of(
                 keepAliveAgent, chainSyncAgent, blockFetchAgent, txSubmissionAgent));

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
@@ -54,7 +54,7 @@ public class N2NPeerFetcher implements Fetcher<Block> {
     // Core connection fields
     private final String host;
     private final int port;
-    private final VersionTable versionTable;
+    private VersionTable versionTable;
     private final Point wellKnownPoint;
 
     // Agents
@@ -136,10 +136,27 @@ public class N2NPeerFetcher implements Fetcher<Block> {
         blockFetchAgent.resetPoints(wellKnownPoint, wellKnownPoint);
         setupAgentListeners();
 
+        validateAppProtocolConfiguration();
+    }
+
+    private void ensureClientInitialized() {
+        if (n2nClient != null)
+            return;
+
+        validateAppProtocolConfiguration();
+
         List<Agent<?>> allAgents = new ArrayList<>(List.of(
                 keepAliveAgent, chainSyncAgent, blockFetchAgent, txSubmissionAgent));
         allAgents.addAll(appProtocolManager.getAgents());
         n2nClient = new TCPNodeClient(host, port, handshakeAgent, allAgents.toArray(new Agent<?>[0]));
+    }
+
+    private void validateAppProtocolConfiguration() {
+        if (appProtocolManager.isAppMsgEnabled()
+                && !N2NVersionTableConstant.hasAppLayerVersion(versionTable)) {
+            throw new IllegalStateException(
+                    "App message protocol requires a version table with app-layer V100 support");
+        }
     }
 
     private void setupAgentListeners() {
@@ -399,6 +416,7 @@ public class N2NPeerFetcher implements Fetcher<Block> {
             }
         });
 
+        ensureClientInitialized();
         n2nClient.start();
     }
 
@@ -407,7 +425,7 @@ public class N2NPeerFetcher implements Fetcher<Block> {
      * Useful for header-only synchronization or when you want to control body fetching manually
      */
     public void startChainSyncOnly(Point from, boolean isPipelined) {
-        if (!n2nClient.isRunning()) {
+        if (!isRunning()) {
             throw new IllegalStateException("Connection not established. Call connect() first.");
         }
 
@@ -424,7 +442,7 @@ public class N2NPeerFetcher implements Fetcher<Block> {
      * Must be called after connection is established
      */
     public void startBlockFetchOnly(Point from, Point to) {
-        if (!n2nClient.isRunning()) {
+        if (!isRunning()) {
             throw new IllegalStateException("Connection not established. Call connect() first.");
         }
 
@@ -459,7 +477,7 @@ public class N2NPeerFetcher implements Fetcher<Block> {
     }
 
     public void sendKeepAliveMessage(int cookie) {
-        if (n2nClient.isRunning())
+        if (isRunning())
             keepAliveAgent.sendKeepAlive(cookie);
     }
 
@@ -482,16 +500,17 @@ public class N2NPeerFetcher implements Fetcher<Block> {
 
     @Override
     public boolean isRunning() {
-        return n2nClient.isRunning();
+        return n2nClient != null && n2nClient.isRunning();
     }
 
     @Override
     public void shutdown() {
-        n2nClient.shutdown();
+        if (n2nClient != null)
+            n2nClient.shutdown();
     }
 
     public void fetch(Point from, Point to) {
-        if (!n2nClient.isRunning())
+        if (!isRunning())
             throw new IllegalStateException("fetch() should be called after start()");
 
         blockFetchAgent.resetPoints(from, to);
@@ -502,7 +521,7 @@ public class N2NPeerFetcher implements Fetcher<Block> {
     }
 
     public void startSync(Point from, boolean isPipelined) {
-        if (!n2nClient.isRunning())
+        if (!isRunning())
             throw new IllegalStateException("startSync() should be called after start()");
 
         chainSyncAgent.enablePipelining(isPipelined);
@@ -514,7 +533,7 @@ public class N2NPeerFetcher implements Fetcher<Block> {
     }
 
     public Optional<Tip> getLatestTip() {
-        if (!n2nClient.isRunning())
+        if (!isRunning())
             throw new IllegalStateException("getTip() should be called after start()");
 
         // Return the latest known tip if available
@@ -536,6 +555,14 @@ public class N2NPeerFetcher implements Fetcher<Block> {
 
     public void enableTxSubmission() {
         txSubmissionAgent.sendNextMessage();
+    }
+
+    public void enableAppMsg() {
+        if (n2nClient != null)
+            throw new IllegalStateException("App message protocol must be enabled before start()");
+
+        this.versionTable = N2NVersionTableConstant.withAppLayer(versionTable);
+        appProtocolManager.enableAppMsg();
     }
 
     /**

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
@@ -183,6 +183,14 @@ public class PeerClient {
         n2NPeerFetcher.enableTxSubmission();
     }
 
+    public void enableAppMsg() {
+        if (n2NPeerFetcher != null)
+            throw new IllegalStateException("App message protocol must be enabled before connect()");
+
+        this.versionTable = N2NVersionTableConstant.withAppLayer(versionTable);
+        appProtocolManager.enableAppMsg();
+    }
+
     /**
      * Get the app protocol manager for this peer connection.
      * Available before and after connect().

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
@@ -31,6 +31,8 @@ public class PeerClient {
 
     private int txMaxQueueSize;
 
+    private final AppProtocolManager appProtocolManager = new AppProtocolManager();
+
     private N2NPeerFetcher n2NPeerFetcher;
 
     /**
@@ -62,7 +64,7 @@ public class PeerClient {
         if (n2NPeerFetcher != null && n2NPeerFetcher.isRunning())
             throw new IllegalStateException("Already connected. Please call shutdown() before connecting again.");
 
-        n2NPeerFetcher = new N2NPeerFetcher(host, port, wellKnownPoint, versionTable);
+        n2NPeerFetcher = new N2NPeerFetcher(host, port, wellKnownPoint, versionTable, appProtocolManager);
         if (txMaxQueueSize > 0)
             n2NPeerFetcher.setTxMaxQueueSize(txMaxQueueSize);
 
@@ -179,6 +181,14 @@ public class PeerClient {
 
     public void enableTxSubmission() {
         n2NPeerFetcher.enableTxSubmission();
+    }
+
+    /**
+     * Get the app protocol manager for this peer connection.
+     * Available before and after connect().
+     */
+    public AppProtocolManager getAppProtocolManager() {
+        return appProtocolManager;
     }
 
     // ========================================

--- a/helper/src/test/java/com/bloxbean/cardano/yaci/helper/AppProtocolManagerTest.java
+++ b/helper/src/test/java/com/bloxbean/cardano/yaci/helper/AppProtocolManagerTest.java
@@ -2,11 +2,14 @@ package com.bloxbean.cardano.yaci.helper;
 
 import com.bloxbean.cardano.yaci.core.protocol.Agent;
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.AppMsgSubmissionAgent;
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AppProtocolManagerTest {
 
@@ -29,5 +32,33 @@ class AppProtocolManagerTest {
 
         assertThat(manager.isAppMsgEnabled()).isTrue();
         assertThat(agents).containsExactly(appMsgAgent);
+    }
+
+    @Test
+    void enabledAppMsgRequiresAppLayerVersionTable() {
+        AppProtocolManager manager = new AppProtocolManager();
+        manager.enableAppMsg();
+
+        assertThatThrownBy(() -> new N2NPeerFetcher(
+                "localhost",
+                1,
+                Point.ORIGIN,
+                N2NVersionTableConstant.v11AndAbove(42),
+                manager))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("V100");
+    }
+
+    @Test
+    void enableAppMsgOnFetcherAddsAppLayerVersion() {
+        N2NPeerFetcher fetcher = new N2NPeerFetcher(
+                "localhost",
+                1,
+                Point.ORIGIN,
+                N2NVersionTableConstant.v11AndAbove(42));
+
+        fetcher.enableAppMsg();
+
+        assertThat(fetcher.getAppProtocolManager().isAppMsgEnabled()).isTrue();
     }
 }

--- a/helper/src/test/java/com/bloxbean/cardano/yaci/helper/AppProtocolManagerTest.java
+++ b/helper/src/test/java/com/bloxbean/cardano/yaci/helper/AppProtocolManagerTest.java
@@ -1,0 +1,33 @@
+package com.bloxbean.cardano.yaci.helper;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.AppMsgSubmissionAgent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppProtocolManagerTest {
+
+    @Test
+    void getAgentsReturnsEmptyUntilAppMsgIsEnabled() {
+        AppProtocolManager manager = new AppProtocolManager();
+
+        assertThat(manager.isAppMsgEnabled()).isFalse();
+        assertThat(manager.getAgents()).isEmpty();
+    }
+
+    @Test
+    void enableAppMsgExposesAppMsgAgent() {
+        AppProtocolManager manager = new AppProtocolManager();
+
+        manager.enableAppMsg();
+
+        List<Agent<?>> agents = manager.getAgents();
+        AppMsgSubmissionAgent appMsgAgent = manager.getAppMsgSubmissionAgent();
+
+        assertThat(manager.isAppMsgEnabled()).isTrue();
+        assertThat(agents).containsExactly(appMsgAgent);
+    }
+}


### PR DESCRIPTION
## Summary

  - Updates application-layer protocol handling for N2N/N2C mini-protocol flows.
  - Adds/adjusts protocol message models, serialization/deserialization, and agent handling needed by the new N2N/N2C behavior.
  - Improves protocol-version handling so client and node negotiation stays aligned with supported Cardano node versions.
  - Keeps higher-level APIs stable while limiting behavior changes to the protocol/runtime layer.

  ## Rationale

  These changes bring Yaci’s application-layer N2N/N2C protocol support closer to current Cardano node behavior and make the protocol implementation more reliable for downstream consumers such as Yano. The updates are focused on protocol correctness and compatibility without changing unrelated helper APIs.