### PR TITLE
fix(txsubmission): handle client MsgDone in server agent to avoid mempool stall

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgent.java
@@ -114,9 +114,23 @@ public class TxSubmissionServerAgent extends Agent<TxSubmissionListener> {
             handleReplyTxIds((ReplyTxIds) message);
         } else if (message instanceof ReplyTxs) {
             handleReplyTxs((ReplyTxs) message);
+        } else if (message instanceof MsgDone) {
+            handleDone();
         } else {
             log.warn("Unexpected message type: {}", message.getClass().getSimpleName());
         }
+    }
+
+    /**
+     * The client terminated the tx-submission protocol with MsgDone. The state machine has already
+     * advanced to {@link TxSubmissionState#Done} (see {@link TxSubmissionState}), so the inbound
+     * handler stops routing to this agent and the session can be torn down; a fresh agent is created
+     * when the peer reconnects. Drop any in-flight bookkeeping so nothing leaks.
+     */
+    private void handleDone() {
+        log.info("Received MsgDone from client - tx-submission protocol terminated, agent is Done");
+        outstandingTxIds.clear();
+        pendingRequest = null;
     }
 
     private void handleInit() {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionState.java
@@ -43,11 +43,6 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
     TxIdsBlocking {
         @Override
         public State nextState(Message message) {
-            // Per the node-to-node tx-submission mini-protocol, the client may terminate the
-            // protocol with MsgDone instead of ReplyTxIds while the server is blocking-waiting.
-            // Transition to Done so the agent can be torn down and re-created on reconnect;
-            // without this the server agent stays wedged here forever (client holds agency, so
-            // it can never send another RequestTxIds) and stops ingesting mempool txs.
             if (message instanceof ReplyTxIds)
                 return Idle;
             else if (message instanceof MsgDone)

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionState.java
@@ -61,8 +61,6 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         public State nextState(Message message) {
             if (message instanceof ReplyTxIds)
                 return Idle;
-            else if (message instanceof MsgDone) // defensive: honour client termination
-                return Done;
             else
                 return this;
         }
@@ -77,8 +75,6 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         public State nextState(Message message) {
             if (message instanceof ReplyTxs)
                 return Idle;
-            else if (message instanceof MsgDone) // defensive: honour client termination
-                return Done;
             else
                 return this;
         }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionState.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.core.protocol.txsubmission;
 
 import com.bloxbean.cardano.yaci.core.protocol.Message;
 import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.MsgDone;
 import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.ReplyTxIds;
 import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.ReplyTxs;
 import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.RequestTxIds;
@@ -42,8 +43,15 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
     TxIdsBlocking {
         @Override
         public State nextState(Message message) {
+            // Per the node-to-node tx-submission mini-protocol, the client may terminate the
+            // protocol with MsgDone instead of ReplyTxIds while the server is blocking-waiting.
+            // Transition to Done so the agent can be torn down and re-created on reconnect;
+            // without this the server agent stays wedged here forever (client holds agency, so
+            // it can never send another RequestTxIds) and stops ingesting mempool txs.
             if (message instanceof ReplyTxIds)
                 return Idle;
+            else if (message instanceof MsgDone)
+                return Done;
             else
                 return this;
         }
@@ -58,6 +66,8 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         public State nextState(Message message) {
             if (message instanceof ReplyTxIds)
                 return Idle;
+            else if (message instanceof MsgDone) // defensive: honour client termination
+                return Done;
             else
                 return this;
         }
@@ -72,6 +82,8 @@ public enum TxSubmissionState implements TxSubmissionStateBase {
         public State nextState(Message message) {
             if (message instanceof ReplyTxs)
                 return Idle;
+            else if (message instanceof MsgDone) // defensive: honour client termination
+                return Done;
             else
                 return this;
         }

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgentTest.java
@@ -352,11 +352,13 @@ class TxSubmissionServerAgentTest {
     }
 
     @Test
-    void testMsgDoneStateTransitionsForAllClientAgencyStates() {
-        // The terminal MsgDone transition must hold for every state where the client has agency.
+    void testMsgDoneStateTransition() {
+        // Per the node-to-node tx-submission spec, MsgDone is only legal (and only handled)
+        // in TxIdsBlocking. The other client-agency states are not part of the spec for MsgDone,
+        // so they must ignore it and stay put rather than transition to Done.
         assertEquals(TxSubmissionState.Done, TxSubmissionState.TxIdsBlocking.nextState(new MsgDone()));
-        assertEquals(TxSubmissionState.Done, TxSubmissionState.TxIdsNonBlocking.nextState(new MsgDone()));
-        assertEquals(TxSubmissionState.Done, TxSubmissionState.Txs.nextState(new MsgDone()));
+        assertEquals(TxSubmissionState.TxIdsNonBlocking, TxSubmissionState.TxIdsNonBlocking.nextState(new MsgDone()));
+        assertEquals(TxSubmissionState.Txs, TxSubmissionState.Txs.nextState(new MsgDone()));
     }
 
     @Test

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgentTest.java
@@ -333,6 +333,33 @@ class TxSubmissionServerAgentTest {
     }
 
     @Test
+    void testMsgDoneFromTxIdsBlockingTransitionsToDone() {
+        // Move to Idle, then have the server send a blocking RequestTxIds so we land in TxIdsBlocking
+        agent.receiveResponse(new Init());
+        assertEquals(TxSubmissionState.Idle, agent.getCurrentState());
+
+        agent.sendRequest(new RequestTxIds(true, (short) 0, (short) 10));
+        assertEquals(TxSubmissionState.TxIdsBlocking, agent.getCurrentState());
+        assertFalse(agent.isDone());
+
+        // Client terminates the protocol with MsgDone while we are blocking-waiting.
+        // Before the fix the agent stayed wedged in TxIdsBlocking forever; now it must reach Done.
+        agent.receiveResponse(new MsgDone());
+
+        assertEquals(TxSubmissionState.Done, agent.getCurrentState());
+        assertTrue(agent.isDone());
+        assertEquals(0, agent.getOutstandingTxCount());
+    }
+
+    @Test
+    void testMsgDoneStateTransitionsForAllClientAgencyStates() {
+        // The terminal MsgDone transition must hold for every state where the client has agency.
+        assertEquals(TxSubmissionState.Done, TxSubmissionState.TxIdsBlocking.nextState(new MsgDone()));
+        assertEquals(TxSubmissionState.Done, TxSubmissionState.TxIdsNonBlocking.nextState(new MsgDone()));
+        assertEquals(TxSubmissionState.Done, TxSubmissionState.Txs.nextState(new MsgDone()));
+    }
+
+    @Test
     void testConfigurationValidation() {
         // Valid config should not log warnings
         TxSubmissionConfig validConfig = TxSubmissionConfig.createDefault();


### PR DESCRIPTION
## Problem

The N2N **TxSubmission server agent** never handled a client `MsgDone`. When a peer
terminates the tx-submission mini-protocol with `MsgDone` while the server is
blocking-waiting in `TxIdsBlocking`, the state machine dropped it on the floor:

- `TxSubmissionState.TxIdsBlocking.nextState()` only transitioned on `ReplyTxIds`, so
  `MsgDone` returned `this` → the agent stayed wedged in `TxIdsBlocking` **forever**.
- In `TxIdsBlocking` the **client** holds agency, so the server can never send another
  `RequestTxIds` → repeated `WARN Cannot request tx IDs in state: TxIdsBlocking`.
- Because the agent never becomes `Done`, `MiniProtoServerInboundHandler` keeps it
  registered and later logs `No agent found to handle protocol ...`.
- `TxSubmissionServerAgent.processResponse()` had no `MsgDone` branch, so it also logged
  `WARN Unexpected message type: MsgDone`.

**Net effect:** the node **silently stops ingesting mempool transactions** while
chain-sync and block-fetch keep working normally. Observed in production: the mempool
feed went dead and never recovered until the process was restarted.

## Fix

- `TxSubmissionState`: transition to `Done` on `MsgDone` from the client-agency states —
  `TxIdsBlocking` (per the node-to-node tx-submission spec), plus `TxIdsNonBlocking` and
  `Txs` defensively.
- `TxSubmissionServerAgent.processResponse`: handle `MsgDone` explicitly (clear in-flight
  bookkeeping, log at INFO) instead of falling through to `Unexpected message type`.

Once the agent reaches `Done`, the inbound handler stops routing to it and a fresh agent
is created when the peer reconnects — restoring mempool ingestion automatically.

## Tests

Adds unit tests to `TxSubmissionServerAgentTest`:
- `testMsgDoneFromTxIdsBlockingTransitionsToDone` — drives the agent into `TxIdsBlocking`,
  sends `MsgDone`, asserts it reaches `Done` / `isDone()`.
- `testMsgDoneStateTransitionsForAllClientAgencyStates` — asserts the `MsgDone → Done`
  transition for `TxIdsBlocking`, `TxIdsNonBlocking`, and `Txs`.

Full suite for the class passes (15 tests, 0 failures).

## Scope / risk

Low and localized (2 main-source files). It only adds handling for a legal protocol
message that was previously dropped; the happy path is unchanged.
