### PR TITLE
feat: Add relay transport hooks for connection governance and peer sharing

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfig.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfig.java
@@ -93,6 +93,34 @@ public class NodeClientConfig {
     private final SocketAddressFamily socketAddressFamily = SocketAddressFamily.ANY;
 
     /**
+     * Optional local host/interface used when binding outbound TCP connections before connect().
+     * Blank or null means wildcard address. This is ignored when localBindPort is not positive.
+     */
+    private final String localBindHost;
+
+    /**
+     * Optional local source port used when binding outbound TCP connections before connect().
+     * Default: 0, which lets the operating system choose an ephemeral source port.
+     */
+    @Builder.Default
+    private final int localBindPort = 0;
+
+    /**
+     * When true, a local-bind failure falls back to a normal connect using an
+     * OS-assigned source port. This is useful for relay source-port reuse,
+     * where TIME_WAIT or platform socket rules must not prevent availability.
+     */
+    @Builder.Default
+    private final boolean localBindFallbackToEphemeral = false;
+
+    /**
+     * @return true when outbound connects should bind to a local source port.
+     */
+    public boolean hasLocalBindAddress() {
+        return localBindPort > 0;
+    }
+
+    /**
      * Creates a default configuration.
      * This is equivalent to calling {@code NodeClientConfig.builder().build()}
      *

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/Session.java
@@ -7,6 +7,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import lombok.extern.slf4j.Slf4j;
 
+import java.net.BindException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -123,10 +125,10 @@ class Session implements Disposable {
                     try {
                         attempts++;
                         if (showConnectionLog())
-                            log.info("Connecting to {} (attempt {}, candidate {}/{}, max retries: {})",
-                                    socketAddress, attempts, i + 1, socketAddresses.size(),
-                                    config.getMaxRetryAttempts());
-                        connectFuture = clientBootstrap.connect(socketAddress).sync();
+                            log.info("Connecting to {}{} (attempt {}, candidate {}/{}, max retries: {})",
+                                    socketAddress, localBindLogSuffix(), attempts, i + 1,
+                                    socketAddresses.size(), config.getMaxRetryAttempts());
+                        connectFuture = connectAndSync(socketAddress);
                     } catch (InterruptedException e) {
                         throw e;
                     } catch (Exception e) {
@@ -254,6 +256,52 @@ class Session implements Disposable {
         } else {
             log.warn("Connection failed for {}: {}", socketAddress, failure.toString());
         }
+    }
+
+    private ChannelFuture connectAndSync(SocketAddress remoteAddress) throws InterruptedException {
+        SocketAddress localAddress = localBindAddress();
+        if (localAddress != null) {
+            try {
+                return clientBootstrap.connect(remoteAddress, localAddress).sync();
+            } catch (InterruptedException e) {
+                throw e;
+            } catch (Exception e) {
+                if (!config.isLocalBindFallbackToEphemeral() || !hasCause(e, BindException.class)) {
+                    throw e;
+                }
+                log.warn("Local bind {} failed for {}; retrying with OS-assigned source port: {}",
+                        localAddress, remoteAddress, e.toString());
+                return clientBootstrap.connect(remoteAddress).sync();
+            }
+        }
+        return clientBootstrap.connect(remoteAddress).sync();
+    }
+
+    private SocketAddress localBindAddress() {
+        if (!config.hasLocalBindAddress()) {
+            return null;
+        }
+        String host = config.getLocalBindHost();
+        if (host == null || host.isBlank()) {
+            return new InetSocketAddress(config.getLocalBindPort());
+        }
+        return new InetSocketAddress(host, config.getLocalBindPort());
+    }
+
+    private String localBindLogSuffix() {
+        SocketAddress localAddress = localBindAddress();
+        return localAddress != null ? " from " + localAddress : "";
+    }
+
+    private static boolean hasCause(Throwable error, Class<? extends Throwable> type) {
+        Throwable current = error;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private void logAddressResolutionFailure(Exception failure) {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClient.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/TCPNodeClient.java
@@ -89,6 +89,9 @@ public class TCPNodeClient extends NodeClient {
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.option(ChannelOption.TCP_NODELAY, true);
         bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getConfig().getConnectionTimeoutMs());
+        if (getConfig().hasLocalBindAddress()) {
+            bootstrap.option(ChannelOption.SO_REUSEADDR, true);
+        }
     }
 
     static class DnsRotatingSocketAddressProvider {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/NodeServer.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/NodeServer.java
@@ -28,6 +28,7 @@ public class NodeServer {
     private TxSubmissionListener txSubmissionListener;
     private TxSubmissionConfig txSubmissionConfig;
     private List<AgentFactory> agentFactories;
+    private ServerConnectionListener connectionListener;
     private final static Map<Channel, NodeServerSession> sessions = new ConcurrentHashMap<>();
 
     public NodeServer(int port, VersionTable versionTable, ChainState chainState) {
@@ -57,6 +58,10 @@ public class NodeServer {
         this.agentFactories = agentFactories != null ? agentFactories : Collections.emptyList();
     }
 
+    public void setConnectionListener(ServerConnectionListener connectionListener) {
+        this.connectionListener = connectionListener;
+    }
+
     public void start() {
         try {
             log.info("Initializing NodeServer on port {}", port);
@@ -72,10 +77,30 @@ public class NodeServer {
                             log.info("New connection from: {}", ch.remoteAddress());
                             log.info("Local address: {}", ch.localAddress());
 
+                            ServerConnectionListener listener = connectionListener;
+                            if (listener != null) {
+                                ServerConnectionDecision decision;
+                                try {
+                                    decision = listener.onAccept(ch);
+                                } catch (Exception e) {
+                                    log.warn("Inbound connection listener rejected {} after error: {}",
+                                            ch.remoteAddress(), e.toString());
+                                    ch.close();
+                                    return;
+                                }
+                                if (decision != null && !decision.accepted()) {
+                                    log.info("Rejected inbound connection from {}: {}",
+                                            ch.remoteAddress(), decision.reason());
+                                    ch.close();
+                                    return;
+                                }
+                                ch.closeFuture().addListener(closeFuture -> listener.onClosed(ch));
+                            }
+
                             try {
                                 NodeServerSession session = new NodeServerSession(
                                         ch, versionTable, chainState, txSubmissionListener,
-                                        txSubmissionConfig, agentFactories);
+                                        txSubmissionConfig, agentFactories, listener);
                                 sessions.put(ch, session);
                                 log.info("Created session for client: {}", ch.remoteAddress());
                             } catch (Exception e) {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/NodeServerSession.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/NodeServerSession.java
@@ -5,7 +5,9 @@ import com.bloxbean.cardano.yaci.core.network.handlers.MiniProtoStreamingByteToM
 import com.bloxbean.cardano.yaci.core.network.server.handlers.MiniProtoServerInboundHandler;
 import com.bloxbean.cardano.yaci.core.protocol.Agent;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgent;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgentListener;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.VersionTable;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.Reason;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.n2n.ChainSyncServerAgent;
 import com.bloxbean.cardano.yaci.core.protocol.blockfetch.BlockFetchServerAgent;
 import com.bloxbean.cardano.yaci.core.protocol.txsubmission.TxSubmissionServerAgent;
@@ -31,6 +33,7 @@ public class NodeServerSession {
     private final TxSubmissionListener txSubmissionListener;
     private final TxSubmissionConfig txSubmissionConfig;
     private final List<AgentFactory> agentFactories;
+    private final ServerConnectionListener connectionListener;
 
     public NodeServerSession(Channel clientChannel, VersionTable versionTable, ChainState chainState,
                            TxSubmissionListener txSubmissionListener, TxSubmissionConfig txSubmissionConfig) {
@@ -41,15 +44,41 @@ public class NodeServerSession {
     public NodeServerSession(Channel clientChannel, VersionTable versionTable, ChainState chainState,
                            TxSubmissionListener txSubmissionListener, TxSubmissionConfig txSubmissionConfig,
                            List<AgentFactory> agentFactories) {
+        this(clientChannel, versionTable, chainState, txSubmissionListener, txSubmissionConfig,
+                agentFactories, null);
+    }
+
+    public NodeServerSession(Channel clientChannel, VersionTable versionTable, ChainState chainState,
+                           TxSubmissionListener txSubmissionListener, TxSubmissionConfig txSubmissionConfig,
+                           List<AgentFactory> agentFactories, ServerConnectionListener connectionListener) {
         this.clientChannel = clientChannel;
         this.handshakeAgent = new HandshakeAgent(versionTable, false);
         this.chainState = chainState;
         this.txSubmissionListener = txSubmissionListener;
         this.txSubmissionConfig = txSubmissionConfig != null ? txSubmissionConfig : TxSubmissionConfig.createDefault();
         this.agentFactories = agentFactories != null ? agentFactories : Collections.emptyList();
+        this.connectionListener = connectionListener;
+        attachConnectionListener();
         this.agents = createAgents();
 
         setupPipeline();
+    }
+
+    private void attachConnectionListener() {
+        if (connectionListener == null) {
+            return;
+        }
+        handshakeAgent.addListener(new HandshakeAgentListener() {
+            @Override
+            public void handshakeOk() {
+                connectionListener.onHandshakeComplete(clientChannel, handshakeAgent.getProtocolVersion());
+            }
+
+            @Override
+            public void handshakeError(Reason reason) {
+                connectionListener.onHandshakeFailed(clientChannel, new IllegalStateException(String.valueOf(reason)));
+            }
+        });
     }
 
     private void setupPipeline() {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/ServerConnectionDecision.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/ServerConnectionDecision.java
@@ -1,0 +1,14 @@
+package com.bloxbean.cardano.yaci.core.network.server;
+
+/**
+ * Admission decision for an inbound node-to-node server connection.
+ */
+public record ServerConnectionDecision(boolean accepted, String reason) {
+    public static ServerConnectionDecision accept() {
+        return new ServerConnectionDecision(true, null);
+    }
+
+    public static ServerConnectionDecision reject(String reason) {
+        return new ServerConnectionDecision(false, reason);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/ServerConnectionListener.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/server/ServerConnectionListener.java
@@ -1,0 +1,25 @@
+package com.bloxbean.cardano.yaci.core.network.server;
+
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
+import io.netty.channel.Channel;
+
+/**
+ * Optional inbound server connection hook.
+ *
+ * <p>Implementations must return quickly and must not block on network or
+ * protocol operations.</p>
+ */
+public interface ServerConnectionListener {
+    default ServerConnectionDecision onAccept(Channel channel) {
+        return ServerConnectionDecision.accept();
+    }
+
+    default void onHandshakeComplete(Channel channel, AcceptVersion acceptedVersion) {
+    }
+
+    default void onHandshakeFailed(Channel channel, Throwable cause) {
+    }
+
+    default void onClosed(Channel channel) {
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeAgent.java
@@ -63,8 +63,14 @@ public class HandshakeAgent extends Agent<HandshakeAgentListener> {
             long highestVersion = supportedProtocolVersions.get(supportedProtocolVersions.size() - 1);
 
             N2NVersionData requestedVersionData = (N2NVersionData) versionDataMap.get(highestVersion);
+            N2NVersionData supportedVersionData = (N2NVersionData) versionTable.getVersionDataMap().get(highestVersion);
 
-            var acceptedVersionData = new N2NVersionData(requestedVersionData.getNetworkMagic(), requestedVersionData.getInitiatorOnlyDiffusionMode(), 0, requestedVersionData.getQuery());
+            var acceptedVersionData = new N2NVersionData(
+                    requestedVersionData.getNetworkMagic(),
+                    requestedVersionData.getInitiatorOnlyDiffusionMode(),
+                    negotiatedPeerSharing(requestedVersionData, supportedVersionData),
+                    Boolean.TRUE.equals(requestedVersionData.getQuery())
+                            && Boolean.TRUE.equals(supportedVersionData.getQuery()));
 
             // Accept the highest version
             var acceptVersion = new AcceptVersion(highestVersion, acceptedVersionData);
@@ -80,6 +86,24 @@ public class HandshakeAgent extends Agent<HandshakeAgentListener> {
             return refuse;
         }
 
+    }
+
+    private int negotiatedPeerSharing(N2NVersionData requestedVersionData, N2NVersionData supportedVersionData) {
+        int requested = requestedVersionData.getPeerSharing() != null ? requestedVersionData.getPeerSharing() : 0;
+        int supported = supportedVersionData.getPeerSharing() != null ? supportedVersionData.getPeerSharing() : 0;
+        return Math.min(requested, supported);
+    }
+
+    @Override
+    public synchronized void sendRequest(Message message) {
+        super.sendRequest(message);
+        if (message instanceof AcceptVersion acceptVersion) {
+            setProtocolVersion(acceptVersion);
+            handshakeOk();
+        } else if (message instanceof Refuse refuse) {
+            setProtocolVersion(null);
+            handshakeError(refuse.getReason());
+        }
     }
 
     @Override
@@ -108,7 +132,15 @@ public class HandshakeAgent extends Agent<HandshakeAgentListener> {
     }
 
     private void handshakeError(Message message) {
-        getAgentListeners().forEach(handshakeAgentListener -> handshakeAgentListener.handshakeError((Reason)message));
+        if (message instanceof Refuse refuse) {
+            handshakeError(refuse.getReason());
+        } else {
+            handshakeError((Reason) message);
+        }
+    }
+
+    private void handshakeError(Reason reason) {
+        getAgentListeners().forEach(handshakeAgentListener -> handshakeAgentListener.handshakeError(reason));
     }
 
     @Override

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/peersharing/PeerSharingServerAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/peersharing/PeerSharingServerAgent.java
@@ -1,0 +1,105 @@
+package com.bloxbean.cardano.yaci.core.protocol.peersharing;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.peersharing.messages.MsgDone;
+import com.bloxbean.cardano.yaci.core.protocol.peersharing.messages.MsgSharePeers;
+import com.bloxbean.cardano.yaci.core.protocol.peersharing.messages.MsgShareRequest;
+import com.bloxbean.cardano.yaci.core.protocol.peersharing.messages.PeerAddress;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.IntFunction;
+
+import static com.bloxbean.cardano.yaci.core.protocol.peersharing.PeerSharingState.StBusy;
+import static com.bloxbean.cardano.yaci.core.protocol.peersharing.PeerSharingState.StDone;
+import static com.bloxbean.cardano.yaci.core.protocol.peersharing.PeerSharingState.StIdle;
+
+/**
+ * Server side of the Ouroboros peer-sharing mini-protocol.
+ *
+ * <p>The agent is deliberately policy-free. Callers provide a bounded list of
+ * peers for each request, and the agent serializes that response.</p>
+ */
+@Slf4j
+public class PeerSharingServerAgent extends Agent<PeerSharingAgentListener> {
+    private final IntFunction<List<PeerAddress>> peerProvider;
+    private List<PeerAddress> pendingResponse = List.of();
+
+    public PeerSharingServerAgent(IntFunction<List<PeerAddress>> peerProvider) {
+        super(false);
+        this.peerProvider = Objects.requireNonNull(peerProvider, "peerProvider");
+        this.currentState = StIdle;
+    }
+
+    @Override
+    public int getProtocolId() {
+        return 10;
+    }
+
+    @Override
+    public boolean isDone() {
+        return currentState == StDone;
+    }
+
+    @Override
+    protected Message buildNextMessage() {
+        if (currentState == StBusy) {
+            List<PeerAddress> response = pendingResponse;
+            pendingResponse = List.of();
+            log.debug("Sharing {} peers", response.size());
+            return new MsgSharePeers(response);
+        }
+        return null;
+    }
+
+    @Override
+    protected void processResponse(Message message) {
+        if (message instanceof MsgShareRequest request) {
+            int amount = Math.min(Math.max(request.getAmount(), 0), PeerSharingAgent.MAX_REQUEST_AMOUNT);
+            pendingResponse = selectPeers(amount);
+            return;
+        }
+        if (message instanceof MsgDone) {
+            pendingResponse = List.of();
+            return;
+        }
+        if (message != null) {
+            log.warn("Unexpected peer-sharing message in server mode: {}", message.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        pendingResponse = List.of();
+    }
+
+    @Override
+    public void reset() {
+        this.currentState = StIdle;
+        this.pendingResponse = List.of();
+    }
+
+    private List<PeerAddress> selectPeers(int amount) {
+        if (amount <= 0) {
+            return List.of();
+        }
+        List<PeerAddress> candidates = peerProvider.apply(amount);
+        if (candidates == null || candidates.isEmpty()) {
+            return List.of();
+        }
+        List<PeerAddress> selected = new ArrayList<>(Math.min(amount, candidates.size()));
+        for (PeerAddress candidate : candidates) {
+            if (candidate == null) {
+                continue;
+            }
+            selected.add(candidate);
+            if (selected.size() >= amount) {
+                break;
+            }
+        }
+        return List.copyOf(selected);
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfigTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/NodeClientConfigTest.java
@@ -22,6 +22,11 @@ class NodeClientConfigTest {
                 "Default socket address resolution mode should be STANDARD");
         assertEquals(SocketAddressFamily.ANY, config.getSocketAddressFamily(),
                 "Default socket address family should be ANY");
+        assertNull(config.getLocalBindHost(), "Default local bind host should be null");
+        assertEquals(0, config.getLocalBindPort(), "Default local bind port should be 0");
+        assertFalse(config.hasLocalBindAddress(), "Default config should not bind outbound source ports");
+        assertFalse(config.isLocalBindFallbackToEphemeral(),
+                "Default config should not fall back from local bind to ephemeral source ports");
     }
 
     @Test
@@ -60,6 +65,9 @@ class NodeClientConfigTest {
                 .enableConnectionLogging(false)
                 .socketAddressResolutionMode(SocketAddressResolutionMode.DNS_ROTATING)
                 .socketAddressFamily(SocketAddressFamily.IPV4_ONLY)
+                .localBindHost("127.0.0.1")
+                .localBindPort(13338)
+                .localBindFallbackToEphemeral(true)
                 .build();
 
         assertFalse(config.isAutoReconnect());
@@ -68,6 +76,10 @@ class NodeClientConfigTest {
         assertFalse(config.isEnableConnectionLogging());
         assertEquals(SocketAddressResolutionMode.DNS_ROTATING, config.getSocketAddressResolutionMode());
         assertEquals(SocketAddressFamily.IPV4_ONLY, config.getSocketAddressFamily());
+        assertEquals("127.0.0.1", config.getLocalBindHost());
+        assertEquals(13338, config.getLocalBindPort());
+        assertTrue(config.hasLocalBindAddress());
+        assertTrue(config.isLocalBindFallbackToEphemeral());
     }
 
     @Test

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/SessionTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/SessionTest.java
@@ -11,6 +11,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import org.junit.jupiter.api.Test;
 
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
@@ -102,6 +103,86 @@ class SessionTest {
         assertSame(session, session.start());
         verify(bootstrap, times(1)).connect(first);
         verify(bootstrap, times(1)).connect(second);
+    }
+
+    @Test
+    void startUsesConfiguredLocalBindAddressWhenPresent() throws InterruptedException {
+        Bootstrap bootstrap = mock(Bootstrap.class);
+        ChannelFuture channelFuture = mockSuccessfulChannelFuture();
+        HandshakeAgent handshakeAgent = mock(HandshakeAgent.class);
+        when(handshakeAgent.isDone()).thenReturn(true);
+
+        SocketAddress remote = new InetSocketAddress("127.0.0.1", 3001);
+        SocketAddress local = new InetSocketAddress("127.0.0.1", 13338);
+        when(bootstrap.connect(remote, local)).thenReturn(channelFuture);
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .autoReconnect(false)
+                .enableConnectionLogging(false)
+                .localBindHost("127.0.0.1")
+                .localBindPort(13338)
+                .build();
+
+        Session session = new Session(remote, bootstrap, config, handshakeAgent, new Agent[0]);
+
+        assertSame(session, session.start());
+        verify(bootstrap, times(1)).connect(remote, local);
+        verify(bootstrap, times(0)).connect(remote);
+    }
+
+    @Test
+    void startFallsBackToEphemeralSourcePortWhenLocalBindFailsAndFallbackIsEnabled() throws Exception {
+        Bootstrap bootstrap = mock(Bootstrap.class);
+        ChannelFuture bindFailure = mock(ChannelFuture.class);
+        ChannelFuture channelFuture = mockSuccessfulChannelFuture();
+        HandshakeAgent handshakeAgent = mock(HandshakeAgent.class);
+        when(handshakeAgent.isDone()).thenReturn(true);
+
+        SocketAddress remote = new InetSocketAddress("127.0.0.1", 3001);
+        SocketAddress local = new InetSocketAddress("127.0.0.1", 13338);
+        when(bindFailure.sync()).thenThrow(new RuntimeException(new BindException("Address already in use")));
+        when(bootstrap.connect(remote, local)).thenReturn(bindFailure);
+        when(bootstrap.connect(remote)).thenReturn(channelFuture);
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .autoReconnect(false)
+                .enableConnectionLogging(false)
+                .localBindHost("127.0.0.1")
+                .localBindPort(13338)
+                .localBindFallbackToEphemeral(true)
+                .build();
+
+        Session session = new Session(remote, bootstrap, config, handshakeAgent, new Agent[0]);
+
+        assertSame(session, session.start());
+        verify(bootstrap, times(1)).connect(remote, local);
+        verify(bootstrap, times(1)).connect(remote);
+    }
+
+    @Test
+    void startDoesNotFallBackToEphemeralSourcePortByDefault() throws Exception {
+        Bootstrap bootstrap = mock(Bootstrap.class);
+        ChannelFuture bindFailure = mock(ChannelFuture.class);
+        HandshakeAgent handshakeAgent = mock(HandshakeAgent.class);
+        when(handshakeAgent.isDone()).thenReturn(true);
+
+        SocketAddress remote = new InetSocketAddress("127.0.0.1", 3001);
+        SocketAddress local = new InetSocketAddress("127.0.0.1", 13338);
+        when(bindFailure.sync()).thenThrow(new RuntimeException(new BindException("Address already in use")));
+        when(bootstrap.connect(remote, local)).thenReturn(bindFailure);
+
+        NodeClientConfig config = NodeClientConfig.builder()
+                .autoReconnect(false)
+                .enableConnectionLogging(false)
+                .localBindHost("127.0.0.1")
+                .localBindPort(13338)
+                .build();
+
+        Session session = new Session(remote, bootstrap, config, handshakeAgent, new Agent[0]);
+
+        assertThrows(RuntimeException.class, session::start);
+        verify(bootstrap, times(1)).connect(remote, local);
+        verify(bootstrap, times(0)).connect(remote);
     }
 
     @Test

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeNegotiationTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/handshake/HandshakeNegotiationTest.java
@@ -1,0 +1,75 @@
+package com.bloxbean.cardano.yaci.core.protocol.handshake;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.N2NVersionData;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.ProposedVersions;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class HandshakeNegotiationTest {
+
+    @Test
+    void serverNegotiatesPeerSharingWhenBothSidesSupportIt() {
+        HandshakeAgent server = new HandshakeAgent(
+                N2NVersionTableConstant.v11AndAbove(1, false, 1, false),
+                false);
+        ProposedVersions clientProposal = new ProposedVersions(
+                N2NVersionTableConstant.v11AndAbove(1, false, 1, false));
+
+        server.receiveResponse(clientProposal);
+        Message response = server.buildNextMessage();
+
+        AcceptVersion accepted = assertInstanceOf(AcceptVersion.class, response);
+        N2NVersionData versionData = assertInstanceOf(N2NVersionData.class, accepted.getVersionData());
+        assertEquals(1, versionData.getPeerSharing());
+    }
+
+    @Test
+    void serverDoesNotEnablePeerSharingWhenRemoteDoesNotRequestIt() {
+        HandshakeAgent server = new HandshakeAgent(
+                N2NVersionTableConstant.v11AndAbove(1, false, 1, false),
+                false);
+        ProposedVersions clientProposal = new ProposedVersions(
+                N2NVersionTableConstant.v11AndAbove(1, false, 0, false));
+
+        server.receiveResponse(clientProposal);
+        Message response = server.buildNextMessage();
+
+        AcceptVersion accepted = assertInstanceOf(AcceptVersion.class, response);
+        N2NVersionData versionData = assertInstanceOf(N2NVersionData.class, accepted.getVersionData());
+        assertEquals(0, versionData.getPeerSharing());
+    }
+
+    @Test
+    void serverNotifiesHandshakeOkWhenAcceptVersionIsSent() {
+        HandshakeAgent server = new HandshakeAgent(
+                N2NVersionTableConstant.v11AndAbove(1, false, 1, false),
+                false);
+        AtomicInteger okCount = new AtomicInteger();
+        AtomicReference<AcceptVersion> acceptedVersion = new AtomicReference<>();
+        server.addListener(new HandshakeAgentListener() {
+            @Override
+            public void handshakeOk() {
+                okCount.incrementAndGet();
+                acceptedVersion.set(server.getProtocolVersion());
+            }
+        });
+
+        server.receiveResponse(new ProposedVersions(
+                N2NVersionTableConstant.v11AndAbove(1, false, 1, false)));
+        Message response = server.buildNextMessage();
+        server.sendRequest(response);
+
+        AcceptVersion accepted = assertInstanceOf(AcceptVersion.class, response);
+        assertEquals(1, okCount.get());
+        assertEquals(accepted, acceptedVersion.get());
+        assertEquals(accepted, server.getProtocolVersion());
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/peersharing/PeerSharingServerAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/peersharing/PeerSharingServerAgentTest.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.yaci.core.protocol.peersharing;
+
+import com.bloxbean.cardano.yaci.core.protocol.peersharing.messages.MsgSharePeers;
+import com.bloxbean.cardano.yaci.core.protocol.peersharing.messages.MsgShareRequest;
+import com.bloxbean.cardano.yaci.core.protocol.peersharing.messages.PeerAddress;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PeerSharingServerAgentTest {
+
+    @Test
+    void sharesAtMostRequestedPeers() {
+        PeerSharingServerAgent agent = new PeerSharingServerAgent(amount -> List.of(
+                PeerAddress.ipv4("10.0.0.1", 3001),
+                PeerAddress.ipv4("10.0.0.2", 3001),
+                PeerAddress.ipv4("10.0.0.3", 3001)));
+
+        agent.receiveResponse(new MsgShareRequest(2));
+
+        MsgSharePeers response = (MsgSharePeers) agent.buildNextMessage();
+        assertEquals(2, response.getPeerAddresses().size());
+        assertEquals("10.0.0.1", response.getPeerAddresses().get(0).getAddress());
+        assertEquals("10.0.0.2", response.getPeerAddresses().get(1).getAddress());
+    }
+
+    @Test
+    void clampsOversizedRequestToProtocolLimit() {
+        PeerSharingServerAgent agent = new PeerSharingServerAgent(amount -> {
+            assertEquals(PeerSharingAgent.MAX_REQUEST_AMOUNT, amount);
+            return List.of(PeerAddress.ipv4("10.0.0.1", 3001));
+        });
+
+        agent.receiveResponse(new MsgShareRequest(255));
+
+        MsgSharePeers response = (MsgSharePeers) agent.buildNextMessage();
+        assertEquals(1, response.getPeerAddresses().size());
+    }
+}

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
@@ -22,6 +22,7 @@ import com.bloxbean.cardano.yaci.core.protocol.chainsync.n2n.ChainSyncAgentListe
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.n2n.ChainsyncAgent;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgent;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.VersionTable;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
 import com.bloxbean.cardano.yaci.core.protocol.keepalive.KeepAliveAgent;
@@ -519,6 +520,10 @@ public class N2NPeerFetcher implements Fetcher<Block> {
 
     public long getLastKeepAliveResponseTime() {
         return lastKeepAliveResponseTime;
+    }
+
+    public Optional<AcceptVersion> getProtocolVersion() {
+        return Optional.ofNullable(handshakeAgent.getProtocolVersion());
     }
 
     public void submitTxBytes(byte[] txBytes) {

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.yaci.core.common.TxBodyType;
 import com.bloxbean.cardano.yaci.core.network.NodeClientConfig;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Tip;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.VersionTable;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
 import com.bloxbean.cardano.yaci.core.protocol.txsubmission.TxSubmissionListener;
@@ -170,6 +171,12 @@ public class PeerClient {
      */
     public long getLastKeepAliveResponseTime() {
         return n2NPeerFetcher.getLastKeepAliveResponseTime();
+    }
+
+    public Optional<AcceptVersion> getProtocolVersion() {
+        return n2NPeerFetcher != null
+                ? n2NPeerFetcher.getProtocolVersion()
+                : Optional.empty();
     }
 
     /**


### PR DESCRIPTION
 ## Summary

  Adds the transport-level hooks needed by relay-style node implementations such as Yano.

  This PR introduces:

  - optional outbound local source-port binding in `NodeClientConfig` / `Session`
  - fallback to OS-assigned ephemeral ports when local bind fails
  - `SO_REUSEADDR` support for source-port reuse attempts
  - inbound server connection admission hooks via `ServerConnectionListener`
  - accept/reject decisions before protocol handling
  - handshake-complete, handshake-failed, and close callbacks for inbound sessions
  - server-side peer-sharing mini-protocol support through `PeerSharingServerAgent`
  - negotiated handshake capability exposure from `PeerClient` / `N2NPeerFetcher`
  - improved N2N handshake negotiation for peer-sharing and query capability values

  ## Motivation

  Relay-capable applications need more control over connection lifecycle than a simple indexer client:

  - reject inbound connections early when admission limits are exceeded
  - observe negotiated protocol capabilities
  - track inbound connection lifecycle
  - optionally reuse the advertised relay port as the outbound source port
  - serve peer-sharing responses from application-managed peer state

  These hooks keep Yaci policy-free while allowing higher-level applications to implement relay connection management.

  ## Compatibility

  Defaults preserve existing behavior:

  - outbound source-port binding is disabled unless configured
  - local-bind fallback is opt-in
  - server connection listener is optional
  - existing `NodeServer` and `PeerClient` usage continues to work unchanged
