### PR TITLE
 fix(network): re-resolve socket address on each connect retry (#161)

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClient.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClient.java
@@ -97,9 +97,7 @@ public abstract class NodeClient {
                 }
             });
 
-            SocketAddress socketAddress = createSocketAddress();
-
-            session = new Session(socketAddress, b, config, handshakeAgent, agents);
+            session = new Session(this::createSocketAddress, b, config, handshakeAgent, agents);
             session.setSessionListener(sessionListener);
             session.start();
         } catch (Exception e) {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
@@ -9,13 +9,14 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 /**
  * This class tries to open the network connection. The session gets destroyed during disconnection event.
  */
 @Slf4j
 class Session implements Disposable {
-    private final SocketAddress socketAddress;
+    private final Supplier<SocketAddress> socketAddressSupplier;
     private final Bootstrap clientBootstrap;
     private Channel activeChannel;
     private final AtomicBoolean shouldReconnect;
@@ -25,38 +26,15 @@ class Session implements Disposable {
 
     private SessionListener sessionListener;
 
-    /**
-     * Constructor with NodeClientConfig for configurable connection behavior.
-     *
-     * @param socketAddress the socket address to connect to
-     * @param clientBootstrap the Netty bootstrap
-     * @param config the connection configuration
-     * @param handshakeAgent the handshake agent
-     * @param agents the protocol agents
-     */
-    public Session(SocketAddress socketAddress, Bootstrap clientBootstrap, NodeClientConfig config,
+    public Session(Supplier<SocketAddress> socketAddressSupplier, Bootstrap clientBootstrap, NodeClientConfig config,
                    HandshakeAgent handshakeAgent, Agent[] agents) {
-        this.socketAddress = socketAddress;
+        this.socketAddressSupplier = socketAddressSupplier;
         this.clientBootstrap = clientBootstrap;
         this.config = config != null ? config : NodeClientConfig.defaultConfig();
         this.shouldReconnect = new AtomicBoolean(this.config.isAutoReconnect());
 
         this.handshakeAgent = handshakeAgent;
         this.agents = agents;
-    }
-
-    /**
-     * Constructor with default configuration (for backward compatibility).
-     *
-     * @param socketAddress the socket address to connect to
-     * @param clientBootstrap the Netty bootstrap
-     * @param handshakeAgent the handshake agent
-     * @param agents the protocol agents
-     * @deprecated Use {@link #Session(SocketAddress, Bootstrap, NodeClientConfig, HandshakeAgent, Agent[])} instead
-     */
-    @Deprecated
-    public Session(SocketAddress socketAddress, Bootstrap clientBootstrap, HandshakeAgent handshakeAgent, Agent[] agents) {
-        this(socketAddress, clientBootstrap, NodeClientConfig.defaultConfig(), handshakeAgent, agents);
     }
 
     public void setSessionListener(SessionListener sessionListener) {
@@ -71,10 +49,11 @@ class Session implements Disposable {
         ChannelFuture connectFuture = null;
         // Always try to connect at least once, then retry only if shouldReconnect is true
         do {
+            SocketAddress socketAddress = socketAddressSupplier.get();
             try {
                 connectFuture = clientBootstrap.connect(socketAddress).sync();
             } catch (Exception e) {
-                log.error("Connection failed", e);
+                log.error("Connection failed to {}", socketAddress, e);
                 if (shouldReconnect.get()) {
                     Thread.sleep(config.getInitialRetryDelayMs());
                     log.debug("Trying to reconnect !!!");

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClient.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClient.java
@@ -50,7 +50,13 @@ public class TCPNodeClient extends NodeClient {
 
     @Override
     protected SocketAddress createSocketAddress() {
-        return new InetSocketAddress(host, port);
+        InetSocketAddress addr = new InetSocketAddress(host, port);
+        if (addr.isUnresolved()) {
+            log.warn("Could not resolve host {}", host);
+        } else {
+            log.info("Resolved {} to {}:{}", host, addr.getAddress().getHostAddress(), port);
+        }
+        return addr;
     }
 
     @Override

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/SessionTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/SessionTest.java
@@ -1,0 +1,64 @@
+package com.bloxbean.cardano.yaci.core.network;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgent;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SessionTest {
+
+    /**
+     * Verifies that Session asks for a fresh SocketAddress on each connection attempt.
+     *
+     * <p>The first mocked connect attempt fails, which keeps the internal retry loop running.
+     * The second attempt succeeds with a different address. This protects the DNS re-resolution
+     * behavior where TCPNodeClient can resolve the configured host again before every retry.</p>
+     */
+    @Test
+    void startResolvesSocketAddressForEachRetryAttempt() throws Exception {
+        SocketAddress firstAddress = new InetSocketAddress("127.0.0.1", 3001);
+        SocketAddress secondAddress = new InetSocketAddress("127.0.0.2", 3001);
+
+        @SuppressWarnings("unchecked")
+        Supplier<SocketAddress> socketAddressSupplier = mock(Supplier.class);
+        when(socketAddressSupplier.get()).thenReturn(firstAddress, secondAddress);
+
+        Bootstrap clientBootstrap = mock(Bootstrap.class);
+        ChannelFuture failedConnectFuture = mock(ChannelFuture.class);
+        ChannelFuture successfulConnectFuture = mock(ChannelFuture.class);
+        Channel channel = mock(Channel.class);
+        HandshakeAgent handshakeAgent = mock(HandshakeAgent.class);
+
+        when(clientBootstrap.connect(firstAddress)).thenReturn(failedConnectFuture);
+        when(failedConnectFuture.sync()).thenThrow(new RuntimeException("connect timeout"));
+        when(clientBootstrap.connect(secondAddress)).thenReturn(successfulConnectFuture);
+        when(successfulConnectFuture.sync()).thenReturn(successfulConnectFuture);
+        when(successfulConnectFuture.channel()).thenReturn(channel);
+        when(successfulConnectFuture.addListeners()).thenReturn(successfulConnectFuture);
+        when(handshakeAgent.isDone()).thenReturn(true);
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .initialRetryDelayMs(0)
+                .enableConnectionLogging(false)
+                .build();
+
+        Session session = new Session(socketAddressSupplier, clientBootstrap, config, handshakeAgent, new Agent[0]);
+
+        session.start();
+
+        verify(socketAddressSupplier, times(2)).get();
+        verify(clientBootstrap).connect(firstAddress);
+        verify(clientBootstrap).connect(secondAddress);
+    }
+}


### PR DESCRIPTION
 ## Summary

  Fixes #161.

  `Session` previously cached a single `SocketAddress` resolved at construction time and reused it forever in its retry loop. When a load-balanced hostname's first-returned IP became unhealthy, every retry — and every reconnection after `disconnected()` — hammered the same dead IP until the JVM was restarted.

  Session now takes a `Supplier<SocketAddress>` instead of a pre-resolved address and invokes it on every iteration of the retry loop, giving the JVM DNS resolver an opportunity to return a different IP. The error log now includes the address that failed so resolution drift is visible in normal logs.

  ## Changes
  
  - `Session`: field changed from `SocketAddress` to `Supplier<SocketAddress>`; resolved fresh inside the `do/while` retry loop. Deprecated single-arg constructor dropped (class is package-private, no external API impact).
  - `NodeClient.start()`: passes `this::createSocketAddress` as the supplier
  - `TCPNodeClient.createSocketAddress()`: logs the resolved IP (or warns when unresolved) so operators can see resolution drift across reconnects.
  - `UnixSocketNodeClient`: untouched — `DomainSocketAddress` has no resolver semantics.
  - Added `SessionTest` covering the per-retry re-resolution behavior.
  
  ## Important: JVM DNS cache TTL
  
  This patch lets the retry loop *ask* for a fresh address on each attempt, but whether a new IP actually comes back depends on the JVM's DNS positive-cache TTL. On modern JDKs the default policy is **cache forever**.
  
  Operators connecting Yaci to a load-balanced or DNS-failover endpoint should lower the TTL with the following JVM flag:
  
  ```-Dsun.net.inetaddr.ttl=30```

  Note: `-Dnetworkaddress.cache.ttl=...` does **not** work from the command line — that's a security property, not a system property. `sun.net.inetaddr.ttl` is the system-property fallback the JDK reads when configured via `-D`.

  Without this set, the JVM keeps handing back the same cached IP and this fix is a no-op. With a sane TTL, retries (which already back off by `config.getInitialRetryDelayMs()`) will eventually re-resolve and pick up a healthy IP from a load-balanced pool.

  ## Known limitation / follow-up

  If a resolver consistently returns the same dead IP first (no randomization healthy IP from a load-balanced pool.

  ## Known limitation / follow-up

  If a resolver consistently returns the same dead IP first (no randomization across A-records), this patch still won't help on its own. Tracking explicit `InetAddress.getAllByName(host)` enumeration + rotation as a follow-up — that work brings IPv6/dual-stack concerns and is intentionally out of scope for v0.4.4.

  ## Test plan

  - [x] `./gradlew :core:test --tests SessionTest` passes
  - [x] `./gradlew :core:compileJava :core:compileTestJava` clean
  - [ ] Manual: point a TCP client at a hostname with multiple A-records, kill
        the first IP, verify reconnect picks up the second (requires
        `-Dsun.net.inetaddr.ttl=30`)