### PR TITLE
feat: Leios network mini-protocols (LeiosNotify/LeiosFetch) for Musashi — transport-only [ADR 0007]

### DIFF
--- a/adr/0007-linear-leios-musashi-network-mini-protocols.md
+++ b/adr/0007-linear-leios-musashi-network-mini-protocols.md
@@ -1,0 +1,443 @@
+# ADR 0007: Linear Leios (Musashi) Network Mini-Protocols — Transport-Only (Consolidated)
+
+Date: 2026-07-01
+
+Status: Proposed 
+
+
+## Context
+
+**Linear Leios (CIP-0164)** extends Ouroboros Praos with an endorsement layer
+(Endorser Blocks + committee votes + BLS certificates) to raise throughput while
+preserving Praos security. A prototype testnet — **"Musashi"** — is live (network
+magic **164**, Dijkstra era / PV12). It adds **two new node-to-node (N2N)
+mini-protocols** on the existing Ouroboros mux:
+
+- **`LeiosNotify`** (protocol **18**) — pull-based dissemination: a peer announces
+  new Endorser Blocks (EBs), offers EB bodies / their transaction closures for
+  eager fetching, and diffuses votes.
+- **`LeiosFetch`** (protocol **19**) — pull-based fetch: the client requests a full
+  EB, a bitmap-selected subset of an EB's transactions, (in the full spec) votes,
+  or a slot range of EBs; the server streams the response.
+
+Ranking Blocks (the Praos-chain blocks that will carry the Leios certificate)
+continue to flow over the **existing** ChainSync / BlockFetch protocols and are
+**out of scope** here.
+
+### Why a transport-only PR, and why two profiles
+
+The blueprint marks the heavy Leios structures as not-yet-final (`endorser_block`,
+`announcement_header`, `bitmaps`, `tx`, and vote fields are `any` / `TODO` /
+`REVIEW`). The **framing** of the mini-protocols (states, agencies, message tags,
+request/response arity) is stable enough to implement, while the **contents** of
+the messages are still moving. This PR cuts exactly at that boundary: implement
+the two state machines and message envelopes; carry every payload as an
+**opaque CBOR value** (`LeiosRawCbor` / `byte[]`); defer all block/tx/vote/cert
+decoding and BLS to a later PR.
+
+Critically, the wire that Musashi speaks **today** differs from the current
+Blueprint `main` in several envelope details. Rather than guess, this ADR pins
+**two profiles** against **exact commits** and implements the prototype first:
+
+- **`MUSASHI_PROTOTYPE`** — matches what the testnet exercises now; the initial,
+  default, feature-gated target.
+- **`BLUEPRINT_CURRENT`** — the fuller `main` shape; a follow-up profile, inactive
+  until a peer supports it.
+
+### Sources reviewed
+
+- **cardano-blueprint** (`cardano-scaling/cardano-blueprint`), the network spec of
+  record:
+  - `BLUEPRINT_CURRENT` = `main` @ **`e773b951a0697ac1a7eeb755014ddba4c1856a05`**
+  - `MUSASHI_PROTOTYPE` = `leios-prototype` @ **`188183b37081fa012fa890236edb7771f96ae92f`**
+  - Paths (both branches): `src/network/node-to-node/leios-notify/{README.md,messages.cddl}`,
+    `src/network/node-to-node/leios-fetch/{README.md,messages.cddl}`,
+    `src/network/node-to-node/handshake/README.md`,
+    `src/codecs/base.cddl` (`slotNo = word64`, `hash = bstr .size 32`,
+    `word16 = uint .size 2`, `word32 = uint .size 4`)
+- **CIP-0164** (Leios) — referenced by the blueprint pages for rationale.
+- **Yaci codebase** — existing mini-protocol scaffolding this PR mirrors
+  (`core/.../protocol/{peersharing,appmsg}/**`, `Agent`/`State`/`Serializer`,
+  `handshake/util/N2NVersionTableConstant.java`, helper `*Sync*` fetchers).
+
+## Decision
+
+Add Yaci core support for the two Leios N2N mini-protocols as a **feature-gated,
+profile-aware, transport-only** implementation:
+
+- `LeiosNotify` = mini-protocol **18**, `LeiosFetch` = mini-protocol **19**.
+- Default target = `MUSASHI_PROTOTYPE`; structure the code so `BLUEPRINT_CURRENT`
+  can be added without touching ChainSync / BlockFetch / Store.
+- Keep **all** payload-bearing values opaque (`LeiosRawCbor` / `byte[]` CBOR):
+  announcements, Endorser Blocks, transaction lists, votes, certificates, vote
+  deliveries.
+- The network layer may parse **envelope tags, points, `(slot, voter_id)`
+  selectors, slot ranges, envelope size scalars (`eb_size`), and the bitmap map**
+  — nothing else. It must not decode transactions, blocks, EB maps, votes, BLS
+  signatures, or ledger structures.
+- Opaque means "no domain decoding". It does not require byte-for-byte
+  preservation of inbound CBOR encodings through Yaci's existing `DataItem`
+  parser/re-serializer unless the implementation adds a dedicated
+  byte-preserving extraction path.
+
+### Non-goals (this PR does NOT do)
+
+Dijkstra block/header/body decoding; transaction CBOR deserialization; EB-map →
+transaction-reference decoding; vote/certificate decoding; BLS verification;
+Ledger or Yaci-Store persistence changes; EB-closure validation; request
+scheduling beyond a small safe queue; full catch-up/range support unless the
+target profile and peer already support it. Those are follow-up PRs, once the
+block/ledger formats are pinned.
+
+## Protocol Baseline
+
+Standard Ouroboros framing applies: each mini-protocol is a replicated state
+machine multiplexed over the shared connection; messages are CBOR arrays whose
+first element is an integer tag; **agency** decides who sends next. Yaci already
+implements the mux, the `0x8000` responder flag, and >64 KiB payload
+segmentation — **no mux changes are needed**. Protocol ids 18/19 are within Yaci's
+valid mux range (`Agent` warns only above 199) and do not collide with Yaci's
+app-layer squatters (mini-protocol ids 100/101/102).
+
+### LeiosNotify (protocol 18)
+
+State machine (identical in both profiles): `StIdle` (client agency) →
+`MsgLeiosNotificationRequestNext` → `StBusy` (server agency) → one
+announcement/offer → `StIdle`; `MsgClientDone` from `StIdle` → `StDone`.
+
+| State  | Agency | 
+| :----- | :----- |
+| StIdle | Initiator (client) |
+| StBusy | Responder (server) |
+| StDone | terminal |
+
+**`MUSASHI_PROTOTYPE` (188183b):**
+
+```cddl
+msgLeiosNotificationRequestNext = [0]
+msgLeiosBlockAnnouncement       = [1, announcement]        ; announcement = any (opaque)
+msgLeiosBlockOffer              = [2, point, eb_size]       ; eb_size = word32
+msgLeiosBlockTxsOffer           = [3, point]
+msgLeiosVotes                   = [4, [1* vote]]            ; inline opaque votes
+msgClientDone                   = [5]
+point = [slot, eb_hash]                                    ; explicit array
+vote  = [slot, eb_hash, voter_id: word16, vote_signature: bytes .size 48]
+```
+
+**`BLUEPRINT_CURRENT` (e773b95):**
+
+```cddl
+msgLeiosNotificationRequestNext = [0]
+msgLeiosBlockAnnouncement       = [1, announcement_header]  ; = any (opaque)
+msgLeiosBlockOffer              = [2, point]                ; (README table shows "point, size")
+msgLeiosBlockTxsOffer           = [3, point]
+msgLeiosVotesOffer              = [4, [1* (slot, voter_id)]]; vote *identifiers*, not bodies
+msgClientDone                   = [5]
+point    = (slot, eb_hash)                                 ; CDDL group
+voter_id = word16                                          ; REVIEW: size
+```
+
+Prototype → current differences: (a) prototype `BlockOffer` carries **`eb_size`**;
+`main`'s CDDL body omits it (its README table shows `point, size`, i.e. `main` is
+internally inconsistent and the prototype's `[2, point, eb_size]` is the concrete
+live form). (b) Prototype **tag 4 = inline vote bodies** (`MsgLeiosVotes`); `main`
+tag 4 = **vote identifiers** (`MsgLeiosVotesOffer`, `(slot, voter_id)` pairs).
+(c) Prototype `point` is an explicit array `[slot, eb_hash]`; `main` writes it as a
+CDDL group `(slot, eb_hash)`.
+
+| Tag | Prototype message | Current message | From → To | Agency | Yaci handling |
+| :-- | :---------------- | :-------------- | :-------- | :----- | :------------ |
+| 0 | `MsgLeiosNotificationRequestNext` `[0]` | same | StIdle→StBusy | client | send |
+| 1 | `MsgLeiosBlockAnnouncement` `[1, announcement]` | `[1, announcement_header]` | StBusy→StIdle | server | **opaque** announcement |
+| 2 | `MsgLeiosBlockOffer` `[2, point, eb_size]` | `[2, point]` | StBusy→StIdle | server | parse `point` (+`eb_size` in prototype) |
+| 3 | `MsgLeiosBlockTxsOffer` `[3, point]` | same | StBusy→StIdle | server | parse `point` |
+| 4 | `MsgLeiosVotes` `[4, [1* vote]]` (bodies) | `MsgLeiosVotesOffer` `[4, [1*(slot,voter_id)]]` (ids) | StBusy→StIdle | server | prototype: **opaque** vote list; current: parse `(slot,voter_id)` |
+| 5 | `MsgClientDone` `[5]` | same | StIdle→StDone | client | send |
+
+### LeiosFetch (protocol 19)
+
+**`MUSASHI_PROTOTYPE` (188183b)** — smaller; range/votes not yet implemented:
+
+```cddl
+msgLeiosBlockRequest    = [0, point]
+msgLeiosBlock           = [1, endorser_block]              ; endorser_block = { * hash => word32 } (opaque here)
+msgLeiosBlockTxsRequest = [2, point, bitmaps]
+msgLeiosBlockTxs        = [3, point, bitmaps, tx_list]     ; server echoes point + bitmaps
+msgClientDone           = [9]
+; msgLeiosBlockRangeRequest / Next / Last  — commented out: "not implemented yet in leios-prototype"
+point   = [slot, eb_hash]
+bitmaps = { * word16 => word64 }                           ; indefinite map; 64-tx window => 64-bit presence
+tx_list = [ *tx.tx ]                                       ; each tx opaque
+```
+
+Prototype states: `StIdle` (client), `StBlock`, `StBlockTxs` (server), `StDone` —
+the prototype subset of the full state machine (no `StVotes` / `StBlockRange`).
+
+**`BLUEPRINT_CURRENT` (e773b95)** — the fuller intended protocol:
+
+```cddl
+msgLeiosBlockRequest           = [0, point]
+msgLeiosBlock                  = [1, endorser_block]
+msgLeiosBlockTxsRequest        = [2, point, bitmaps]
+msgLeiosBlockTxs               = [3, tx_list]              ; (README table shows "point, bitmaps, tx_list")
+msgLeiosVotesRequest           = [4, [1* (slot, voter_id)]]
+msgLeiosVoteDelivery           = [5, [1* vote]]
+msgLeiosBlockRangeRequest      = [6, start_slot, end_slot, start_hash, end_hash]
+msgLeiosNextBlockAndTxsInRange = [7, endorser_block, tx_list]
+msgLeiosLastBlockAndTxsInRange = [8, endorser_block, tx_list]
+msgClientDone                  = [9]
+vote = [ election_id: slotNo (word64), persistent_voter_id: word16,
+         eligibility_signature: bytes .size 48, endorser_block_hash: hash,
+         vote_signature: bytes .size 48 ]
+```
+
+Current states: `StIdle`, `StBlock`, `StBlockTxs`, `StVotes`, `StBlockRange`
+(loops to itself on tag 7, returns to `StIdle` on tag 8), `StDone`.
+
+| Tag | Prototype | Current | From → To | Agency |
+| :-- | :-------- | :------ | :-------- | :----- |
+| 0 | `MsgLeiosBlockRequest` `[0, point]` | same | StIdle→StBlock | client |
+| 1 | `MsgLeiosBlock` `[1, endorser_block]` (opaque) | same | StBlock→StIdle | server |
+| 2 | `MsgLeiosBlockTxsRequest` `[2, point, bitmaps]` | same | StIdle→StBlockTxs | client |
+| 3 | `MsgLeiosBlockTxs` `[3, point, bitmaps, tx_list]` | `[3, tx_list]` | StBlockTxs→StIdle | server |
+| 4 | — | `MsgLeiosVotesRequest` `[4, [1*(slot,voter_id)]]` | StIdle→StVotes | client |
+| 5 | — | `MsgLeiosVoteDelivery` `[5, [1* vote]]` | StVotes→StIdle | server |
+| 6 | — | `MsgLeiosBlockRangeRequest` `[6, start_slot, end_slot, start_hash, end_hash]` | StIdle→StBlockRange | client |
+| 7 | — | `MsgLeiosNextBlockAndTxsInRange` `[7, endorser_block, tx_list]` | StBlockRange→StBlockRange | server |
+| 8 | — | `MsgLeiosLastBlockAndTxsInRange` `[8, endorser_block, tx_list]` | StBlockRange→StIdle | server |
+| 9 | `MsgClientDone` `[9]` | same | StIdle→StDone | client |
+
+Prototype → current differences: prototype `BlockTxs` **echoes `point, bitmaps`**
+before `tx_list` (`main`'s CDDL body says `[3, tx_list]` but its README table
+lists `point, bitmaps, tx_list` — so the echoed form is what's live); votes (4/5)
+and range (6/7/8) exist only in `main`. The vote shape also differs (4-field
+prototype vs 5-field current) — irrelevant at this layer since votes stay opaque.
+
+The **first Yaci PR implements only the prototype `LeiosFetch` set**
+(`BlockRequest`, `Block`, `BlockTxsRequest`, `BlockTxs`, `Done`); votes/range
+message classes may be reserved as TODOs but must not be exposed as working API
+until a target peer/profile supports them.
+
+## Yaci Design
+
+### Package layout
+
+Add under `core/src/main/java/com/bloxbean/cardano/yaci/core/`:
+
+```
+protocol/leios/                 (shared)
+  LeiosProtocolProfile.java     (enum: MUSASHI_PROTOTYPE, BLUEPRINT_CURRENT[inactive])
+  LeiosPoint.java               (long slot, byte[] ebHash)
+  LeiosRawCbor.java             (byte[] cbor; opaque wrapper, hex only as a derived helper)
+  LeiosTxBitmap.java            (ordered map: int window -> long mask; fromIndices(...), firstN(int))
+  messages/ , serializers/      (shared message bases if useful)
+protocol/leiosnotify/           (LeiosNotifyState, LeiosNotifyStateBase, LeiosNotifyAgent,
+                                 [LeiosNotifyServerAgent], LeiosNotifyListener, messages/, serializers/)
+protocol/leiosfetch/            (LeiosFetchState, LeiosFetchStateBase, LeiosFetchAgent,
+                                 [LeiosFetchServerAgent], LeiosFetchListener, messages/, serializers/)
+```
+
+Reference patterns: **`protocol/peersharing/**`** (closest N2N template: enum
+`State` + `StateBase.handleInbound` tag-dispatch + `Agent` + `Listener` +
+`messages/` + `serializers/`) and **`protocol/appmsg/n2n/**`** (adds a
+`*ServerAgent`). **No new models for EB/tx/vote/cert** — they are opaque CBOR
+values on the message objects; the follow-up PR adds `model/leios/*` and
+structured decoders.
+
+### Mapping onto Yaci's mini-protocol contract
+
+- **`Agent<T>`** (`getProtocolId`, `buildNextMessage`, `processResponse`,
+  `isDone`): `LeiosNotifyAgent` (id 18) mirrors `PeerSharingAgent` — a queue of
+  outstanding `RequestNext`s, `MsgClientDone` on shutdown, `reset()` → `StIdle`.
+  `LeiosFetchAgent` (id 19) tracks the outstanding request so `processResponse`
+  can pair a response with its `LeiosPoint` (chain-sync "pending data" idiom).
+  The `0x8000` responder flag and >64 KiB segmentation are handled by the base
+  `Agent`.
+- **`State`** (`nextState`, `hasAgency`, `handleInbound`): enums per the state
+  machines above; `hasAgency(isClient)` = `isClient` in `StIdle`, `!isClient` in
+  every server-agency state (`StBusy` for Notify; `StBlock` / `StBlockTxs` /
+  `StVotes` / `StBlockRange` for Fetch), `false` in `StDone`.
+- **`StateBase.handleInbound(byte[])`**: read `array[0]` as the tag and dispatch to
+  the matching serializer (exactly like `PeerSharingStateBase.handleInbound`).
+- **`Serializer<T>`** (`co.nstant.in.cbor`): one enum-singleton per message.
+  `LeiosPoint` en/decodes `[slot (uint), eb_hash (bstr32)]`; opaque payload fields
+  are decoded only to the CBOR value boundary and stored as `LeiosRawCbor` bytes
+  using Yaci's normal CBOR serialization unless a dedicated byte-preserving
+  extractor is added. This keeps unknown/`any` structures opaque and avoids domain
+  decoding, but it is not a guarantee that inbound indefinite/canonical encoding
+  details remain byte-for-byte identical.
+- **Profile awareness lives in the serializers/agent, not the payloads.** Because
+  payloads are opaque, the only profile-divergent code is envelope arity/semantics:
+  `MsgLeiosBlockOffer` (`[2, point]` vs `[2, point, eb_size]`), notify tag 4
+  (opaque bodies vs `(slot, voter_id)` ids), and `MsgLeiosBlockTxs`
+  (`[3, point, bitmaps, tx_list]` vs `[3, tx_list]`). Serializers switch on
+  `LeiosProtocolProfile`; decoders SHOULD accept the extra fields defensively.
+
+### Shared models & bitmap handling
+
+`LeiosTxBitmap` is a CBOR map `word16 window → word64 mask`. Implementation:
+encode as an **indefinite-length** map for prototype compatibility; decode both
+indefinite and definite maps; preserve key order deterministically for tests;
+document the bit convention as **64 transactions per window, tx index 0 = MSB of
+window 0** *(bit convention is an implementation detail not pinned by the CDDL
+comment — confirm against a live peer)*; provide `firstN(int count)` and
+`fromIndices(...)` helpers **without decoding transactions**.
+
+### Agents
+
+**`LeiosNotifyAgent`** (id 18) — states `StIdle`/`StBusy`/`StDone`. Outbound from
+`StIdle`: `MsgLeiosNotificationRequestNext`, `MsgClientDone`. Inbound in `StBusy`
+(prototype): `MsgLeiosBlockAnnouncement` (opaque), `MsgLeiosBlockOffer`
+(`LeiosPoint` + `ebSize`), `MsgLeiosBlockTxsOffer` (`LeiosPoint`), `MsgLeiosVotes`
+(opaque list). Start with **one in-flight `RequestNext`**; pipelining deferred
+until admitted depth is documented. Listener: `onBlockAnnouncement(LeiosRawCbor)`,
+`onBlockOffer(LeiosPoint, long ebSize)`, `onBlockTxsOffer(LeiosPoint)`,
+`onVotes(List<LeiosRawCbor>)`, `onNotifyError(Throwable)`.
+
+**`LeiosFetchAgent`** (id 19) — prototype states `StIdle`/`StBlock`/
+`StBlockTxs`/`StDone`. Outbound from `StIdle`: `MsgLeiosBlockRequest`,
+`MsgLeiosBlockTxsRequest`, `MsgClientDone`. Inbound: `MsgLeiosBlock` (opaque EB),
+`MsgLeiosBlockTxs` (echoed `LeiosPoint` + `LeiosTxBitmap` + opaque `tx_list`).
+**One outstanding request per peer** (small FIFO ok; concurrency deferred). Retain
+echoed point/bitmap even when the request context already knows them. Public:
+`requestBlock(LeiosPoint)`, `requestBlockTxs(LeiosPoint, LeiosTxBitmap)`,
+`done()`. Listener: `onBlock(LeiosPoint requested, LeiosRawCbor eb)`,
+`onBlockTxs(LeiosPoint requested, LeiosPoint response, LeiosTxBitmap bitmap,
+LeiosRawCbor txList)`, `onFetchError(Throwable)`.
+
+### Handshake & activation
+
+Leios agents are **inactive unless explicitly configured**. Add a Musashi helper
+(in `N2NVersionTableConstant` or an equivalent builder): network magic **164**,
+negotiated N2N version **≥ `PROTOCOL_V15`** *(assumed Leios-enabling version;
+Yaci already advertises up to V15 — confirm the exact version and any version-data
+capability bit from a live handshake)*. Attach the two Leios agents **only** when
+the accepted version is compatible; otherwise the client behaves exactly as today.
+The helper must **not** replace the existing app-layer version-100 path; ids 18/19
+route through the existing mux dispatch by protocol id.
+
+### Helper-level integration
+
+Keep it small in the first PR: a focused `LeiosNetworkClient` (or a builder method
+on an existing peer client) that wires the handshake + notify + fetch agents to
+`TCPNodeClient(host, port, handshakeAgent, agents...)`. First usable workflow:
+(1) connect to a Musashi peer, magic 164; (2) negotiate a Leios-capable version;
+(3) start `LeiosNotify`; (4) on `BlockOffer`, optionally `requestBlock(point)`;
+(5) on `BlockTxsOffer`, optionally `requestBlockTxs(point, bitmap)`; (6) emit raw
+CBOR events, no Store persistence.
+
+## Current testnet posture (conservative)
+
+Treat `BlockAnnouncement`/`Block`/`Votes`/`tx_list` as opaque CBOR values.
+Request EB txs only after a `BlockTxsOffer` for the same `LeiosPoint`. Don't
+request all txs of a large EB by default — start with `LeiosTxBitmap.firstN(64)` and make callers opt
+into larger windows. Keep request timeouts and disconnect handling explicit
+(prototype relays may reset on unsupported/poorly-timed requests). Log protocol
+id, state, tag, EB point, EB size, bitmap windows — **not** raw tx payloads. This
+layer is **not** a stable API promise; it validates Yaci's mux/state-machine/
+request-response before block-serialization work starts.
+
+## Phased plan
+
+1. **Network skeleton & fixtures** — shared models, `LeiosProtocolProfile`, id
+   constants 18/19, fixture tests for prototype tags/shapes, CDDL source comments
+   with the two commit hashes. *Exit:* all prototype envelopes encode/decode by
+   profile; no
+   block/tx/vote/cert deserializer exists.
+2. **LeiosNotify** — state, messages, serializers, agent, listener; transition
+   tests for request-next, each notification variant, done. *Exit:* agent emits
+   listener events with raw payloads; does not self-fetch.
+3. **LeiosFetch** — state, messages, serializers, agent, listener; bitmap helper +
+   golden tests; one-request-at-a-time queue. *Exit:* requests EB bodies and tx
+   payloads; responses preserve opaque CBOR payload values; bitmap encoding
+   covered by golden tests.
+4. **Handshake & smoke client** — Musashi version-table helper, optional agent
+   wiring, a default-disabled smoke/integration test. *Exit:* a developer can
+   connect to a Musashi relay, observe notifications, optionally fetch opaque EB/
+   tx-list CBOR values; existing ChainSync/BlockFetch/app-message tests unchanged.
+5. **Blueprint-drift follow-up** — add the `BLUEPRINT_CURRENT` profile (`main`
+   shape) when needed, incl. `VotesOffer`/`VotesRequest`/`VoteDelivery` and the
+   range messages, only after a peer supports them. *Exit:* behavior selectable by
+   profile; prototype-only shapes don't leak into stable public APIs.
+
+## Verification
+
+- **Unit (serializers):** for Yaci-constructed messages, assert encode → decode →
+  re-encode matches the expected profile encoding; for inbound opaque payloads,
+  assert tag/arity/profile handling and payload value preservation without domain
+  decoding. Require byte-for-byte inbound payload preservation only if a dedicated
+  byte-preserving extractor is implemented. Validate sample encodings against the
+  **vendored `messages.cddl` at both commits** (prototype required; current as the
+  follow-up profile lands).
+- **Unit (state machines):** table-driven legal-transition + agency tests per
+  state; illegal messages rejected (mirror `peersharing` tests).
+- **Bitmap golden tests:** indefinite-map encoding; `firstN`/`fromIndices` MSB-
+  first convention; definite-map decode tolerance.
+- **Integration (default-disabled):** drive `LeiosNetworkClient` against a Musashi
+  relay (magic 164); assert the notify→fetch loop yields ≥1 EB body and its tx
+  closure as opaque CBOR bytes, and that a non-Leios peer still connects with the
+  Leios agents simply inactive.
+
+## Consequences
+
+**Positive:** small, reviewable, self-contained surface that lands Leios transport
+independently of still-moving payload formats; the opaque-CBOR boundary means
+later EB/tx/vote/cert churn touches only the follow-up PR; two pinned profiles let
+Yaci experiment on the live testnet today while keeping a clean path to the final
+shape; zero risk to existing ChainSync/BlockFetch/PeerSharing (agents attach only
+on a Leios-capable handshake). Resolves the "read the ids from the blueprint, don't
+guess" item: **18 = LeiosNotify, 19 = LeiosFetch**.
+
+**Negative / costs:** two state machines + ~a dozen prototype message classes +
+serializers to build against a **proposed** spec (mitigated by opaque payloads,
+pinned commits, and CDDL fixture tests); without payload decoding the PR yields
+**opaque CBOR bytes** — a transport foundation whose end-to-end value needs the
+follow-up PR; profile divergence adds a little serializer branching.
+
+## Risks & unknowns
+
+| Risk | Mitigation |
+| :--- | :--------- |
+| **Provisional spec / tags** (`any`/`REVIEW`, may change to final CIP-0164) | Opaque payloads; pin both profiles to exact commits; CDDL fixture tests; isolate in new packages. |
+| **Prototype ≠ current Blueprint** (`BlockOffer` `eb_size`, tag-4 votes vs offer, `BlockTxs` echo) | Explicit `LeiosProtocolProfile`; implement prototype first; decode extra fields defensively. |
+| **Bitmap encoding** (definite-map or reversed bit order may be rejected by prototype peers) | Encode outbound bitmaps as indefinite-length maps; document MSB-first 64-tx windows; golden tests; decode inbound maps without changing their transaction-index semantics. |
+| **Premature / oversized requests cause disconnects** | Request txs only after an offer; default `firstN(64)`; explicit timeouts + disconnect handling. |
+| **Large payloads exceed one mux segment** | Reuse `Agent`'s existing >64 KiB segmentation. |
+| **Handshake version / magic** (v15 assumed; capability bit unknown) | Yaci already advertises V15; confirm negotiated version + version-data from a live handshake; keep Musashi helper isolated from mainnet/preprod. |
+| **Pipeline depth** (admitted depth is `TODO` in the spec) | Start with one in-flight request; make it configurable once documented. |
+| **Ids 18/19 vs code assuming the old mini-protocol set** | Route via existing mux dispatch by id; add tests asserting 18/19 don't collide. |
+| **Scope creep into payload decoding** | Hard non-goals list; opaque `LeiosRawCbor`; block-serialization is a separate PR. |
+
+## Open questions
+
+- Exact Leios-enabling N2N handshake version and any version-data capability flag
+  (confirm from a live Musashi handshake).
+- Admitted pipeline depth for LeiosNotify / LeiosFetch without peer penalties.
+- Final bitmap structure (map vs roaring bitmap vs other) and the definitive
+  bit-order convention.
+- Whether final `LeiosFetch` keeps echoed `point,bitmaps` on `BlockTxs` or adopts
+  the `main`-branch `[3, tx_list]` body.
+- Whether `tx_list` should later surface as one CBOR blob or a list of per-tx CBOR
+  blobs (a block-serialization-PR decision).
+
+## Acceptance criteria
+
+- This ADR exists and supersedes 0005/0006.
+- No Store dependency; no block-level serializers/deserializers added.
+- `LeiosNotify` (18) and `LeiosFetch` (19) are feature-gated and profile-aware.
+- Musashi prototype behavior is testable with raw-CBOR payloads.
+- Existing Yaci protocols continue to pass their current tests.
+
+## Key files / new packages
+
+**New:** `core/.../protocol/leios/{LeiosProtocolProfile,LeiosPoint,LeiosRawCbor,LeiosTxBitmap}.java`;
+`core/.../protocol/leiosnotify/**`; `core/.../protocol/leiosfetch/**`;
+`helper/.../LeiosNetworkClient.java` (+ `LeiosDataListener`).
+**Touched (only if a live handshake requires it):**
+`core/.../protocol/handshake/util/N2NVersionTableConstant.java` (Musashi helper);
+helper client wiring to attach the Leios agents when a Leios-capable version is
+negotiated.
+**Reference patterns:** `core/.../protocol/peersharing/**`, `core/.../protocol/appmsg/n2n/**`.
+**Deferred to the block-serialization PR:** `model/leios/*` (EndorserBlock, txs,
+votes, certificate), structured decoders for the opaque payloads, BLS
+verification, Dijkstra `Era`/`Block` changes, Yaci-Store integration.

--- a/adr/0008-leios-musashi-code-review-findings-fable.md
+++ b/adr/0008-leios-musashi-code-review-findings-fable.md
@@ -1,0 +1,443 @@
+# ADR 0008: Leios (Musashi) Mini-Protocol Implementation — Code Review Findings
+
+Date: 2026-07-02
+
+Status: Proposed
+
+> Authored by Claude (Fable 5). This ADR records the verified findings of a
+> multi-agent code review (xhigh effort: 6 finder agents across independent
+> correctness/cleanup angles, 44 candidate findings, each adversarially
+> verified by an independent agent; 4 refuted, survivors deduplicated to 15)
+> over the Leios mini-protocol implementation on branch
+> `feat/leios_protocol_impl`. Scope: `core/.../protocol/leios/`,
+> `core/.../protocol/leiosfetch/`, `core/.../protocol/leiosnotify/`, the
+> `N2NVersionTableConstant` handshake change, `helper/LeiosNetworkClient.java`,
+> `helper/listener/LeiosDataListener.java`, and related tests.
+>
+> Companions: ADR 0005 / 0006 / 0007 (design and plan records for the same
+> implementation). This document is the review record against that design and
+> the input for the remediation PR(s).
+
+## Context
+
+The Leios implementation (per ADR 0007) adds two client-side N2N mini-protocol
+agents — `LeiosNotifyAgent` (mux protocol 18) and `LeiosFetchAgent` (mux
+protocol 19) — plus CBOR serializers that treat Leios payloads as opaque raw
+CBOR, and a `LeiosNetworkClient` helper facade targeting the Musashi prototype
+testnet (magic 164, N2N version ≥ 15).
+
+The review confirmed the overall state-machine and serializer structure is
+sound, but found a recurring failure mode across the highest-severity items:
+**error paths are one-way streets**. Any parse error, listener exception, or
+failed Netty write leaves an agent in a state that nothing can drive out of —
+the connection stays up, `isLeiosActive()` stays true, and the stream is
+silently dead. A second theme is that the inbound mux pipeline's
+decode→re-encode step is not byte-faithful for certain wire-legal CBOR
+encodings, which can desync the stream entirely.
+
+## Findings
+
+Ranked most-severe first. Verdicts are from the independent verification pass
+(`CONFIRMED` = mechanism proven against the code and/or by execution;
+`PLAUSIBLE` = mechanism real but trigger not proven wire-legal).
+
+### Critical — protocol/stream-breaking
+
+#### 1. Empty indefinite-length CBOR maps corrupt the leiosfetch stream — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/serializers/LeiosCborUtil.java:56`
+
+The known cbor-java 0.9 bug — an empty chunked map `BF FF` re-encodes to a
+lone `BF`, dropping the break byte — is worked around only on the **outbound**
+path (`serializeTxBitmapBytes`). The inbound mux path
+(`MiniProtoStreamingByteToMessageDecoder`) decodes and **re-encodes** every
+frame with the same buggy encoder, and has no counterpart workaround.
+
+Failure scenario (mechanism proven by executing cbor-java 0.9): client calls
+`requestFirstBlockTxs(point, 0)` or `requestBlockTxs(point, LeiosTxBitmap.empty())`;
+the node echoes `msgLeiosBlockTxs [3, point, {_}, txList]` with the empty
+indefinite bitmap encoded as `BF FF`. The re-encoded payload is one byte
+shorter (verified: 41-byte frame → 40 bytes), fails CBOR parsing
+("Unexpected end of stream"), surfaces as `MsgLeiosFetchError` (request queue
+cleared, no txs delivered) — and the 1-byte length mismatch leaves a stray
+break byte in the per-protocol buffer, **desyncing every subsequent leiosfetch
+message on the connection**. The same corruption fires for any fetched empty
+endorser block whose map is encoded as `BF FF`.
+
+#### 2. Notify stream stalls permanently after any parse error — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyAgent.java:69`
+
+On `MsgLeiosNotifyError` or an unexpected inbound message, `receiveResponse`
+resets to `StIdle` and returns **before** `requestNextIfStreaming()`. Nothing
+else drives the agent.
+
+Failure scenario: the node sends one message the client cannot parse (a
+new/unknown notify tag after a node upgrade, or any malformed frame) —
+`LeiosNotifyStateBase.deserialize` converts it to `MsgLeiosNotifyError`,
+`onNotifyError` fires, and no further `MsgLeiosNotificationRequestNext` is
+ever sent. The client silently stops receiving all Leios block announcements,
+offers, and votes while the connection stays up and `isLeiosActive()` reports
+true. No disconnect/reconnect recovery occurs.
+
+#### 3. Fetch error recovery can pair a response with the wrong request — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchAgent.java:204`
+(also `:208`, `:89`)
+
+`clearOutstandingAndReturnIdle` forces the state back to `StIdle` and bumps
+`writeGeneration` while a request write may already be on the wire, so the
+server's response to that in-flight request gets paired with the **next**
+outstanding request. It also silently discards all queued requests with no
+per-request error.
+
+Failure scenario: client sends `MsgLeiosBlockRequest(A)` (write in flight or
+flushed), then a garbage segment on protocol 19 (e.g. finding 1) produces
+`MsgLeiosFetchError`: state resets, A's write callback is treated as stale
+even though A reached the server. The application calls `requestBlock(B)`;
+the server replies with block(A) first, which arrives in state `StBlock` with
+`outstandingRequest = B`, so `handleBlock` invokes
+`listener.onBlock(requestedPoint=B, endorserBlock=blockOfA)` — **block A is
+delivered under point B**. The subsequent block(B) response is rejected as
+invalid. Any other queued requests vanish (`requestQueue.clear()`), so their
+callers wait forever with neither a response nor an error callback.
+
+#### 4. Failed Netty write permanently wedges the fetch agent — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchAgent.java:227`
+(also `:229`)
+
+`writeNextMessageIfReady` sets `writeInFlight = true`, but `Agent.writeMessage`
+only invokes the completion callback on write **success** — a failed or skipped
+write (channel goes inactive between the `isChannelActive()` check and the
+write, or `writeAndFlush` fails) never runs `completeWrite`, so `writeInFlight`
+is stuck true with no generation bump.
+
+Failure scenario: TCP drops in that window; every later
+`requestBlock()`/`requestBlockTxs()` is accepted and enqueued but
+`buildNextMessage`/`writeNextMessageIfReady` permanently return early —
+requests are never sent, no error is surfaced. Recovery only happens via a
+disconnect-triggered `reset()`; with `autoReconnect(false)` or retries
+exhausted, the fetch agent silently stalls forever.
+
+#### 5. A throwing user listener stalls both agents — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyAgent.java:83`
+
+An exception thrown by any user listener during notification dispatch
+propagates out of `super.receiveResponse` **before** `requestNextIfStreaming()`
+runs — a distinct trigger from finding 2, with no `onNotifyError` callback at
+all.
+
+Failure scenario: a `LeiosDataListener.onBlockAnnouncement` (or
+`onBlockOffer`/`onVotes`) implementation throws once (e.g. a transient NPE in
+application code). The exception skips `requestNextIfStreaming()`, unwinds
+through `MiniProtoClientInboundHandler.channelRead` into Netty's tail handler
+(logged, channel stays open), and no `RequestNext` is ever sent again. The
+same pattern in `LeiosFetchAgent.receiveResponse` (listener throwing in
+`onBlock`/`onBlockTxs` skips `writeNextMessageIfReady`) strands queued fetch
+requests until the next `requestBlock` call. Listener dispatch should be
+wrapped (as elsewhere in yaci's helper listeners).
+
+### High — lifecycle and handshake
+
+#### 6. Notify agent lacks an in-flight write guard — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyAgent.java:62`
+(also `:142`)
+
+Unlike `LeiosFetchAgent`, `LeiosNotifyAgent` has no `writeInFlight` guard:
+`currentState` remains `StIdle` until the asynchronous Netty write-future
+callback runs `sendRequest`, so a check-then-act race lets a second client
+message be written while a `MsgLeiosNotificationRequestNext` is still in
+flight.
+
+Failure scenario: `LeiosNetworkClient.shutdown()` runs while a `RequestNext`
+write has not yet completed: `buildNextMessage` sees `StIdle` + `shutDown` and
+writes `MsgClientDone` as well; the peer receives ClientDone while it has
+agency in `StBusy` and aborts the connection as a protocol violation. Locally
+the ClientDone callback's `sendRequest` no-ops, so the agent never reaches
+`StDone` and `isDone()` stays false.
+
+#### 7. `shutdown()` never sends ClientDone in the normal streaming state — CONFIRMED
+
+`helper/src/main/java/com/bloxbean/cardano/yaci/helper/LeiosNetworkClient.java:84`
+(also `:82`)
+
+`shutdown()` tries to send the notify `MsgClientDone` via
+`leiosNotifyAgent.sendNextMessage()`, but in the steady streaming state the
+notify agent sits in `StBusy` (client has no agency, `buildNextMessage`
+returns null), so nothing is written. The same applies to
+`leiosFetchAgent.done()` when a fetch response is outstanding. The socket is
+then closed abruptly: the Musashi peer observes a mini-protocol violation /
+unclean disconnect instead of graceful termination.
+
+#### 8. Handshake refusal passes null `AcceptVersion` to `onLeiosNotActivated` — CONFIRMED
+
+`helper/src/main/java/com/bloxbean/cardano/yaci/helper/LeiosNetworkClient.java:188`
+(also `:186`)
+
+The `handshakeError` adapter forwards `handshakeAgent.getProtocolVersion()`,
+but `HandshakeAgent` explicitly calls `setProtocolVersion(null)` before firing
+`handshakeError` — so the callback receives null, unlike every other
+invocation site. A listener that dereferences it (e.g.
+`acceptVersion.getVersionNumber()`) throws NPE inside the handshake listener
+`forEach`, aborting notification of remaining listeners.
+
+#### 9. Client-initiated shutdown fires `onDisconnect` — CONFIRMED
+
+`helper/src/main/java/com/bloxbean/cardano/yaci/helper/LeiosNetworkClient.java:253`
+
+`handleDisconnect` fires `LeiosDataListener.onDisconnect` even for a
+client-initiated `shutdown()` (Session dispose → closeFuture →
+`agent.disconnected()`), so applications cannot distinguish an intentional
+close from a lost connection. The bundled `LeiosMusashiSmokeTest` has to
+hand-roll a `stopping` AtomicBoolean to suppress the spurious callback — the
+tell that the API is missing this state.
+
+#### 10. `isLeiosCompatible` treats any v15+ node as Leios-capable — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/handshake/util/N2NVersionTableConstant.java:120`
+(also `:121`)
+
+Any negotiated N2N version in 15..99 with a matching network magic is treated
+as Leios-capable, but v15 is a regular cardano-node version ("srv support" per
+the constant's own comment) that implies nothing about Leios mini-protocols
+being served.
+
+Failure scenario: a user builds `LeiosNetworkClient(host, port, PREPROD_MAGIC)`
+against a future cardano-node release that negotiates v15:
+`handleHandshakeComplete` activates Leios, `LeiosNotifyAgent` sends on mux
+protocol 18, and the node terminates the connection as a mux protocol
+violation — the client disconnects instead of reporting "Leios not
+supported". Gating on the Musashi-specific magic (or a dedicated capability
+flag) is the deeper fix; version ≥ 15 is a prototype-only special case baked
+into shared handshake constants.
+
+### Medium / Low — robustness and cleanups
+
+#### 11. Arity guards reject wire-legal indefinite-length arrays — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/serializers/LeiosCborUtil.java:37`
+
+`deserializePointArray`'s `items.size() != 2` check and the
+`messageItems`/`requireArity` helpers count the trailing `SimpleValue.BREAK`
+item that cbor-java appends when decoding chunked arrays, while the sibling
+decoders (`deserializeTxBitmap`, `deserializeRawCborArrayItems`) deliberately
+skip BREAK. A peer encoding a message frame or point as an indefinite-length
+array (e.g. `MsgLeiosBlockOffer` as `9F 02 <point> <eb_size> FF`) trips the
+guard → `MsgLeiosNotifyError`/`MsgLeiosFetchError` → the finding-2/3 error
+paths, even though the same message's chunked bitmap map field is explicitly
+supported.
+
+#### 12. `MsgLeiosVotes` rejects an empty votes list — PLAUSIBLE (likely spec-conformant as-is)
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosVotes.java:16`
+
+The constructor throws on an empty list, so a zero-vote `MsgLeiosVotes` would
+become a fatal `MsgLeiosNotifyError` (and, via finding 2, a stalled stream).
+However, two duplicate candidates were **refuted** during verification: the
+blueprint CDDL at the Musashi prototype commit defines
+`msgLeiosVotes = [4, [1* vote]]` — one or more votes — so the guard arguably
+matches the spec. Recommendation: keep the guard, but note it becomes a stream
+killer only in combination with finding 2; fixing finding 2 defuses this.
+
+#### 13. `toRawCbor` re-encodes instead of slicing wire bytes — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/serializers/LeiosCborUtil.java:84`
+
+Opaque payloads (endorser block, tx list, votes, announcement) are extracted
+by decoding the wire CBOR into a DataItem tree and re-encoding it, instead of
+slicing the original payload bytes. The "raw" bytes are therefore not
+guaranteed byte-identical to the wire (cbor-java always re-encodes in minimal
+form): a consumer that hashes `endorserBlock.getCbor()` to verify it against
+the announced `LeiosPoint` `ebHash` gets a mismatch on any non-minimally
+encoded field and rejects a valid block. Even when bytes match, every received
+multi-hundred-KB EB pays a full decode + re-encode + two array copies
+(`LeiosRawCbor` ctor and `getCbor`) on the hot receive path. Related
+(confirmed, lower severity): `validatedRawCborBytes` re-parses
+already-validated bytes and makes two copies on every `MsgLeiosBlock`/
+`MsgLeiosBlockTxs` serialization.
+
+#### 14. Keep-alive scheduling is left to every caller — CONFIRMED
+
+`helper/src/main/java/com/bloxbean/cardano/yaci/helper/LeiosNetworkClient.java:164`
+
+The client sends exactly one keep-alive at handshake and leaves periodic
+keep-alive to the application (the smoke test hand-rolls a 10s virtual-thread
+loop). A production user who doesn't copy that pattern gets dropped by the
+peer's inactivity timeout and sees periodic `onDisconnect` with no obvious
+cause. The client owns the connection; it should own the timer.
+
+#### 15. `BLUEPRINT_CURRENT` is dead plumbing — CONFIRMED
+
+`core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosProtocolProfile.java:5`
+
+Both agent constructors throw for `BLUEPRINT_CURRENT`, yet the profile
+parameter is threaded through every serializer `deserialize(di, profile)`,
+`requireMusashi` guard, and both `StateBase.deserialize` dispatchers — ~15
+branches no runtime path can reach, plus tests asserting the unreachable
+throws. Drop the enum value and profile parameters until a second profile
+actually exists; adding it back later is mechanical.
+
+### Refuted during verification (recorded to prevent re-litigating)
+
+- **`PROTOCOL_V15` in shared version tables breaks existing clients
+  (peer sharing / SRV addresses)** — REFUTED. Upstream ouroboros-network's
+  `NodeToNodeV_15` "SRV support" is a CIP-155 local DNS-SRV resolution feature
+  for ledger/root peers, not a peer-sharing wire change; the peer-sharing CDDL
+  (v14+, unchanged for v15/16) has no SRV/domain address type, and v15
+  handshake version data is wire-identical to v14 for everything yaci
+  implements.
+- **Notify error path resurrects a completed `StDone` state machine** —
+  REFUTED. The scenario is guarded elsewhere and not constructible.
+- **Empty `[4, []]` votes message is wire-legal** — REFUTED (×2). CDDL says
+  `1* vote`; see finding 12.
+
+## Decision
+
+Yaci is a dependency of existing critical products (yaci-store, DevKit,
+downstream chain-sync/block-fetch consumers), so remediation is **split by
+blast radius**: changes that touch code executed by every existing yaci client
+go into a separate, heavily-tested PR; everything that lives purely in the new
+Leios files ships with the Leios feature PR at no risk to existing users.
+
+### Part A — Global / shared-code changes (regression risk; heavy testing, separate PR)
+
+These modify pre-existing files on the hot path of **every** N2N/N2C
+mini-protocol (chain-sync, block-fetch, tx-submission, handshake, keep-alive,
+peer sharing). Each must be covered by a full regression pass: existing
+protocol unit/integration tests, multi-epoch sync against a real Haskell node
+(the `test-haskell-sync` regression), sync against preprod/mainnet relays, and
+a yaci-store smoke run.
+
+- **A1. Inbound mux decode→re-encode fidelity** —
+  `MiniProtoStreamingByteToMessageDecoder` / `CborSerializationUtil`
+  (root cause of findings **1**, **13** wire-fidelity, and the environment for
+  **11**).
+  - *Full fix:* stop re-encoding inbound frames; hand agents slices of the
+    original wire bytes. Fixes the empty-chunked-map corruption, makes raw
+    CBOR byte-identical to the wire (hash-verifiable EBs), and removes a
+    decode+re-encode from the receive path of every protocol.
+  - *Contained alternative:* patch only the empty-chunked-map break-byte case
+    in the re-encode step. Much smaller diff, but still global — the encoder
+    is shared by all protocols.
+  - Regression exposure: **highest** — every inbound message of every
+    protocol flows through this code.
+- **A2. `Agent.writeMessage` write-failure signal** (root cause of finding
+  **4**). Additive change: a new overload/callback invoked on write failure;
+  the existing success-only path stays byte-for-byte identical so existing
+  agents are unaffected unless they opt in. Regression exposure: low
+  (additive), but the base class is shared by all agents, so it belongs in
+  the shared PR.
+- **A3. `PROTOCOL_V15` in the shared `v4AndAbove`/`v11AndAbove` tables**
+  (already in this branch's diff; context for finding **10**). The review
+  verified v15 is wire-identical to v14 for everything yaci implements (see
+  Refuted section), but it still changes the version every existing client
+  negotiates against every peer — it must ride the global PR's regression
+  run, not the Leios PR.
+  - *De-risking alternative (recommended):* revert the shared tables to v14
+    and give `LeiosNetworkClient` its own Leios-specific version table. This
+    moves the entire item into Part B and leaves existing clients'
+    negotiation behavior untouched.
+- **A4. (Optional) `HandshakeAgent` nulling `protocolVersion` before
+  `handshakeError`** (root cause of finding **8**). Not required — the Leios
+  PR fixes it locally (B7). Touch `HandshakeAgent` only as deliberate shared
+  cleanup, if ever.
+
+### Part B — Leios-isolated changes (no regression risk; ship with the Leios PR)
+
+Everything below lives in files new on this branch (`protocol/leios/`,
+`protocol/leiosfetch/`, `protocol/leiosnotify/`, `LeiosNetworkClient`,
+`LeiosDataListener`, their tests). No existing consumer loads these classes,
+so they cannot regress existing products. If the A3 alternative is taken, the
+Leios feature PR has **zero shared-code diff**.
+
+- **B1.** Re-arm the notify loop on error paths (finding **2**): after
+  `MsgLeiosNotifyError`/invalid inbound, either re-issue `RequestNext` or
+  fail loudly — never return to silent idle.
+- **B2.** Fetch error semantics (finding **3**): on a fetch error, fail every
+  outstanding and queued request via an explicit per-request error callback
+  (or disconnect) instead of clearing the queue; never re-pair a late
+  response with the next request.
+- **B3.** Wrap user-listener dispatch in both agents (finding **5**) so an
+  application exception cannot kill the protocol loop.
+- **B4.** Local `writeInFlight` recovery (finding **4** mitigation): re-check
+  channel state / generation timeout inside `LeiosFetchAgent` so a lost write
+  cannot wedge the agent; adopt the A2 callback once the shared PR lands.
+- **B5.** In-flight write guard in `LeiosNotifyAgent` (finding **6**),
+  mirroring the fetch agent, so shutdown cannot race a `RequestNext`.
+- **B6.** Graceful shutdown (finding **7**): defer `MsgClientDone` until the
+  agent regains agency (StIdle) instead of attempting it from StBusy — or
+  document abrupt close as intentional for the prototype.
+- **B7.** Null-safe `onLeiosNotActivated` in the `LeiosNetworkClient`
+  handshake adapter (finding **8**, local fix).
+- **B8.** Track client-initiated close so `onDisconnect` only fires for real
+  connection loss (finding **9**); removes the smoke test's hand-rolled
+  `stopping` flag.
+- **B9.** Gate Leios activation on the Musashi network magic / explicit
+  config flag instead of `version >= 15` (finding **10**). `isLeiosCompatible`
+  is only called from the Leios path, so this is isolated even though it
+  lives in `N2NVersionTableConstant` today; moving it out of the shared
+  constants file entirely is cleaner (pairs with the A3 alternative).
+- **B10.** BREAK-aware arity guards in the Leios serializers (finding **11**)
+  — Leios-side hardening; the root asymmetry disappears with A1.
+- **B11.** Single-validation raw CBOR (finding **13**, Leios-side part):
+  validate `LeiosRawCbor` once at construction; drop the re-parse and double
+  copy in `validatedRawCborBytes`. (Byte-fidelity to the wire still requires
+  A1.)
+- **B12.** Built-in periodic keep-alive timer in `LeiosNetworkClient`
+  (finding **14**).
+- **B13.** Drop `BLUEPRINT_CURRENT` and the profile plumbing (finding **15**).
+- **B14.** Finding **12**: no code change — the empty-votes guard matches the
+  CDDL (`1* vote`); B1 removes its only dangerous consequence.
+- **Interim mitigation for finding 1** until A1 lands: reject empty-bitmap
+  requests at the `LeiosNetworkClient`/`LeiosTxBitmap` API boundary (the
+  client-triggerable case) and document server-sent empty EB maps as a known
+  limitation of the prototype client.
+
+### Sequencing
+
+1. **PR-1 (this branch, Leios feature):** all of Part B, plus the A3
+   alternative (Leios-local version table). Zero diff to shared code; no
+   regression testing burden beyond the new Leios tests and the Musashi smoke
+   test.
+2. **PR-2 (shared infrastructure):** A1 + A2 (and A3 as originally written,
+   if the shared-table route is preferred). Gate on the full regression
+   matrix above before release.
+3. Finding 1 is only fully fixed once PR-2 lands; until then PR-1 carries the
+   interim mitigation and a documented limitation.
+
+## Consequences
+
+- Findings 1–5 are release blockers for any real consumer of
+  `LeiosNetworkClient`: each produces a silently dead or corrupted stream that
+  applications cannot detect via the public API. All except the finding-1
+  root cause are fixable inside Part B.
+- The split means the Leios feature PR cannot regress existing products: with
+  the A3 alternative it touches no file that existing consumers execute.
+  The cost is a temporary, documented limitation (empty chunked maps from the
+  server) until the shared PR-2 lands.
+- PR-2 (A1 full fix) is the highest-leverage shared change: it resolves the
+  finding-1 corruption, makes EB bytes hash-verifiable (finding 13), and
+  removes a decode+re-encode from every protocol's receive path — but it is
+  exactly the kind of change that demands the multi-epoch Haskell-node sync
+  regression before release.
+- Finding 10's fix (B9) changes activation behavior for non-Musashi networks
+  only; Musashi behavior is unchanged.
+- The refuted-findings section documents why `PROTOCOL_V15` in the shared
+  version tables is wire-safe, so future reviews need not re-derive it — but
+  wire-safe is not regression-tested; A3 keeps that burden in the shared PR.
+
+## Review provenance
+
+- Branch: `feat/leios_protocol_impl` (untracked new files + modified
+  `N2NVersionTableConstant.java`), reviewed 2026-07-02.
+- Method: workflow-backed multi-agent review, xhigh effort — 6 finder agents
+  (independent correctness angles + cleanup), 44 candidates, one independent
+  adversarial verifier per distinct (file, line) location; 4 refuted; ranked
+  and capped to 15 reported findings (minor duplication findings omitted under
+  the cap).
+- Key mechanisms were verified by execution where possible (e.g. the cbor-java
+  0.9 empty-chunked-map re-encode was reproduced against the exact dependency
+  version from `gradle/libs.versions.toml`).

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/common/Constants.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/common/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
     public static final long PREPROD_PROTOCOL_MAGIC = NetworkType.PREPROD.getProtocolMagic();
     public static final long PREVIEW_PROTOCOL_MAGIC = NetworkType.PREVIEW.getProtocolMagic();
     public static final long SANCHONET_PROTOCOL_MAGIC = NetworkType.SANCHONET.getProtocolMagic();
+    public static final long MUSASHI_PROTOCOL_MAGIC = 164L;
 
     /**
      * @deprecated Use MAINNET_PUBLIC_RELAY_ADDR

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosPoint.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosPoint.java
@@ -1,0 +1,58 @@
+package com.bloxbean.cardano.yaci.core.protocol.leios;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class LeiosPoint {
+    public static final int EB_HASH_LENGTH = 32;
+
+    private final long slot;
+    private final byte[] ebHash;
+
+    public LeiosPoint(long slot, byte[] ebHash) {
+        if (slot < 0) {
+            throw new IllegalArgumentException("slot must be non-negative");
+        }
+        Objects.requireNonNull(ebHash, "ebHash");
+        if (ebHash.length != EB_HASH_LENGTH) {
+            throw new IllegalArgumentException("ebHash must be " + EB_HASH_LENGTH + " bytes");
+        }
+
+        this.slot = slot;
+        this.ebHash = Arrays.copyOf(ebHash, ebHash.length);
+    }
+
+    public long getSlot() {
+        return slot;
+    }
+
+    public byte[] getEbHash() {
+        return Arrays.copyOf(ebHash, ebHash.length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof LeiosPoint that)) {
+            return false;
+        }
+        return slot == that.slot && Arrays.equals(ebHash, that.ebHash);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Long.hashCode(slot);
+        result = 31 * result + Arrays.hashCode(ebHash);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "LeiosPoint{" +
+                "slot=" + slot +
+                ", ebHash=" + Arrays.toString(ebHash) +
+                '}';
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosProtocolConstants.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosProtocolConstants.java
@@ -1,0 +1,9 @@
+package com.bloxbean.cardano.yaci.core.protocol.leios;
+
+public final class LeiosProtocolConstants {
+    public static final int LEIOS_NOTIFY_PROTOCOL_ID = 18;
+    public static final int LEIOS_FETCH_PROTOCOL_ID = 19;
+
+    private LeiosProtocolConstants() {
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosRawCbor.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosRawCbor.java
@@ -1,0 +1,52 @@
+package com.bloxbean.cardano.yaci.core.protocol.leios;
+
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class LeiosRawCbor {
+    private final byte[] cbor;
+
+    public LeiosRawCbor(byte[] cbor) {
+        Objects.requireNonNull(cbor, "cbor");
+        if (CborSerializationUtil.deserialize(cbor).length != 1) {
+            throw new IllegalArgumentException("raw CBOR must contain exactly one top-level value");
+        }
+        this.cbor = Arrays.copyOf(cbor, cbor.length);
+    }
+
+    public static LeiosRawCbor of(byte[] cbor) {
+        return new LeiosRawCbor(cbor);
+    }
+
+    public byte[] getCbor() {
+        return Arrays.copyOf(cbor, cbor.length);
+    }
+
+    public String toHex() {
+        return HexUtil.encodeHexString(cbor);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof LeiosRawCbor that)) {
+            return false;
+        }
+        return Arrays.equals(cbor, that.cbor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(cbor);
+    }
+
+    @Override
+    public String toString() {
+        return "LeiosRawCbor{bytes=" + cbor.length + '}';
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosTxBitmap.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosTxBitmap.java
@@ -1,0 +1,143 @@
+package com.bloxbean.cardano.yaci.core.protocol.leios;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+public final class LeiosTxBitmap {
+    public static final int TXS_PER_WINDOW = 64;
+    public static final int MAX_WINDOW_INDEX = 0xFFFF;
+
+    private final Map<Integer, Long> windows;
+
+    public LeiosTxBitmap(Map<Integer, Long> windows) {
+        Objects.requireNonNull(windows, "windows");
+
+        TreeMap<Integer, Long> sorted = new TreeMap<>();
+        windows.forEach((window, mask) -> {
+            validateWindow(window);
+            if (mask != 0L) {
+                sorted.put(window, mask);
+            }
+        });
+
+        this.windows = Collections.unmodifiableMap(new LinkedHashMap<>(sorted));
+    }
+
+    public static LeiosTxBitmap empty() {
+        return new LeiosTxBitmap(Map.of());
+    }
+
+    public static LeiosTxBitmap firstN(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count must be non-negative");
+        }
+        if (count == 0) {
+            return empty();
+        }
+
+        Map<Integer, Long> windows = new LinkedHashMap<>();
+        int remaining = count;
+        int window = 0;
+        while (remaining > 0) {
+            validateWindow(window);
+            int inWindow = Math.min(TXS_PER_WINDOW, remaining);
+            windows.put(window, firstBits(inWindow));
+            remaining -= inWindow;
+            window++;
+        }
+
+        return new LeiosTxBitmap(windows);
+    }
+
+    public static LeiosTxBitmap fromIndices(int... indices) {
+        Objects.requireNonNull(indices, "indices");
+        Map<Integer, Long> windows = new LinkedHashMap<>();
+        for (int index : indices) {
+            addIndex(windows, index);
+        }
+        return new LeiosTxBitmap(windows);
+    }
+
+    public static LeiosTxBitmap fromIndices(Collection<Integer> indices) {
+        Objects.requireNonNull(indices, "indices");
+        Map<Integer, Long> windows = new LinkedHashMap<>();
+        for (Integer index : indices) {
+            if (index == null) {
+                throw new IllegalArgumentException("index cannot be null");
+            }
+            addIndex(windows, index);
+        }
+        return new LeiosTxBitmap(windows);
+    }
+
+    public Map<Integer, Long> getWindows() {
+        return windows;
+    }
+
+    public boolean isEmpty() {
+        return windows.isEmpty();
+    }
+
+    public Long getMask(int window) {
+        validateWindow(window);
+        return windows.get(window);
+    }
+
+    private static void addIndex(Map<Integer, Long> windows, int index) {
+        if (index < 0) {
+            throw new IllegalArgumentException("transaction index must be non-negative");
+        }
+        int window = index / TXS_PER_WINDOW;
+        validateWindow(window);
+
+        int offset = index % TXS_PER_WINDOW;
+        long bit = 1L << (TXS_PER_WINDOW - 1 - offset);
+        windows.merge(window, bit, (left, right) -> left | right);
+    }
+
+    private static long firstBits(int count) {
+        if (count < 0 || count > TXS_PER_WINDOW) {
+            throw new IllegalArgumentException("count must be between 0 and " + TXS_PER_WINDOW);
+        }
+        if (count == 0) {
+            return 0L;
+        }
+        if (count == TXS_PER_WINDOW) {
+            return -1L;
+        }
+        return -1L << (TXS_PER_WINDOW - count);
+    }
+
+    private static void validateWindow(int window) {
+        if (window < 0 || window > MAX_WINDOW_INDEX) {
+            throw new IllegalArgumentException("window must be between 0 and " + MAX_WINDOW_INDEX);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof LeiosTxBitmap that)) {
+            return false;
+        }
+        return windows.equals(that.windows);
+    }
+
+    @Override
+    public int hashCode() {
+        return windows.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "LeiosTxBitmap{" +
+                "windows=" + windows +
+                '}';
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/serializers/LeiosCborUtil.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leios/serializers/LeiosCborUtil.java
@@ -1,0 +1,178 @@
+package com.bloxbean.cardano.yaci.core.protocol.leios.serializers;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class LeiosCborUtil {
+    private static final BigInteger WORD64_MODULUS = BigInteger.ONE.shiftLeft(64);
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+    private static final BigInteger INT_MAX = BigInteger.valueOf(Integer.MAX_VALUE);
+
+    private LeiosCborUtil() {
+    }
+
+    public static Array serializePointArray(LeiosPoint point) {
+        Array array = new Array();
+        array.add(new UnsignedInteger(point.getSlot()));
+        array.add(new ByteString(point.getEbHash()));
+        return array;
+    }
+
+    public static LeiosPoint deserializePointArray(DataItem dataItem) {
+        List<DataItem> items = arrayItems(dataItem, "point");
+        if (items.size() != 2) {
+            throw new IllegalArgumentException("point must have 2 fields");
+        }
+
+        long slot = toLong((UnsignedInteger) items.get(0), "slot");
+        byte[] ebHash = ((ByteString) items.get(1)).getBytes();
+        return new LeiosPoint(slot, ebHash);
+    }
+
+    public static co.nstant.in.cbor.model.Map serializeTxBitmap(LeiosTxBitmap bitmap) {
+        co.nstant.in.cbor.model.Map map = new co.nstant.in.cbor.model.Map();
+        if (!bitmap.isEmpty()) {
+            map.setChunked(true);
+        }
+        bitmap.getWindows().forEach((window, mask) ->
+                map.put(new UnsignedInteger(window), unsignedLong(mask)));
+        return map;
+    }
+
+    public static byte[] serializeTxBitmapBytes(LeiosTxBitmap bitmap) {
+        // The CBOR library omits the break byte for empty chunked maps; write this field directly.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(0xBF);
+        bitmap.getWindows().forEach((window, mask) -> {
+            writeBytes(baos, CborSerializationUtil.serialize(new UnsignedInteger(window), false));
+            writeBytes(baos, CborSerializationUtil.serialize(unsignedLong(mask), false));
+        });
+        baos.write(0xFF);
+        return baos.toByteArray();
+    }
+
+    public static LeiosTxBitmap deserializeTxBitmap(DataItem dataItem) {
+        co.nstant.in.cbor.model.Map cborMap = (co.nstant.in.cbor.model.Map) dataItem;
+        Map<Integer, Long> windows = new LinkedHashMap<>();
+        for (DataItem key : cborMap.getKeys()) {
+            if (key == SimpleValue.BREAK) {
+                continue;
+            }
+            DataItem value = cborMap.get(key);
+            int window = toWord16((UnsignedInteger) key);
+            long mask = toWord64((UnsignedInteger) value);
+            windows.put(window, mask);
+        }
+
+        return new LeiosTxBitmap(windows);
+    }
+
+    public static LeiosRawCbor toRawCbor(DataItem dataItem) {
+        return LeiosRawCbor.of(CborSerializationUtil.serialize(dataItem, false));
+    }
+
+    public static DataItem fromRawCbor(LeiosRawCbor rawCbor) {
+        DataItem[] dataItems = CborSerializationUtil.deserialize(rawCbor.getCbor());
+        return dataItems[0];
+    }
+
+    public static byte[] validatedRawCborBytes(LeiosRawCbor rawCbor) {
+        return rawCbor.getCbor();
+    }
+
+    public static Array serializeRawCborArray(List<LeiosRawCbor> rawItems) {
+        Array array = new Array();
+        rawItems.forEach(raw -> array.add(fromRawCbor(raw)));
+        return array;
+    }
+
+    public static List<LeiosRawCbor> deserializeRawCborArrayItems(DataItem dataItem) {
+        List<LeiosRawCbor> rawItems = new ArrayList<>();
+        for (DataItem item : arrayItems(dataItem, "raw list")) {
+            rawItems.add(toRawCbor(item));
+        }
+        return rawItems;
+    }
+
+    public static int readTag(DataItem dataItem) {
+        List<DataItem> items = arrayItems(dataItem, "message");
+        if (items.isEmpty()) {
+            throw new IllegalArgumentException("message must contain a tag");
+        }
+        return toInt((UnsignedInteger) items.get(0), "message tag");
+    }
+
+    public static Array asArray(DataItem dataItem, String name) {
+        if (!(dataItem instanceof Array array)) {
+            throw new IllegalArgumentException(name + " must be a CBOR array");
+        }
+        return array;
+    }
+
+    public static List<DataItem> arrayItems(DataItem dataItem, String name) {
+        List<DataItem> items = new ArrayList<>();
+        for (DataItem item : asArray(dataItem, name).getDataItems()) {
+            if (item != SimpleValue.BREAK) {
+                items.add(item);
+            }
+        }
+        return items;
+    }
+
+    private static UnsignedInteger unsignedLong(long value) {
+        if (value >= 0) {
+            return new UnsignedInteger(value);
+        }
+        return new UnsignedInteger(BigInteger.valueOf(value).add(WORD64_MODULUS));
+    }
+
+    private static int toWord16(UnsignedInteger value) {
+        BigInteger bigint = value.getValue();
+        if (bigint.signum() < 0 || bigint.compareTo(BigInteger.valueOf(LeiosTxBitmap.MAX_WINDOW_INDEX)) > 0) {
+            throw new IllegalArgumentException("bitmap window must fit in word16");
+        }
+        return bigint.intValue();
+    }
+
+    private static long toWord64(UnsignedInteger value) {
+        BigInteger bigint = value.getValue();
+        if (bigint.signum() < 0 || bigint.bitLength() > 64) {
+            throw new IllegalArgumentException("bitmap mask must fit in word64");
+        }
+        return bigint.longValue();
+    }
+
+    private static long toLong(UnsignedInteger value, String name) {
+        BigInteger bigint = value.getValue();
+        if (bigint.signum() < 0 || bigint.compareTo(LONG_MAX) > 0) {
+            throw new IllegalArgumentException(name + " must fit in signed long");
+        }
+        return bigint.longValue();
+    }
+
+    private static int toInt(UnsignedInteger value, String name) {
+        BigInteger bigint = value.getValue();
+        if (bigint.signum() < 0 || bigint.compareTo(INT_MAX) > 0) {
+            throw new IllegalArgumentException(name + " must fit in int");
+        }
+        return bigint.intValue();
+    }
+
+    private static void writeBytes(ByteArrayOutputStream baos, byte[] bytes) {
+        baos.write(bytes, 0, bytes.length);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchAgent.java
@@ -1,0 +1,358 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosProtocolConstants;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlock;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockRequest;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxs;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxsRequest;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosFetchError;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+@Slf4j
+public class LeiosFetchAgent extends Agent<LeiosFetchAgentListener> {
+    private static final long WRITE_TIMEOUT_SECONDS = 30;
+
+    private final Queue<Message> requestQueue = new ConcurrentLinkedQueue<>();
+    private volatile Message outstandingRequest;
+    private volatile boolean shutDown;
+    private volatile boolean writeInFlight;
+    private volatile Throwable terminalFailure;
+    private long writeGeneration;
+
+    public LeiosFetchAgent() {
+        super(true);
+        this.currentState = LeiosFetchState.StIdle;
+    }
+
+    @Override
+    public int getProtocolId() {
+        return LeiosProtocolConstants.LEIOS_FETCH_PROTOCOL_ID;
+    }
+
+    @Override
+    public boolean isDone() {
+        return currentState == LeiosFetchState.StDone;
+    }
+
+    @Override
+    public Message deserializeResponse(byte[] bytes) {
+        return LeiosFetchStateBase.deserialize(bytes);
+    }
+
+    @Override
+    public Message buildNextMessage() {
+        if (currentState != LeiosFetchState.StIdle || writeInFlight || terminalFailure != null) {
+            return null;
+        }
+        if (shutDown) {
+            return new MsgClientDone();
+        }
+        return requestQueue.peek();
+    }
+
+    @Override
+    public synchronized void sendRequest(Message message) {
+        LeiosFetchState oldState = (LeiosFetchState) currentState;
+        super.sendRequest(message);
+        if (oldState == LeiosFetchState.StIdle && currentState != oldState) {
+            if (message instanceof MsgLeiosBlockRequest || message instanceof MsgLeiosBlockTxsRequest) {
+                requestQueue.remove(message);
+                outstandingRequest = message;
+            } else if (message instanceof MsgClientDone) {
+                requestQueue.clear();
+                outstandingRequest = null;
+            }
+        }
+        writeInFlight = false;
+    }
+
+    @Override
+    public synchronized void receiveResponse(Message message) {
+        if (terminalFailure != null) {
+            log.warn("Ignoring LeiosFetch response after terminal fetch failure: {}", messageName(message));
+            return;
+        }
+
+        if (message instanceof MsgLeiosFetchError error) {
+            failFetchStream(error.getCause());
+            return;
+        }
+
+        LeiosFetchState state = (LeiosFetchState) currentState;
+        if (!isAllowedInbound(state, message)) {
+            failFetchStream(new IllegalStateException("Invalid LeiosFetch inbound message " +
+                    messageName(message) + " in state " + state));
+            return;
+        }
+
+        State oldState = currentState;
+        currentState = currentState.nextState(message);
+        processResponse(message);
+        notifyStateUpdate(oldState, currentState);
+        writeNextMessageIfReady();
+    }
+
+    @Override
+    protected void processResponse(Message message) {
+        try {
+            if (message instanceof MsgLeiosBlock block) {
+                handleBlock(block);
+            } else if (message instanceof MsgLeiosBlockTxs blockTxs) {
+                handleBlockTxs(blockTxs);
+            } else {
+                log.warn("Unexpected LeiosFetch message: {}", messageName(message));
+            }
+        } finally {
+            outstandingRequest = null;
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        this.shutDown = true;
+        failQueuedRequests(new IllegalStateException("LeiosFetchAgent is shutting down"));
+    }
+
+    @Override
+    public synchronized void reset() {
+        this.currentState = LeiosFetchState.StIdle;
+        this.shutDown = false;
+        this.outstandingRequest = null;
+        this.writeInFlight = false;
+        this.terminalFailure = null;
+        this.writeGeneration++;
+        this.requestQueue.clear();
+    }
+
+    public synchronized void requestBlock(LeiosPoint point) {
+        ensureAvailable();
+        requestQueue.add(new MsgLeiosBlockRequest(point));
+        writeNextMessageIfReady();
+    }
+
+    public synchronized void requestBlockTxs(LeiosPoint point, LeiosTxBitmap bitmap) {
+        ensureAvailable();
+        if (bitmap.isEmpty()) {
+            throw new IllegalArgumentException("Empty Leios tx bitmap requests are disabled until inbound mux " +
+                    "CBOR byte-fidelity is fixed");
+        }
+        requestQueue.add(new MsgLeiosBlockTxsRequest(point, bitmap));
+        writeNextMessageIfReady();
+    }
+
+    private void ensureAvailable() {
+        if (terminalFailure != null) {
+            throw new IllegalStateException("LeiosFetchAgent is failed", terminalFailure);
+        }
+        if (shutDown || currentState == LeiosFetchState.StDone) {
+            throw new IllegalStateException("LeiosFetchAgent is shutting down");
+        }
+    }
+
+    public synchronized void done() {
+        shutdown();
+        writeNextMessageIfReady();
+    }
+
+    @Override
+    public synchronized void sendNextMessage() {
+        writeNextMessageIfReady();
+    }
+
+    public int getQueueSize() {
+        return requestQueue.size();
+    }
+
+    public Message getOutstandingRequest() {
+        return outstandingRequest;
+    }
+
+    private void handleBlock(MsgLeiosBlock block) {
+        if (!(outstandingRequest instanceof MsgLeiosBlockRequest request)) {
+            notifyError(new IllegalStateException("Received block without matching block request"));
+            return;
+        }
+        dispatchListener(listener -> listener.onBlock(request.getPoint(), block.getEndorserBlock()),
+                "onBlock", request.getPoint());
+    }
+
+    private void handleBlockTxs(MsgLeiosBlockTxs blockTxs) {
+        if (!(outstandingRequest instanceof MsgLeiosBlockTxsRequest request)) {
+            notifyError(new IllegalStateException("Received block txs without matching tx request"));
+            return;
+        }
+        dispatchListener(listener -> listener.onBlockTxs(
+                        request.getPoint(), blockTxs.getPoint(), blockTxs.getBitmap(), blockTxs.getTxList()),
+                "onBlockTxs", request.getPoint());
+    }
+
+    private boolean isAllowedInbound(LeiosFetchState state, Message message) {
+        if (message == null) {
+            return false;
+        }
+        if (state == LeiosFetchState.StBlock) {
+            return message instanceof MsgLeiosBlock;
+        }
+        if (state == LeiosFetchState.StBlockTxs) {
+            return message instanceof MsgLeiosBlockTxs;
+        }
+        return false;
+    }
+
+    private synchronized void writeNextMessageIfReady() {
+        if (terminalFailure != null) {
+            return;
+        }
+        if (writeInFlight && !isChannelActive()) {
+            failFetchStream(new IllegalStateException("LeiosFetch write failed because the channel is inactive"));
+            return;
+        }
+        if (currentState != LeiosFetchState.StIdle || writeInFlight || !isChannelActive()) {
+            return;
+        }
+        if (requestQueue.isEmpty() && !shutDown) {
+            return;
+        }
+
+        Message message = buildNextMessage();
+        if (message == null) {
+            return;
+        }
+
+        writeInFlight = true;
+        long generation = ++writeGeneration;
+        writeMessage(message, () -> completeWrite(message, generation));
+        scheduleWriteTimeout(generation);
+    }
+
+    private synchronized void completeWrite(Message message, long generation) {
+        if (generation != writeGeneration || !writeInFlight) {
+            log.debug("Ignoring stale LeiosFetch write callback for {}", messageName(message));
+            return;
+        }
+        sendRequest(message);
+    }
+
+    private void notifyError(Throwable error) {
+        dispatchError(error);
+    }
+
+    private void failFetchStream(Throwable error) {
+        Throwable cause = error != null ? error : new IllegalStateException("LeiosFetch failed");
+        terminalFailure = cause;
+        failRequest(outstandingRequest, cause);
+        failQueuedRequests(cause);
+        outstandingRequest = null;
+        writeInFlight = false;
+        writeGeneration++;
+        if (currentState != LeiosFetchState.StDone) {
+            currentState = LeiosFetchState.StIdle;
+        }
+    }
+
+    private void failQueuedRequests(Throwable error) {
+        Message request;
+        while ((request = requestQueue.poll()) != null) {
+            failRequest(request, error);
+        }
+    }
+
+    private void failRequest(Message request, Throwable error) {
+        LeiosPoint point = requestPoint(request);
+        if (point != null) {
+            dispatchError(point, error);
+        } else {
+            dispatchError(error);
+        }
+    }
+
+    private LeiosPoint requestPoint(Message request) {
+        if (request instanceof MsgLeiosBlockRequest blockRequest) {
+            return blockRequest.getPoint();
+        }
+        if (request instanceof MsgLeiosBlockTxsRequest txsRequest) {
+            return txsRequest.getPoint();
+        }
+        return null;
+    }
+
+    private void scheduleWriteTimeout(long generation) {
+        var channel = getChannel();
+        if (channel == null) {
+            return;
+        }
+        channel.eventLoop().schedule(() -> recoverTimedOutWrite(generation),
+                WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private synchronized void recoverTimedOutWrite(long generation) {
+        if (generation != writeGeneration || !writeInFlight || terminalFailure != null) {
+            return;
+        }
+        failFetchStream(new IllegalStateException("Timed out waiting for LeiosFetch write completion"));
+    }
+
+    private void notifyStateUpdate(State oldState, State newState) {
+        dispatchListener(listener -> listener.onStateUpdate(oldState, newState), "onStateUpdate", null);
+    }
+
+    private void dispatchListener(Consumer<LeiosFetchAgentListener> action,
+                                  String callbackName,
+                                  LeiosPoint requestedPoint) {
+        for (LeiosFetchAgentListener listener : getAgentListeners()) {
+            try {
+                action.accept(listener);
+            } catch (Exception e) {
+                log.warn("LeiosFetch listener {} failed", callbackName, e);
+                if (requestedPoint != null) {
+                    safeDispatchError(listener, requestedPoint, e);
+                } else {
+                    safeDispatchError(listener, e);
+                }
+            }
+        }
+    }
+
+    private void dispatchError(Throwable error) {
+        for (LeiosFetchAgentListener listener : getAgentListeners()) {
+            safeDispatchError(listener, error);
+        }
+    }
+
+    private void dispatchError(LeiosPoint point, Throwable error) {
+        for (LeiosFetchAgentListener listener : getAgentListeners()) {
+            safeDispatchError(listener, point, error);
+        }
+    }
+
+    private void safeDispatchError(LeiosFetchAgentListener listener, Throwable error) {
+        try {
+            listener.onFetchError(error);
+        } catch (Exception e) {
+            log.warn("LeiosFetch listener onFetchError failed", e);
+        }
+    }
+
+    private void safeDispatchError(LeiosFetchAgentListener listener, LeiosPoint point, Throwable error) {
+        try {
+            listener.onFetchError(point, error);
+        } catch (Exception e) {
+            log.warn("LeiosFetch listener onFetchError(point) failed", e);
+        }
+    }
+
+    private String messageName(Message message) {
+        return message == null ? "null" : message.getClass().getSimpleName();
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchAgentListener.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchAgentListener.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch;
+
+import com.bloxbean.cardano.yaci.core.protocol.AgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+
+public interface LeiosFetchAgentListener extends AgentListener {
+    default void onBlock(LeiosPoint requestedPoint, LeiosRawCbor endorserBlock) {
+    }
+
+    default void onBlockTxs(LeiosPoint requestedPoint, LeiosPoint responsePoint,
+                            LeiosTxBitmap responseBitmap, LeiosRawCbor txList) {
+    }
+
+    default void onFetchError(Throwable error) {
+    }
+
+    default void onFetchError(LeiosPoint requestedPoint, Throwable error) {
+        onFetchError(error);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchState.java
@@ -1,0 +1,71 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlock;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockRequest;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxs;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxsRequest;
+
+public enum LeiosFetchState implements LeiosFetchStateBase {
+    StIdle {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgLeiosBlockRequest) {
+                return StBlock;
+            }
+            if (message instanceof MsgLeiosBlockTxsRequest) {
+                return StBlockTxs;
+            }
+            if (message instanceof MsgClientDone) {
+                return StDone;
+            }
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
+        }
+    },
+    StBlock {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgLeiosBlock) {
+                return StIdle;
+            }
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
+        }
+    },
+    StBlockTxs {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgLeiosBlockTxs) {
+                return StIdle;
+            }
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
+        }
+    },
+    StDone {
+        @Override
+        public State nextState(Message message) {
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchStateBase.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchStateBase.java
@@ -1,0 +1,53 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch;
+
+import co.nstant.in.cbor.model.DataItem;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.leios.serializers.LeiosCborUtil;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosFetchError;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.bloxbean.cardano.yaci.core.protocol.leiosfetch.serializers.LeiosFetchSerializers.*;
+
+public interface LeiosFetchStateBase extends State {
+    Logger log = LoggerFactory.getLogger(LeiosFetchStateBase.class);
+
+    @Override
+    default Message handleInbound(byte[] bytes) {
+        return deserialize(bytes);
+    }
+
+    static Message deserialize(byte[] bytes) {
+        try {
+            DataItem[] dataItems = CborSerializationUtil.deserialize(bytes);
+            if (dataItems.length != 1) {
+                throw new IllegalArgumentException("LeiosFetch message must contain one top-level CBOR value");
+            }
+            DataItem dataItem = dataItems[0];
+            int tag = LeiosCborUtil.readTag(dataItem);
+            switch (tag) {
+                case 0:
+                    return MsgLeiosBlockRequestSerializer.INSTANCE.deserializeDI(dataItem);
+                case 1:
+                    return MsgLeiosBlockSerializer.INSTANCE.deserializeDI(dataItem);
+                case 2:
+                    return MsgLeiosBlockTxsRequestSerializer.INSTANCE.deserializeDI(dataItem);
+                case 3:
+                    return MsgLeiosBlockTxsSerializer.INSTANCE.deserializeDI(dataItem);
+                case 9:
+                    return MsgClientDoneSerializer.INSTANCE.deserializeDI(dataItem);
+                default:
+                    throw new UnsupportedOperationException("LeiosFetch tag " + tag + " is not implemented");
+            }
+        } catch (Exception e) {
+            log.error("LeiosFetch parsing error", e);
+            if (log.isDebugEnabled()) {
+                log.debug("Data: {}", HexUtil.encodeHexString(bytes));
+            }
+            return new MsgLeiosFetchError(e);
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgClientDone.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgClientDone.java
@@ -1,0 +1,11 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.serializers.LeiosFetchSerializers;
+
+public class MsgClientDone implements Message {
+    @Override
+    public byte[] serialize() {
+        return LeiosFetchSerializers.MsgClientDoneSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosBlock.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosBlock.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.serializers.LeiosFetchSerializers;
+
+import java.util.Objects;
+
+public class MsgLeiosBlock implements Message {
+    private final LeiosRawCbor endorserBlock;
+
+    public MsgLeiosBlock(LeiosRawCbor endorserBlock) {
+        this.endorserBlock = Objects.requireNonNull(endorserBlock, "endorserBlock");
+    }
+
+    public LeiosRawCbor getEndorserBlock() {
+        return endorserBlock;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return LeiosFetchSerializers.MsgLeiosBlockSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosBlockRequest.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosBlockRequest.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.serializers.LeiosFetchSerializers;
+
+import java.util.Objects;
+
+public class MsgLeiosBlockRequest implements Message {
+    private final LeiosPoint point;
+
+    public MsgLeiosBlockRequest(LeiosPoint point) {
+        this.point = Objects.requireNonNull(point, "point");
+    }
+
+    public LeiosPoint getPoint() {
+        return point;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return LeiosFetchSerializers.MsgLeiosBlockRequestSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosBlockTxs.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosBlockTxs.java
@@ -1,0 +1,38 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.serializers.LeiosFetchSerializers;
+
+import java.util.Objects;
+
+public class MsgLeiosBlockTxs implements Message {
+    private final LeiosPoint point;
+    private final LeiosTxBitmap bitmap;
+    private final LeiosRawCbor txList;
+
+    public MsgLeiosBlockTxs(LeiosPoint point, LeiosTxBitmap bitmap, LeiosRawCbor txList) {
+        this.point = Objects.requireNonNull(point, "point");
+        this.bitmap = Objects.requireNonNull(bitmap, "bitmap");
+        this.txList = Objects.requireNonNull(txList, "txList");
+    }
+
+    public LeiosPoint getPoint() {
+        return point;
+    }
+
+    public LeiosTxBitmap getBitmap() {
+        return bitmap;
+    }
+
+    public LeiosRawCbor getTxList() {
+        return txList;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return LeiosFetchSerializers.MsgLeiosBlockTxsSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosBlockTxsRequest.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosBlockTxsRequest.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.serializers.LeiosFetchSerializers;
+
+import java.util.Objects;
+
+public class MsgLeiosBlockTxsRequest implements Message {
+    private final LeiosPoint point;
+    private final LeiosTxBitmap bitmap;
+
+    public MsgLeiosBlockTxsRequest(LeiosPoint point, LeiosTxBitmap bitmap) {
+        this.point = Objects.requireNonNull(point, "point");
+        this.bitmap = Objects.requireNonNull(bitmap, "bitmap");
+    }
+
+    public LeiosPoint getPoint() {
+        return point;
+    }
+
+    public LeiosTxBitmap getBitmap() {
+        return bitmap;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return LeiosFetchSerializers.MsgLeiosBlockTxsRequestSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosFetchError.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/messages/MsgLeiosFetchError.java
@@ -1,0 +1,17 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+
+import java.util.Objects;
+
+public class MsgLeiosFetchError implements Message {
+    private final Throwable cause;
+
+    public MsgLeiosFetchError(Throwable cause) {
+        this.cause = Objects.requireNonNull(cause, "cause");
+    }
+
+    public Throwable getCause() {
+        return cause;
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/serializers/LeiosFetchSerializers.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/serializers/LeiosFetchSerializers.java
@@ -1,0 +1,148 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch.serializers;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.Serializer;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+import com.bloxbean.cardano.yaci.core.protocol.leios.serializers.LeiosCborUtil;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlock;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockRequest;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxs;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxsRequest;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+public class LeiosFetchSerializers {
+
+    public enum MsgLeiosBlockRequestSerializer implements Serializer<MsgLeiosBlockRequest> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgLeiosBlockRequest object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(0));
+            array.add(LeiosCborUtil.serializePointArray(object.getPoint()));
+            return CborSerializationUtil.serialize(array, false);
+        }
+
+        @Override
+        public MsgLeiosBlockRequest deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 0, "MsgLeiosBlockRequest");
+            requireArity(items, 2, "MsgLeiosBlockRequest");
+            return new MsgLeiosBlockRequest(LeiosCborUtil.deserializePointArray(items.get(1)));
+        }
+    }
+
+    public enum MsgLeiosBlockSerializer implements Serializer<MsgLeiosBlock> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgLeiosBlock object) {
+            return serializeArray(unsigned(1), LeiosCborUtil.validatedRawCborBytes(object.getEndorserBlock()));
+        }
+
+        @Override
+        public MsgLeiosBlock deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 1, "MsgLeiosBlock");
+            requireArity(items, 2, "MsgLeiosBlock");
+            return new MsgLeiosBlock(LeiosCborUtil.toRawCbor(items.get(1)));
+        }
+    }
+
+    public enum MsgLeiosBlockTxsRequestSerializer implements Serializer<MsgLeiosBlockTxsRequest> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgLeiosBlockTxsRequest object) {
+            return serializeArray(
+                    unsigned(2),
+                    CborSerializationUtil.serialize(LeiosCborUtil.serializePointArray(object.getPoint()), false),
+                    LeiosCborUtil.serializeTxBitmapBytes(object.getBitmap()));
+        }
+
+        @Override
+        public MsgLeiosBlockTxsRequest deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 2, "MsgLeiosBlockTxsRequest");
+            requireArity(items, 3, "MsgLeiosBlockTxsRequest");
+            LeiosPoint point = LeiosCborUtil.deserializePointArray(items.get(1));
+            LeiosTxBitmap bitmap = LeiosCborUtil.deserializeTxBitmap(items.get(2));
+            return new MsgLeiosBlockTxsRequest(point, bitmap);
+        }
+    }
+
+    public enum MsgLeiosBlockTxsSerializer implements Serializer<MsgLeiosBlockTxs> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgLeiosBlockTxs object) {
+            return serializeArray(
+                    unsigned(3),
+                    CborSerializationUtil.serialize(LeiosCborUtil.serializePointArray(object.getPoint()), false),
+                    LeiosCborUtil.serializeTxBitmapBytes(object.getBitmap()),
+                    LeiosCborUtil.validatedRawCborBytes(object.getTxList()));
+        }
+
+        @Override
+        public MsgLeiosBlockTxs deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 3, "MsgLeiosBlockTxs");
+            requireArity(items, 4, "MsgLeiosBlockTxs");
+            LeiosPoint point = LeiosCborUtil.deserializePointArray(items.get(1));
+            LeiosTxBitmap bitmap = LeiosCborUtil.deserializeTxBitmap(items.get(2));
+            return new MsgLeiosBlockTxs(point, bitmap, LeiosCborUtil.toRawCbor(items.get(3)));
+        }
+    }
+
+    public enum MsgClientDoneSerializer implements Serializer<MsgClientDone> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgClientDone object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(9));
+            return CborSerializationUtil.serialize(array, false);
+        }
+
+        @Override
+        public MsgClientDone deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 9, "MsgClientDone");
+            requireArity(items, 1, "MsgClientDone");
+            return new MsgClientDone();
+        }
+    }
+
+    private static List<DataItem> messageItems(DataItem di, int expectedTag, String messageName) {
+        int tag = LeiosCborUtil.readTag(di);
+        if (tag != expectedTag) {
+            throw new IllegalArgumentException(messageName + " expected tag " + expectedTag + " but found " + tag);
+        }
+        return LeiosCborUtil.arrayItems(di, messageName);
+    }
+
+    private static void requireArity(List<DataItem> items, int expected, String messageName) {
+        if (items.size() != expected) {
+            throw new IllegalArgumentException(messageName + " must have " + expected + " fields");
+        }
+    }
+
+    private static byte[] serializeArray(byte[]... encodedItems) {
+        if (encodedItems.length > 23) {
+            throw new IllegalArgumentException("small CBOR array supports at most 23 items");
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(0x80 | encodedItems.length);
+        for (byte[] encodedItem : encodedItems) {
+            baos.write(encodedItem, 0, encodedItem.length);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] unsigned(long value) {
+        return CborSerializationUtil.serialize(new UnsignedInteger(value), false);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyAgent.java
@@ -1,0 +1,237 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosProtocolConstants;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosNotifyError;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockAnnouncement;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockTxsOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosNotificationRequestNext;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosVotes;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+@Slf4j
+public class LeiosNotifyAgent extends Agent<LeiosNotifyAgentListener> {
+    private static final long WRITE_TIMEOUT_SECONDS = 30;
+
+    private volatile boolean shutDown;
+    private volatile boolean autoRequestNext;
+    private volatile boolean writeInFlight;
+    private long writeGeneration;
+
+    public LeiosNotifyAgent() {
+        super(true);
+        this.currentState = LeiosNotifyState.StIdle;
+    }
+
+    @Override
+    public int getProtocolId() {
+        return LeiosProtocolConstants.LEIOS_NOTIFY_PROTOCOL_ID;
+    }
+
+    @Override
+    public boolean isDone() {
+        return currentState == LeiosNotifyState.StDone;
+    }
+
+    @Override
+    public Message deserializeResponse(byte[] bytes) {
+        return LeiosNotifyStateBase.deserialize(bytes);
+    }
+
+    @Override
+    public Message buildNextMessage() {
+        if (currentState != LeiosNotifyState.StIdle || writeInFlight) {
+            return null;
+        }
+        if (shutDown) {
+            return new MsgClientDone();
+        }
+        return new MsgLeiosNotificationRequestNext();
+    }
+
+    @Override
+    public synchronized void sendRequest(Message message) {
+        super.sendRequest(message);
+        writeInFlight = false;
+    }
+
+    @Override
+    public synchronized void receiveResponse(Message message) {
+        if (message instanceof MsgLeiosNotifyError error) {
+            notifyError(error.getCause());
+            this.currentState = LeiosNotifyState.StIdle;
+            writeNextMessageIfReady();
+            return;
+        }
+
+        LeiosNotifyState state = (LeiosNotifyState) currentState;
+        if (!isAllowedInbound(state, message)) {
+            notifyError(new IllegalStateException("Invalid LeiosNotify inbound message " +
+                    messageName(message) + " in state " + state));
+            if (state == LeiosNotifyState.StBusy) {
+                this.currentState = LeiosNotifyState.StIdle;
+            }
+            writeNextMessageIfReady();
+            return;
+        }
+
+        State oldState = currentState;
+        currentState = currentState.nextState(message);
+        processResponse(message);
+        notifyStateUpdate(oldState, currentState);
+        writeNextMessageIfReady();
+    }
+
+    @Override
+    protected void processResponse(Message message) {
+        if (message instanceof MsgLeiosBlockAnnouncement announcement) {
+            dispatchListener(listener -> listener.onBlockAnnouncement(announcement.getAnnouncement()),
+                    "onBlockAnnouncement", true);
+        } else if (message instanceof MsgLeiosBlockOffer offer) {
+            dispatchListener(listener -> listener.onBlockOffer(offer.getPoint(), offer.getEbSize()),
+                    "onBlockOffer", true);
+        } else if (message instanceof MsgLeiosBlockTxsOffer offer) {
+            dispatchListener(listener -> listener.onBlockTxsOffer(offer.getPoint()),
+                    "onBlockTxsOffer", true);
+        } else if (message instanceof MsgLeiosVotes votes) {
+            List<LeiosRawCbor> rawVotes = votes.getVotes();
+            dispatchListener(listener -> listener.onVotes(rawVotes), "onVotes", true);
+        } else if (!(message instanceof MsgClientDone) && !(message instanceof MsgLeiosNotificationRequestNext)) {
+            log.warn("Unexpected LeiosNotify message: {}", message.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public synchronized void shutdown() {
+        this.shutDown = true;
+        this.autoRequestNext = false;
+        writeNextMessageIfReady();
+    }
+
+    @Override
+    public synchronized void reset() {
+        this.currentState = LeiosNotifyState.StIdle;
+        this.shutDown = false;
+        this.autoRequestNext = false;
+        this.writeInFlight = false;
+        this.writeGeneration++;
+    }
+
+    public synchronized void start() {
+        this.autoRequestNext = true;
+        writeNextMessageIfReady();
+    }
+
+    public void stopAutoRequestNext() {
+        this.autoRequestNext = false;
+    }
+
+    public boolean isAutoRequestNext() {
+        return autoRequestNext;
+    }
+
+    @Override
+    public synchronized void sendNextMessage() {
+        writeNextMessageIfReady();
+    }
+
+    private void notifyError(Throwable error) {
+        dispatchListener(listener -> listener.onNotifyError(error), "onNotifyError", false);
+    }
+
+    private synchronized void writeNextMessageIfReady() {
+        if (writeInFlight && !isChannelActive()) {
+            log.warn("Clearing LeiosNotify write-in-flight marker because the channel is inactive");
+            writeInFlight = false;
+            writeGeneration++;
+        }
+        if (currentState != LeiosNotifyState.StIdle || writeInFlight || !isChannelActive()) {
+            return;
+        }
+        if (!shutDown && !autoRequestNext) {
+            return;
+        }
+
+        Message message = buildNextMessage();
+        if (message == null) {
+            return;
+        }
+
+        writeInFlight = true;
+        long generation = ++writeGeneration;
+        writeMessage(message, () -> completeWrite(message, generation));
+        scheduleWriteTimeout(generation);
+    }
+
+    private synchronized void completeWrite(Message message, long generation) {
+        if (generation != writeGeneration || !writeInFlight) {
+            log.debug("Ignoring stale LeiosNotify write callback for {}", messageName(message));
+            return;
+        }
+        sendRequest(message);
+    }
+
+    private void scheduleWriteTimeout(long generation) {
+        var channel = getChannel();
+        if (channel == null) {
+            return;
+        }
+        channel.eventLoop().schedule(() -> recoverTimedOutWrite(generation),
+                WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private synchronized void recoverTimedOutWrite(long generation) {
+        if (generation != writeGeneration || !writeInFlight) {
+            return;
+        }
+        log.warn("Recovering timed-out LeiosNotify write");
+        writeInFlight = false;
+        writeGeneration++;
+        writeNextMessageIfReady();
+    }
+
+    private void notifyStateUpdate(State oldState, State newState) {
+        dispatchListener(listener -> listener.onStateUpdate(oldState, newState), "onStateUpdate", true);
+    }
+
+    private void dispatchListener(Consumer<LeiosNotifyAgentListener> action,
+                                  String callbackName,
+                                  boolean reportCallbackError) {
+        for (LeiosNotifyAgentListener listener : getAgentListeners()) {
+            try {
+                action.accept(listener);
+            } catch (Exception e) {
+                log.warn("LeiosNotify listener {} failed", callbackName, e);
+                if (reportCallbackError) {
+                    notifyError(e);
+                }
+            }
+        }
+    }
+
+    private boolean isAllowedInbound(LeiosNotifyState state, Message message) {
+        if (message == null) {
+            return false;
+        }
+        if (state != LeiosNotifyState.StBusy) {
+            return false;
+        }
+        return message instanceof MsgLeiosBlockAnnouncement ||
+                message instanceof MsgLeiosBlockOffer ||
+                message instanceof MsgLeiosBlockTxsOffer ||
+                message instanceof MsgLeiosVotes;
+    }
+
+    private String messageName(Message message) {
+        return message == null ? "null" : message.getClass().getSimpleName();
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyAgentListener.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyAgentListener.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify;
+
+import com.bloxbean.cardano.yaci.core.protocol.AgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+
+import java.util.List;
+
+public interface LeiosNotifyAgentListener extends AgentListener {
+    default void onBlockAnnouncement(LeiosRawCbor announcement) {
+    }
+
+    default void onBlockOffer(LeiosPoint point, long ebSize) {
+    }
+
+    default void onBlockTxsOffer(LeiosPoint point) {
+    }
+
+    default void onVotes(List<LeiosRawCbor> votes) {
+    }
+
+    default void onNotifyError(Throwable error) {
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyState.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyState.java
@@ -1,0 +1,58 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockAnnouncement;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockTxsOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosNotificationRequestNext;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosVotes;
+
+public enum LeiosNotifyState implements LeiosNotifyStateBase {
+    StIdle {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgLeiosNotificationRequestNext) {
+                return StBusy;
+            }
+            if (message instanceof MsgClientDone) {
+                return StDone;
+            }
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return isClient;
+        }
+    },
+    StBusy {
+        @Override
+        public State nextState(Message message) {
+            if (message instanceof MsgLeiosBlockAnnouncement ||
+                    message instanceof MsgLeiosBlockOffer ||
+                    message instanceof MsgLeiosBlockTxsOffer ||
+                    message instanceof MsgLeiosVotes) {
+                return StIdle;
+            }
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return !isClient;
+        }
+    },
+    StDone {
+        @Override
+        public State nextState(Message message) {
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyStateBase.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyStateBase.java
@@ -1,0 +1,55 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify;
+
+import co.nstant.in.cbor.model.DataItem;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import com.bloxbean.cardano.yaci.core.protocol.leios.serializers.LeiosCborUtil;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosNotifyError;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.bloxbean.cardano.yaci.core.protocol.leiosnotify.serializers.LeiosNotifySerializers.*;
+
+public interface LeiosNotifyStateBase extends State {
+    Logger log = LoggerFactory.getLogger(LeiosNotifyStateBase.class);
+
+    @Override
+    default Message handleInbound(byte[] bytes) {
+        return deserialize(bytes);
+    }
+
+    static Message deserialize(byte[] bytes) {
+        try {
+            DataItem[] dataItems = CborSerializationUtil.deserialize(bytes);
+            if (dataItems.length != 1) {
+                throw new IllegalArgumentException("LeiosNotify message must contain one top-level CBOR value");
+            }
+            DataItem dataItem = dataItems[0];
+            int tag = LeiosCborUtil.readTag(dataItem);
+            switch (tag) {
+                case 0:
+                    return MsgLeiosNotificationRequestNextSerializer.INSTANCE.deserializeDI(dataItem);
+                case 1:
+                    return MsgLeiosBlockAnnouncementSerializer.INSTANCE.deserializeDI(dataItem);
+                case 2:
+                    return MsgLeiosBlockOfferSerializer.INSTANCE.deserializeDI(dataItem);
+                case 3:
+                    return MsgLeiosBlockTxsOfferSerializer.INSTANCE.deserializeDI(dataItem);
+                case 4:
+                    return MsgLeiosVotesSerializer.INSTANCE.deserializeDI(dataItem);
+                case 5:
+                    return MsgClientDoneSerializer.INSTANCE.deserializeDI(dataItem);
+                default:
+                    throw new IllegalArgumentException("Invalid LeiosNotify message tag: " + tag);
+            }
+        } catch (Exception e) {
+            log.error("LeiosNotify parsing error", e);
+            if (log.isDebugEnabled()) {
+                log.debug("Data: {}", HexUtil.encodeHexString(bytes));
+            }
+            return new MsgLeiosNotifyError(e);
+        }
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgClientDone.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgClientDone.java
@@ -1,0 +1,11 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.serializers.LeiosNotifySerializers;
+
+public class MsgClientDone implements Message {
+    @Override
+    public byte[] serialize() {
+        return LeiosNotifySerializers.MsgClientDoneSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosBlockAnnouncement.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosBlockAnnouncement.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.serializers.LeiosNotifySerializers;
+
+import java.util.Objects;
+
+public class MsgLeiosBlockAnnouncement implements Message {
+    private final LeiosRawCbor announcement;
+
+    public MsgLeiosBlockAnnouncement(LeiosRawCbor announcement) {
+        this.announcement = Objects.requireNonNull(announcement, "announcement");
+    }
+
+    public LeiosRawCbor getAnnouncement() {
+        return announcement;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return LeiosNotifySerializers.MsgLeiosBlockAnnouncementSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosBlockOffer.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosBlockOffer.java
@@ -1,0 +1,35 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.serializers.LeiosNotifySerializers;
+
+import java.util.Objects;
+
+public class MsgLeiosBlockOffer implements Message {
+    public static final long MAX_EB_SIZE = 0xFFFF_FFFFL;
+
+    private final LeiosPoint point;
+    private final long ebSize;
+
+    public MsgLeiosBlockOffer(LeiosPoint point, long ebSize) {
+        if (ebSize < 0 || ebSize > MAX_EB_SIZE) {
+            throw new IllegalArgumentException("ebSize must fit in word32");
+        }
+        this.point = Objects.requireNonNull(point, "point");
+        this.ebSize = ebSize;
+    }
+
+    public LeiosPoint getPoint() {
+        return point;
+    }
+
+    public long getEbSize() {
+        return ebSize;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return LeiosNotifySerializers.MsgLeiosBlockOfferSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosBlockTxsOffer.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosBlockTxsOffer.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.serializers.LeiosNotifySerializers;
+
+import java.util.Objects;
+
+public class MsgLeiosBlockTxsOffer implements Message {
+    private final LeiosPoint point;
+
+    public MsgLeiosBlockTxsOffer(LeiosPoint point) {
+        this.point = Objects.requireNonNull(point, "point");
+    }
+
+    public LeiosPoint getPoint() {
+        return point;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return LeiosNotifySerializers.MsgLeiosBlockTxsOfferSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosNotificationRequestNext.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosNotificationRequestNext.java
@@ -1,0 +1,11 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.serializers.LeiosNotifySerializers;
+
+public class MsgLeiosNotificationRequestNext implements Message {
+    @Override
+    public byte[] serialize() {
+        return LeiosNotifySerializers.MsgLeiosNotificationRequestNextSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosNotifyError.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosNotifyError.java
@@ -1,0 +1,17 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+
+import java.util.Objects;
+
+public class MsgLeiosNotifyError implements Message {
+    private final Throwable cause;
+
+    public MsgLeiosNotifyError(Throwable cause) {
+        this.cause = Objects.requireNonNull(cause, "cause");
+    }
+
+    public Throwable getCause() {
+        return cause;
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosVotes.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/messages/MsgLeiosVotes.java
@@ -1,0 +1,29 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages;
+
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.serializers.LeiosNotifySerializers;
+
+import java.util.List;
+import java.util.Objects;
+
+public class MsgLeiosVotes implements Message {
+    private final List<LeiosRawCbor> votes;
+
+    public MsgLeiosVotes(List<LeiosRawCbor> votes) {
+        Objects.requireNonNull(votes, "votes");
+        if (votes.isEmpty()) {
+            throw new IllegalArgumentException("votes cannot be empty");
+        }
+        this.votes = List.copyOf(votes);
+    }
+
+    public List<LeiosRawCbor> getVotes() {
+        return votes;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return LeiosNotifySerializers.MsgLeiosVotesSerializer.INSTANCE.serialize(this);
+    }
+}

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/serializers/LeiosNotifySerializers.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/serializers/LeiosNotifySerializers.java
@@ -1,0 +1,161 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify.serializers;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.Serializer;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.serializers.LeiosCborUtil;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockAnnouncement;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockTxsOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosNotificationRequestNext;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosVotes;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public class LeiosNotifySerializers {
+    private static final BigInteger WORD32_MAX = BigInteger.valueOf(MsgLeiosBlockOffer.MAX_EB_SIZE);
+
+    public enum MsgLeiosNotificationRequestNextSerializer
+            implements Serializer<MsgLeiosNotificationRequestNext> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgLeiosNotificationRequestNext object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(0));
+            return CborSerializationUtil.serialize(array, false);
+        }
+
+        @Override
+        public MsgLeiosNotificationRequestNext deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 0, "MsgLeiosNotificationRequestNext");
+            requireArity(items, 1, "MsgLeiosNotificationRequestNext");
+            return new MsgLeiosNotificationRequestNext();
+        }
+    }
+
+    public enum MsgLeiosBlockAnnouncementSerializer implements Serializer<MsgLeiosBlockAnnouncement> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgLeiosBlockAnnouncement object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(1));
+            array.add(LeiosCborUtil.fromRawCbor(object.getAnnouncement()));
+            return CborSerializationUtil.serialize(array, false);
+        }
+
+        @Override
+        public MsgLeiosBlockAnnouncement deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 1, "MsgLeiosBlockAnnouncement");
+            requireArity(items, 2, "MsgLeiosBlockAnnouncement");
+            return new MsgLeiosBlockAnnouncement(LeiosCborUtil.toRawCbor(items.get(1)));
+        }
+    }
+
+    public enum MsgLeiosBlockOfferSerializer implements Serializer<MsgLeiosBlockOffer> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgLeiosBlockOffer object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(2));
+            array.add(LeiosCborUtil.serializePointArray(object.getPoint()));
+            array.add(new UnsignedInteger(object.getEbSize()));
+            return CborSerializationUtil.serialize(array, false);
+        }
+
+        @Override
+        public MsgLeiosBlockOffer deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 2, "MsgLeiosBlockOffer");
+            requireArity(items, 3, "MsgLeiosBlockOffer");
+            LeiosPoint point = LeiosCborUtil.deserializePointArray(items.get(1));
+            long ebSize = toWord32((UnsignedInteger) items.get(2));
+            return new MsgLeiosBlockOffer(point, ebSize);
+        }
+    }
+
+    public enum MsgLeiosBlockTxsOfferSerializer implements Serializer<MsgLeiosBlockTxsOffer> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgLeiosBlockTxsOffer object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(3));
+            array.add(LeiosCborUtil.serializePointArray(object.getPoint()));
+            return CborSerializationUtil.serialize(array, false);
+        }
+
+        @Override
+        public MsgLeiosBlockTxsOffer deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 3, "MsgLeiosBlockTxsOffer");
+            requireArity(items, 2, "MsgLeiosBlockTxsOffer");
+            return new MsgLeiosBlockTxsOffer(LeiosCborUtil.deserializePointArray(items.get(1)));
+        }
+    }
+
+    public enum MsgLeiosVotesSerializer implements Serializer<MsgLeiosVotes> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgLeiosVotes object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(4));
+            array.add(LeiosCborUtil.serializeRawCborArray(object.getVotes()));
+            return CborSerializationUtil.serialize(array, false);
+        }
+
+        @Override
+        public MsgLeiosVotes deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 4, "MsgLeiosVotes");
+            requireArity(items, 2, "MsgLeiosVotes");
+            return new MsgLeiosVotes(LeiosCborUtil.deserializeRawCborArrayItems(items.get(1)));
+        }
+    }
+
+    public enum MsgClientDoneSerializer implements Serializer<MsgClientDone> {
+        INSTANCE;
+
+        @Override
+        public byte[] serialize(MsgClientDone object) {
+            Array array = new Array();
+            array.add(new UnsignedInteger(5));
+            return CborSerializationUtil.serialize(array, false);
+        }
+
+        @Override
+        public MsgClientDone deserializeDI(DataItem di) {
+            List<DataItem> items = messageItems(di, 5, "MsgClientDone");
+            requireArity(items, 1, "MsgClientDone");
+            return new MsgClientDone();
+        }
+    }
+
+    private static List<DataItem> messageItems(DataItem di, int expectedTag, String messageName) {
+        int tag = LeiosCborUtil.readTag(di);
+        if (tag != expectedTag) {
+            throw new IllegalArgumentException(messageName + " expected tag " + expectedTag + " but found " + tag);
+        }
+        return LeiosCborUtil.arrayItems(di, messageName);
+    }
+
+    private static void requireArity(List<DataItem> items, int expected, String messageName) {
+        if (items.size() != expected) {
+            throw new IllegalArgumentException(messageName + " must have " + expected + " fields");
+        }
+    }
+
+    private static long toWord32(UnsignedInteger value) {
+        BigInteger bigint = value.getValue();
+        if (bigint.signum() < 0 || bigint.compareTo(WORD32_MAX) > 0) {
+            throw new IllegalArgumentException("value must fit in word32");
+        }
+        return bigint.longValue();
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosCborUtilTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosCborUtilTest.java
@@ -1,0 +1,156 @@
+package com.bloxbean.cardano.yaci.core.protocol.leios;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.leios.serializers.LeiosCborUtil;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LeiosCborUtilTest {
+
+    @Test
+    void serializesAndDeserializesPoint() {
+        byte[] hash = hash(7);
+        LeiosPoint point = new LeiosPoint(42, hash);
+
+        DataItem pointDi = LeiosCborUtil.serializePointArray(point);
+        LeiosPoint deserialized = LeiosCborUtil.deserializePointArray(pointDi);
+
+        assertEquals(42, deserialized.getSlot());
+        assertArrayEquals(hash, deserialized.getEbHash());
+    }
+
+    @Test
+    void deserializesPointWithTrailingBreakItem() {
+        byte[] hash = hash(8);
+        Array point = new Array();
+        point.add(new UnsignedInteger(43));
+        point.add(new ByteString(hash));
+        point.add(SimpleValue.BREAK);
+
+        LeiosPoint deserialized = LeiosCborUtil.deserializePointArray(point);
+
+        assertEquals(43, deserialized.getSlot());
+        assertArrayEquals(hash, deserialized.getEbHash());
+    }
+
+    @Test
+    void rejectsPointSlotOutsideSignedLongRange() {
+        Array point = new Array();
+        point.add(new UnsignedInteger(BigInteger.ONE.shiftLeft(63)));
+        point.add(new co.nstant.in.cbor.model.ByteString(hash(0)));
+
+        assertThrows(IllegalArgumentException.class, () -> LeiosCborUtil.deserializePointArray(point));
+    }
+
+    @Test
+    void serializesBitmapAsIndefiniteMap() {
+        LeiosTxBitmap bitmap = LeiosTxBitmap.fromIndices(0);
+
+        byte[] bytes = LeiosCborUtil.serializeTxBitmapBytes(bitmap);
+
+        assertEquals((byte) 0xbf, bytes[0]);
+        assertEquals((byte) 0xff, bytes[bytes.length - 1]);
+        assertEquals(bitmap, LeiosCborUtil.deserializeTxBitmap(CborSerializationUtil.deserializeOne(bytes)));
+    }
+
+    @Test
+    void serializesEmptyBitmapAsIndefiniteMap() {
+        byte[] bytes = LeiosCborUtil.serializeTxBitmapBytes(LeiosTxBitmap.empty());
+
+        assertArrayEquals(new byte[]{(byte) 0xbf, (byte) 0xff}, bytes);
+        assertEquals(LeiosTxBitmap.empty(),
+                LeiosCborUtil.deserializeTxBitmap(CborSerializationUtil.deserializeOne(bytes)));
+    }
+
+    @Test
+    void dataItemEmptyBitmapUsesDefiniteMapToAvoidInvalidLibraryEncoding() {
+        byte[] bytes = CborSerializationUtil.serialize(
+                LeiosCborUtil.serializeTxBitmap(LeiosTxBitmap.empty()), false);
+
+        assertArrayEquals(new byte[]{(byte) 0xa0}, bytes);
+        assertEquals(LeiosTxBitmap.empty(),
+                LeiosCborUtil.deserializeTxBitmap(CborSerializationUtil.deserializeOne(bytes)));
+    }
+
+    @Test
+    void decodesDefiniteBitmapMap() {
+        co.nstant.in.cbor.model.Map map = new co.nstant.in.cbor.model.Map();
+        map.put(new UnsignedInteger(0), new UnsignedInteger(1));
+        map.put(new UnsignedInteger(2), new UnsignedInteger(3));
+
+        LeiosTxBitmap bitmap = LeiosCborUtil.deserializeTxBitmap(map);
+
+        assertEquals(Map.of(0, 1L, 2, 3L), bitmap.getWindows());
+    }
+
+    @Test
+    void rejectsBitmapWindowOutsideWord16() {
+        co.nstant.in.cbor.model.Map map = new co.nstant.in.cbor.model.Map();
+        map.put(new UnsignedInteger(BigInteger.ONE.shiftLeft(32)), new UnsignedInteger(1));
+
+        assertThrows(IllegalArgumentException.class, () -> LeiosCborUtil.deserializeTxBitmap(map));
+    }
+
+    @Test
+    void rejectsBitmapMaskOutsideWord64() {
+        co.nstant.in.cbor.model.Map map = new co.nstant.in.cbor.model.Map();
+        map.put(new UnsignedInteger(0), new UnsignedInteger(BigInteger.ONE.shiftLeft(64)));
+
+        assertThrows(IllegalArgumentException.class, () -> LeiosCborUtil.deserializeTxBitmap(map));
+    }
+
+    @Test
+    void wrapsOpaqueCborWithoutDomainDecoding() {
+        Array rawArray = new Array();
+        rawArray.add(new UnsignedInteger(1));
+        rawArray.add(new UnsignedInteger(2));
+
+        LeiosRawCbor raw = LeiosCborUtil.toRawCbor(rawArray);
+        DataItem dataItem = LeiosCborUtil.fromRawCbor(raw);
+
+        assertEquals(1, LeiosCborUtil.readTag(dataItem));
+    }
+
+    @Test
+    void rejectsMessageTagOutsideIntRange() {
+        Array message = new Array();
+        message.add(new UnsignedInteger(BigInteger.ONE.shiftLeft(32)));
+
+        assertThrows(IllegalArgumentException.class, () -> LeiosCborUtil.readTag(message));
+    }
+
+    @Test
+    void readsMessageTagWithTrailingBreakItem() {
+        Array message = new Array();
+        message.add(new UnsignedInteger(4));
+        message.add(SimpleValue.BREAK);
+
+        assertEquals(4, LeiosCborUtil.readTag(message));
+    }
+
+    @Test
+    void rejectsRawCborSequencesWithMultipleTopLevelValues() {
+        byte[] cborSequence = new byte[]{0x01, 0x02};
+
+        assertThrows(IllegalArgumentException.class, () -> LeiosCborUtil.fromRawCbor(LeiosRawCbor.of(cborSequence)));
+    }
+
+    private byte[] hash(int seed) {
+        byte[] hash = new byte[LeiosPoint.EB_HASH_LENGTH];
+        for (int i = 0; i < hash.length; i++) {
+            hash[i] = (byte) (seed + i);
+        }
+        return hash;
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosPointTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosPointTest.java
@@ -1,0 +1,42 @@
+package com.bloxbean.cardano.yaci.core.protocol.leios;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LeiosPointTest {
+
+    @Test
+    void protectsHashFromMutation() {
+        byte[] hash = new byte[LeiosPoint.EB_HASH_LENGTH];
+        hash[0] = 1;
+        LeiosPoint point = new LeiosPoint(10, hash);
+
+        hash[0] = 2;
+        byte[] returnedHash = point.getEbHash();
+        returnedHash[0] = 3;
+
+        assertEquals(1, point.getEbHash()[0]);
+    }
+
+    @Test
+    void validatesSlotAndHashLength() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new LeiosPoint(-1, new byte[LeiosPoint.EB_HASH_LENGTH]));
+        assertThrows(IllegalArgumentException.class,
+                () -> new LeiosPoint(0, new byte[LeiosPoint.EB_HASH_LENGTH - 1]));
+    }
+
+    @Test
+    void comparesBySlotAndHash() {
+        byte[] hash = new byte[LeiosPoint.EB_HASH_LENGTH];
+        hash[0] = 1;
+
+        assertEquals(new LeiosPoint(1, hash), new LeiosPoint(1, hash));
+        assertArrayEquals(hash, new LeiosPoint(1, hash).getEbHash());
+        assertNotEquals(new LeiosPoint(1, hash), new LeiosPoint(2, hash));
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosTxBitmapTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leios/LeiosTxBitmapTest.java
@@ -1,0 +1,47 @@
+package com.bloxbean.cardano.yaci.core.protocol.leios;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LeiosTxBitmapTest {
+
+    @Test
+    void buildsFirstNUsingMsbFirstConvention() {
+        assertTrue(LeiosTxBitmap.firstN(0).isEmpty());
+        assertEquals(Map.of(0, Long.MIN_VALUE), LeiosTxBitmap.firstN(1).getWindows());
+        assertEquals(Map.of(0, -1L), LeiosTxBitmap.firstN(64).getWindows());
+        assertEquals(Map.of(0, -1L, 1, Long.MIN_VALUE), LeiosTxBitmap.firstN(65).getWindows());
+    }
+
+    @Test
+    void buildsFromIndicesUsingSixtyFourTxWindows() {
+        LeiosTxBitmap bitmap = LeiosTxBitmap.fromIndices(0, 63, 64, 130);
+
+        assertEquals(Long.MIN_VALUE | 1L, bitmap.getMask(0));
+        assertEquals(Long.MIN_VALUE, bitmap.getMask(1));
+        assertEquals(1L << 61, bitmap.getMask(2));
+    }
+
+    @Test
+    void sortsWindowsDeterministically() {
+        LeiosTxBitmap bitmap = LeiosTxBitmap.fromIndices(List.of(130, 0, 64));
+
+        assertEquals(List.of(0, 1, 2), List.copyOf(bitmap.getWindows().keySet()));
+    }
+
+    @Test
+    void validatesIndicesAndWindows() {
+        assertThrows(IllegalArgumentException.class, () -> LeiosTxBitmap.firstN(-1));
+        assertThrows(IllegalArgumentException.class, () -> LeiosTxBitmap.fromIndices(-1));
+        assertThrows(IllegalArgumentException.class,
+                () -> LeiosTxBitmap.fromIndices((LeiosTxBitmap.MAX_WINDOW_INDEX + 1) * 64));
+        assertThrows(UnsupportedOperationException.class,
+                () -> LeiosTxBitmap.firstN(1).getWindows().put(2, 3L));
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchAgentTest.java
@@ -1,0 +1,449 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.Segment;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosProtocolConstants;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+import com.bloxbean.cardano.yaci.core.protocol.leios.serializers.LeiosCborUtil;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlock;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockRequest;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxs;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxsRequest;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosFetchError;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LeiosFetchAgentTest {
+
+    @Test
+    void startsIdleWithClientAgencyAndProtocolId19() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertEquals(LeiosProtocolConstants.LEIOS_FETCH_PROTOCOL_ID, agent.getProtocolId());
+        assertTrue(agent.hasAgency());
+        assertNull(agent.buildNextMessage());
+    }
+
+    @Test
+    void requestBlockMovesToBusyAndDispatchesBlockCallback() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        LeiosPoint point = point(1);
+        LeiosRawCbor block = LeiosCborUtil.toRawCbor(rawArray(1, 2));
+        AtomicReference<LeiosPoint> requestedPoint = new AtomicReference<>();
+        AtomicReference<LeiosRawCbor> observedBlock = new AtomicReference<>();
+        agent.addListener(new LeiosFetchAgentListener() {
+            @Override
+            public void onBlock(LeiosPoint requested, LeiosRawCbor endorserBlock) {
+                requestedPoint.set(requested);
+                observedBlock.set(endorserBlock);
+            }
+        });
+
+        agent.requestBlock(point);
+        Message request = agent.buildNextMessage();
+        agent.sendRequest(request);
+
+        assertInstanceOf(MsgLeiosBlockRequest.class, request);
+        assertEquals(LeiosFetchState.StBlock, agent.getCurrentState());
+        assertEquals(request, agent.getOutstandingRequest());
+        assertEquals(0, agent.getQueueSize());
+        assertFalse(agent.hasAgency());
+
+        agent.receiveResponse(new MsgLeiosBlock(block));
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertEquals(point, requestedPoint.get());
+        assertEquals(block, observedBlock.get());
+        assertNull(agent.getOutstandingRequest());
+        assertTrue(agent.hasAgency());
+    }
+
+    @Test
+    void requestBlockTxsMovesToBusyAndDispatchesBlockTxsCallback() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        LeiosPoint requested = point(2);
+        LeiosPoint response = point(3);
+        LeiosTxBitmap bitmap = LeiosTxBitmap.fromIndices(0, 64, 65);
+        LeiosRawCbor txList = LeiosCborUtil.toRawCbor(rawArray(3, 4));
+        AtomicReference<LeiosPoint> requestedPoint = new AtomicReference<>();
+        AtomicReference<LeiosPoint> responsePoint = new AtomicReference<>();
+        AtomicReference<LeiosTxBitmap> observedBitmap = new AtomicReference<>();
+        AtomicReference<LeiosRawCbor> observedTxList = new AtomicReference<>();
+        agent.addListener(new LeiosFetchAgentListener() {
+            @Override
+            public void onBlockTxs(LeiosPoint requested, LeiosPoint response,
+                                   LeiosTxBitmap responseBitmap, LeiosRawCbor txList) {
+                requestedPoint.set(requested);
+                responsePoint.set(response);
+                observedBitmap.set(responseBitmap);
+                observedTxList.set(txList);
+            }
+        });
+
+        agent.requestBlockTxs(requested, bitmap);
+        Message request = agent.buildNextMessage();
+        agent.sendRequest(request);
+
+        assertInstanceOf(MsgLeiosBlockTxsRequest.class, request);
+        assertEquals(LeiosFetchState.StBlockTxs, agent.getCurrentState());
+
+        agent.receiveResponse(new MsgLeiosBlockTxs(response, bitmap, txList));
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertEquals(requested, requestedPoint.get());
+        assertEquals(response, responsePoint.get());
+        assertEquals(bitmap, observedBitmap.get());
+        assertEquals(txList, observedTxList.get());
+        assertNull(agent.getOutstandingRequest());
+    }
+
+    @Test
+    void queuesSecondRequestAndSendsItAfterFirstResponse() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        agent.setChannel(channel);
+
+        agent.requestBlock(point(4));
+        Segment first = channel.readOutbound();
+        assertEquals(LeiosProtocolConstants.LEIOS_FETCH_PROTOCOL_ID, first.getProtocol());
+        assertInstanceOf(MsgLeiosBlockRequest.class,
+                LeiosFetchStateBase.deserialize(first.getPayload()));
+        assertEquals(LeiosFetchState.StBlock, agent.getCurrentState());
+
+        LeiosTxBitmap bitmap = LeiosTxBitmap.firstN(2);
+        agent.requestBlockTxs(point(5), bitmap);
+        assertNull(channel.readOutbound());
+        assertEquals(1, agent.getQueueSize());
+
+        agent.receiveResponse(new MsgLeiosBlock(LeiosCborUtil.toRawCbor(rawArray(5, 6))));
+
+        Segment second = channel.readOutbound();
+        assertEquals(LeiosProtocolConstants.LEIOS_FETCH_PROTOCOL_ID, second.getProtocol());
+        Message secondMessage = LeiosFetchStateBase.deserialize(second.getPayload());
+        MsgLeiosBlockTxsRequest secondRequest = assertInstanceOf(MsgLeiosBlockTxsRequest.class, secondMessage);
+        assertEquals(bitmap, secondRequest.getBitmap());
+        assertEquals(LeiosFetchState.StBlockTxs, agent.getCurrentState());
+        assertEquals(0, agent.getQueueSize());
+    }
+
+    @Test
+    void doesNotDuplicateRequestWhileAsyncWriteIsPending() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        PendingWriteHandler pendingWrites = new PendingWriteHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(pendingWrites);
+        agent.setChannel(channel);
+
+        agent.requestBlock(point(10));
+        agent.requestBlockTxs(point(11), LeiosTxBitmap.firstN(1));
+
+        assertEquals(1, pendingWrites.writes.size());
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertEquals(2, agent.getQueueSize());
+        assertNull(agent.getOutstandingRequest());
+
+        pendingWrites.succeed(0);
+
+        assertEquals(LeiosFetchState.StBlock, agent.getCurrentState());
+        assertEquals(1, agent.getQueueSize());
+        assertInstanceOf(MsgLeiosBlockRequest.class, agent.getOutstandingRequest());
+
+        agent.receiveResponse(new MsgLeiosBlock(LeiosCborUtil.toRawCbor(rawArray(10, 11))));
+
+        assertEquals(2, pendingWrites.writes.size());
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+
+        pendingWrites.succeed(1);
+
+        assertEquals(LeiosFetchState.StBlockTxs, agent.getCurrentState());
+        assertEquals(0, agent.getQueueSize());
+        assertInstanceOf(MsgLeiosBlockTxsRequest.class, agent.getOutstandingRequest());
+    }
+
+    @Test
+    void ignoresPendingWriteCallbackAfterErrorClearsQueue() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        PendingWriteHandler pendingWrites = new PendingWriteHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(pendingWrites);
+        agent.setChannel(channel);
+        AtomicReference<LeiosPoint> failedPoint = new AtomicReference<>();
+        agent.addListener(new LeiosFetchAgentListener() {
+            @Override
+            public void onFetchError(LeiosPoint requestedPoint, Throwable error) {
+                failedPoint.set(requestedPoint);
+            }
+        });
+
+        LeiosPoint point = point(18);
+        agent.requestBlock(point);
+        assertEquals(1, pendingWrites.writes.size());
+
+        Throwable cause = new IllegalArgumentException("bad frame");
+        agent.receiveResponse(new MsgLeiosFetchError(cause));
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertEquals(0, agent.getQueueSize());
+        assertNull(agent.getOutstandingRequest());
+        assertEquals(point, failedPoint.get());
+
+        pendingWrites.succeed(0);
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertEquals(0, agent.getQueueSize());
+        assertNull(agent.getOutstandingRequest());
+
+        assertThrows(IllegalStateException.class,
+                () -> agent.requestBlockTxs(point(19), LeiosTxBitmap.firstN(1)));
+        assertEquals(1, pendingWrites.writes.size());
+    }
+
+    @Test
+    void ignoresPendingWriteCallbackAfterResetClearsQueue() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        PendingWriteHandler pendingWrites = new PendingWriteHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(pendingWrites);
+        agent.setChannel(channel);
+
+        agent.requestBlock(point(20));
+        assertEquals(1, pendingWrites.writes.size());
+
+        agent.reset();
+        pendingWrites.succeed(0);
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertEquals(0, agent.getQueueSize());
+        assertNull(agent.getOutstandingRequest());
+        assertNull(agent.buildNextMessage());
+    }
+
+    @Test
+    void doneSendsClientDoneAndTransitionsTerminal() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        agent.setChannel(channel);
+
+        agent.done();
+
+        Segment segment = channel.readOutbound();
+        assertEquals(LeiosProtocolConstants.LEIOS_FETCH_PROTOCOL_ID, segment.getProtocol());
+        assertInstanceOf(MsgClientDone.class,
+                LeiosFetchStateBase.deserialize(segment.getPayload()));
+        assertEquals(LeiosFetchState.StDone, agent.getCurrentState());
+        assertTrue(agent.isDone());
+        assertFalse(agent.hasAgency());
+    }
+
+    @Test
+    void doneClearsQueuedRequestsBeforeTerminalMessage() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+
+        agent.requestBlock(point(12));
+        agent.requestBlockTxs(point(13), LeiosTxBitmap.firstN(1));
+        agent.done();
+
+        assertEquals(0, agent.getQueueSize());
+        Message done = agent.buildNextMessage();
+        assertInstanceOf(MsgClientDone.class, done);
+
+        agent.sendRequest(done);
+
+        assertEquals(LeiosFetchState.StDone, agent.getCurrentState());
+        assertEquals(0, agent.getQueueSize());
+    }
+
+    @Test
+    void invalidInboundMessageIsNotDispatchedInIdle() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        AtomicReference<LeiosRawCbor> observedBlock = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        agent.addListener(new LeiosFetchAgentListener() {
+            @Override
+            public void onBlock(LeiosPoint requestedPoint, LeiosRawCbor endorserBlock) {
+                observedBlock.set(endorserBlock);
+            }
+
+            @Override
+            public void onFetchError(Throwable observed) {
+                error.set(observed);
+            }
+        });
+
+        agent.receiveResponse(new MsgLeiosBlock(LeiosCborUtil.toRawCbor(rawArray(7, 8))));
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertNull(observedBlock.get());
+        assertInstanceOf(IllegalStateException.class, error.get());
+    }
+
+    @Test
+    void invalidInboundMessageInBusyReportsErrorAndReturnsIdle() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        AtomicInteger errors = new AtomicInteger();
+        agent.addListener(new LeiosFetchAgentListener() {
+            @Override
+            public void onFetchError(Throwable observed) {
+                errors.incrementAndGet();
+            }
+        });
+
+        agent.requestBlock(point(6));
+        agent.sendRequest(agent.buildNextMessage());
+        agent.requestBlockTxs(point(16), LeiosTxBitmap.firstN(1));
+        agent.receiveResponse(new MsgLeiosBlockTxs(
+                point(7), LeiosTxBitmap.firstN(1), LeiosCborUtil.toRawCbor(rawArray(8, 9))));
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertNull(agent.getOutstandingRequest());
+        assertEquals(0, agent.getQueueSize());
+        assertTrue(errors.get() >= 1);
+        assertThrows(IllegalStateException.class, () -> agent.requestBlock(point(21)));
+    }
+
+    @Test
+    void parseErrorReportsCauseAndReturnsIdle() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        AtomicReference<Throwable> firstError = new AtomicReference<>();
+        AtomicInteger errors = new AtomicInteger();
+        agent.addListener(new LeiosFetchAgentListener() {
+            @Override
+            public void onFetchError(Throwable observed) {
+                errors.incrementAndGet();
+                firstError.compareAndSet(null, observed);
+            }
+        });
+
+        agent.requestBlock(point(8));
+        agent.sendRequest(agent.buildNextMessage());
+        agent.requestBlockTxs(point(17), LeiosTxBitmap.firstN(1));
+        Throwable cause = new IllegalArgumentException("bad frame");
+        agent.receiveResponse(new MsgLeiosFetchError(cause));
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertNull(agent.getOutstandingRequest());
+        assertEquals(0, agent.getQueueSize());
+        assertEquals(cause, firstError.get());
+        assertEquals(2, errors.get());
+        assertThrows(IllegalStateException.class, () -> agent.requestBlock(point(22)));
+    }
+
+    @Test
+    void lateResponseAfterFetchErrorIsNotPairedWithNextRequest() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        AtomicReference<LeiosPoint> observedPoint = new AtomicReference<>();
+        agent.addListener(new LeiosFetchAgentListener() {
+            @Override
+            public void onBlock(LeiosPoint requestedPoint, LeiosRawCbor endorserBlock) {
+                observedPoint.set(requestedPoint);
+            }
+        });
+
+        agent.requestBlock(point(23));
+        agent.sendRequest(agent.buildNextMessage());
+        agent.receiveResponse(new MsgLeiosFetchError(new IllegalArgumentException("bad frame")));
+
+        assertThrows(IllegalStateException.class, () -> agent.requestBlock(point(24)));
+
+        agent.receiveResponse(new MsgLeiosBlock(LeiosCborUtil.toRawCbor(rawArray(23, 24))));
+
+        assertNull(observedPoint.get());
+        assertNull(agent.getOutstandingRequest());
+    }
+
+    @Test
+    void listenerExceptionDoesNotStopQueuedFetchRequest() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        agent.setChannel(channel);
+        AtomicReference<LeiosPoint> failedPoint = new AtomicReference<>();
+        agent.addListener(new LeiosFetchAgentListener() {
+            @Override
+            public void onBlock(LeiosPoint requestedPoint, LeiosRawCbor endorserBlock) {
+                throw new IllegalStateException("listener failed");
+            }
+
+            @Override
+            public void onFetchError(LeiosPoint requestedPoint, Throwable error) {
+                failedPoint.set(requestedPoint);
+            }
+        });
+
+        LeiosPoint first = point(25);
+        LeiosPoint second = point(26);
+        LeiosTxBitmap bitmap = LeiosTxBitmap.firstN(1);
+        agent.requestBlock(first);
+        channel.readOutbound();
+        agent.requestBlockTxs(second, bitmap);
+
+        agent.receiveResponse(new MsgLeiosBlock(LeiosCborUtil.toRawCbor(rawArray(25, 26))));
+
+        Segment secondRequest = channel.readOutbound();
+        assertEquals(first, failedPoint.get());
+        assertInstanceOf(MsgLeiosBlockTxsRequest.class,
+                LeiosFetchStateBase.deserialize(secondRequest.getPayload()));
+        assertEquals(LeiosFetchState.StBlockTxs, agent.getCurrentState());
+    }
+
+    @Test
+    void resetReturnsToIdleAndClearsQueue() {
+        LeiosFetchAgent agent = new LeiosFetchAgent();
+
+        agent.requestBlock(point(9));
+        agent.shutdown();
+        agent.reset();
+
+        assertEquals(LeiosFetchState.StIdle, agent.getCurrentState());
+        assertEquals(0, agent.getQueueSize());
+        assertNull(agent.getOutstandingRequest());
+        assertNull(agent.buildNextMessage());
+    }
+
+    private Array rawArray(long first, long second) {
+        Array array = new Array();
+        array.add(new UnsignedInteger(first));
+        array.add(new UnsignedInteger(second));
+        return array;
+    }
+
+    private LeiosPoint point(int seed) {
+        byte[] hash = new byte[LeiosPoint.EB_HASH_LENGTH];
+        for (int i = 0; i < hash.length; i++) {
+            hash[i] = (byte) (seed + i);
+        }
+        return new LeiosPoint(100 + seed, hash);
+    }
+
+    private static class PendingWriteHandler extends ChannelOutboundHandlerAdapter {
+        private final List<Object> writes = new ArrayList<>();
+        private final List<ChannelPromise> promises = new ArrayList<>();
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            writes.add(msg);
+            promises.add(promise);
+        }
+
+        private void succeed(int index) {
+            promises.get(index).setSuccess();
+        }
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchSerializersTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leiosfetch/LeiosFetchSerializersTest.java
@@ -1,0 +1,160 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosfetch;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+import com.bloxbean.cardano.yaci.core.protocol.leios.serializers.LeiosCborUtil;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlock;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockRequest;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxs;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlockTxsRequest;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosFetchError;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.serializers.LeiosFetchSerializers;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LeiosFetchSerializersTest {
+
+    @Test
+    void serializesDoneTag() {
+        assertEquals("8109", HexUtil.encodeHexString(new MsgClientDone().serialize()));
+    }
+
+    @Test
+    void serializesAndDeserializesPrototypeBlockRequest() {
+        LeiosPoint point = point(1);
+        MsgLeiosBlockRequest request = new MsgLeiosBlockRequest(point);
+
+        MsgLeiosBlockRequest decoded = LeiosFetchSerializers.MsgLeiosBlockRequestSerializer.INSTANCE
+                .deserializeDI(CborSerializationUtil.deserializeOne(request.serialize()));
+
+        assertEquals(point, decoded.getPoint());
+    }
+
+    @Test
+    void serializesAndDeserializesBlockAsOpaqueCbor() {
+        LeiosRawCbor endorserBlock = LeiosCborUtil.toRawCbor(rawArray(10, 11));
+        MsgLeiosBlock block = new MsgLeiosBlock(endorserBlock);
+
+        Message decoded = LeiosFetchStateBase.deserialize(block.serialize());
+
+        MsgLeiosBlock decodedBlock = assertInstanceOf(MsgLeiosBlock.class, decoded);
+        assertEquals(endorserBlock, decodedBlock.getEndorserBlock());
+    }
+
+    @Test
+    void serializesAndDeserializesPrototypeBlockTxsRequest() {
+        LeiosPoint point = point(2);
+        LeiosTxBitmap bitmap = LeiosTxBitmap.fromIndices(0, 63, 64, 127);
+        MsgLeiosBlockTxsRequest request = new MsgLeiosBlockTxsRequest(point, bitmap);
+
+        MsgLeiosBlockTxsRequest decoded = LeiosFetchSerializers.MsgLeiosBlockTxsRequestSerializer.INSTANCE
+                .deserializeDI(CborSerializationUtil.deserializeOne(request.serialize()));
+
+        assertEquals(point, decoded.getPoint());
+        assertEquals(bitmap, decoded.getBitmap());
+        assertTrue(HexUtil.encodeHexString(request.serialize()).contains("bf"));
+    }
+
+    @Test
+    void serializesEmptyBitmapFieldsAsIndefiniteMaps() {
+        MsgLeiosBlockTxsRequest request =
+                new MsgLeiosBlockTxsRequest(point(6), LeiosTxBitmap.empty());
+        MsgLeiosBlockTxs response = new MsgLeiosBlockTxs(
+                point(7), LeiosTxBitmap.empty(), LeiosCborUtil.toRawCbor(rawArray(30, 31)));
+
+        assertTrue(HexUtil.encodeHexString(request.serialize()).contains("bfff"));
+        assertTrue(HexUtil.encodeHexString(response.serialize()).contains("bfff"));
+
+        Message decoded = LeiosFetchStateBase.deserialize(request.serialize());
+        MsgLeiosBlockTxsRequest decodedRequest = assertInstanceOf(MsgLeiosBlockTxsRequest.class, decoded);
+        assertEquals(LeiosTxBitmap.empty(), decodedRequest.getBitmap());
+    }
+
+    @Test
+    void serializesAndDeserializesPrototypeBlockTxsAsOpaqueCbor() {
+        LeiosPoint point = point(3);
+        LeiosTxBitmap bitmap = LeiosTxBitmap.firstN(65);
+        LeiosRawCbor txList = LeiosCborUtil.toRawCbor(rawArray(20, 21));
+        MsgLeiosBlockTxs blockTxs = new MsgLeiosBlockTxs(point, bitmap, txList);
+
+        MsgLeiosBlockTxs decoded = LeiosFetchSerializers.MsgLeiosBlockTxsSerializer.INSTANCE
+                .deserializeDI(CborSerializationUtil.deserializeOne(blockTxs.serialize()));
+
+        assertEquals(point, decoded.getPoint());
+        assertEquals(bitmap, decoded.getBitmap());
+        assertEquals(txList, decoded.getTxList());
+    }
+
+    @Test
+    void rejectsMessagesWithWrongArity() {
+        Array blockRequest = new Array();
+        blockRequest.add(new UnsignedInteger(0));
+
+        Array done = new Array();
+        done.add(new UnsignedInteger(9));
+        done.add(new UnsignedInteger(1));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> LeiosFetchSerializers.MsgLeiosBlockRequestSerializer.INSTANCE.deserializeDI(blockRequest));
+        assertThrows(IllegalArgumentException.class,
+                () -> LeiosFetchSerializers.MsgClientDoneSerializer.INSTANCE.deserializeDI(done));
+    }
+
+    @Test
+    void deserializesChunkedArraysWithBreakItems() {
+        Array done = new Array();
+        done.add(new UnsignedInteger(9));
+        done.add(SimpleValue.BREAK);
+
+        assertInstanceOf(MsgClientDone.class,
+                LeiosFetchSerializers.MsgClientDoneSerializer.INSTANCE.deserializeDI(done));
+    }
+
+    @Test
+    void trailingTopLevelCborReturnsErrorMessage() {
+        byte[] done = new MsgClientDone().serialize();
+        byte[] cborSequence = new byte[]{done[0], done[1], 0x01};
+
+        Message decoded = LeiosFetchStateBase.deserialize(cborSequence);
+
+        assertInstanceOf(MsgLeiosFetchError.class, decoded);
+    }
+
+    @Test
+    void unsupportedRangeTagsReturnErrorMessage() {
+        Array array = new Array();
+        array.add(new UnsignedInteger(4));
+
+        Message decoded = LeiosFetchStateBase.deserialize(CborSerializationUtil.serialize(array, false));
+
+        MsgLeiosFetchError error = assertInstanceOf(MsgLeiosFetchError.class, decoded);
+        assertInstanceOf(UnsupportedOperationException.class, error.getCause());
+    }
+
+    private Array rawArray(long first, long second) {
+        Array array = new Array();
+        array.add(new UnsignedInteger(first));
+        array.add(new UnsignedInteger(second));
+        return array;
+    }
+
+    private LeiosPoint point(int seed) {
+        byte[] hash = new byte[LeiosPoint.EB_HASH_LENGTH];
+        for (int i = 0; i < hash.length; i++) {
+            hash[i] = (byte) (seed + i);
+        }
+        return new LeiosPoint(100 + seed, hash);
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifyAgentTest.java
@@ -1,0 +1,326 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.Segment;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosProtocolConstants;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.serializers.LeiosCborUtil;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockTxsOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosNotificationRequestNext;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosNotifyError;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosVotes;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LeiosNotifyAgentTest {
+
+    @Test
+    void startsIdleWithClientAgencyAndProtocolId18() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+
+        assertEquals(LeiosNotifyState.StIdle, agent.getCurrentState());
+        assertEquals(LeiosProtocolConstants.LEIOS_NOTIFY_PROTOCOL_ID, agent.getProtocolId());
+        assertTrue(agent.hasAgency());
+        assertInstanceOf(MsgLeiosNotificationRequestNext.class, agent.buildNextMessage());
+    }
+
+    @Test
+    void requestNextMovesToBusyAndOfferMovesBackToIdle() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        LeiosPoint point = point(1);
+
+        agent.sendRequest(new MsgLeiosNotificationRequestNext());
+        assertEquals(LeiosNotifyState.StBusy, agent.getCurrentState());
+        assertFalse(agent.hasAgency());
+
+        agent.receiveResponse(new MsgLeiosBlockOffer(point, 44));
+        assertEquals(LeiosNotifyState.StIdle, agent.getCurrentState());
+        assertTrue(agent.hasAgency());
+    }
+
+    @Test
+    void dispatchesOfferCallbacks() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        LeiosPoint point = point(2);
+        AtomicReference<LeiosPoint> blockOfferPoint = new AtomicReference<>();
+        AtomicReference<Long> blockOfferSize = new AtomicReference<>();
+        AtomicReference<LeiosPoint> txOfferPoint = new AtomicReference<>();
+        agent.addListener(new LeiosNotifyAgentListener() {
+            @Override
+            public void onBlockOffer(LeiosPoint point, long ebSize) {
+                blockOfferPoint.set(point);
+                blockOfferSize.set(ebSize);
+            }
+
+            @Override
+            public void onBlockTxsOffer(LeiosPoint point) {
+                txOfferPoint.set(point);
+            }
+        });
+
+        agent.sendRequest(new MsgLeiosNotificationRequestNext());
+        agent.receiveResponse(new MsgLeiosBlockOffer(point, 45));
+        agent.sendRequest(new MsgLeiosNotificationRequestNext());
+        agent.receiveResponse(new MsgLeiosBlockTxsOffer(point));
+
+        assertEquals(point, blockOfferPoint.get());
+        assertEquals(45, blockOfferSize.get());
+        assertEquals(point, txOfferPoint.get());
+    }
+
+    @Test
+    void dispatchesVotesCallback() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        LeiosRawCbor vote = LeiosCborUtil.toRawCbor(rawArray(1));
+        AtomicReference<List<LeiosRawCbor>> observedVotes = new AtomicReference<>();
+        agent.addListener(new LeiosNotifyAgentListener() {
+            @Override
+            public void onVotes(List<LeiosRawCbor> votes) {
+                observedVotes.set(votes);
+            }
+        });
+
+        agent.sendRequest(new MsgLeiosNotificationRequestNext());
+        agent.receiveResponse(new MsgLeiosVotes(List.of(vote)));
+
+        assertEquals(List.of(vote), observedVotes.get());
+        assertEquals(LeiosNotifyState.StIdle, agent.getCurrentState());
+    }
+
+    @Test
+    void shutdownBuildsDoneAndTransitionsTerminal() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+
+        agent.shutdown();
+        Message done = agent.buildNextMessage();
+        assertInstanceOf(MsgClientDone.class, done);
+        agent.sendRequest(done);
+
+        assertTrue(agent.isDone());
+        assertFalse(agent.hasAgency());
+    }
+
+    @Test
+    void invalidInboundMessageIsNotDispatchedInIdle() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicReference<LeiosPoint> blockOfferPoint = new AtomicReference<>();
+        agent.addListener(new LeiosNotifyAgentListener() {
+            @Override
+            public void onBlockOffer(LeiosPoint point, long ebSize) {
+                blockOfferPoint.set(point);
+            }
+
+            @Override
+            public void onNotifyError(Throwable observed) {
+                error.set(observed);
+            }
+        });
+
+        agent.receiveResponse(new MsgLeiosBlockOffer(point(3), 3));
+
+        assertEquals(LeiosNotifyState.StIdle, agent.getCurrentState());
+        assertNull(blockOfferPoint.get());
+        assertInstanceOf(IllegalStateException.class, error.get());
+    }
+
+    @Test
+    void invalidInboundMessageInBusyReportsErrorAndReturnsIdle() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        agent.addListener(new LeiosNotifyAgentListener() {
+            @Override
+            public void onNotifyError(Throwable observed) {
+                error.set(observed);
+            }
+        });
+
+        agent.sendRequest(new MsgLeiosNotificationRequestNext());
+        agent.receiveResponse(new MsgClientDone());
+
+        assertEquals(LeiosNotifyState.StIdle, agent.getCurrentState());
+        assertInstanceOf(IllegalStateException.class, error.get());
+    }
+
+    @Test
+    void parseErrorReportsCauseAndReturnsIdle() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        agent.addListener(new LeiosNotifyAgentListener() {
+            @Override
+            public void onNotifyError(Throwable observed) {
+                error.set(observed);
+            }
+        });
+
+        agent.sendRequest(new MsgLeiosNotificationRequestNext());
+        Throwable cause = new IllegalArgumentException("bad frame");
+        agent.receiveResponse(new MsgLeiosNotifyError(cause));
+
+        assertEquals(LeiosNotifyState.StIdle, agent.getCurrentState());
+        assertEquals(cause, error.get());
+    }
+
+    @Test
+    void parseErrorWhileStreamingReportsAndReArmsRequestNext() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        agent.setChannel(channel);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        agent.addListener(new LeiosNotifyAgentListener() {
+            @Override
+            public void onNotifyError(Throwable observed) {
+                error.set(observed);
+            }
+        });
+
+        agent.start();
+        assertInstanceOf(MsgLeiosNotificationRequestNext.class,
+                LeiosNotifyStateBase.deserialize(((Segment) channel.readOutbound()).getPayload()));
+
+        Throwable cause = new IllegalArgumentException("bad frame");
+        agent.receiveResponse(new MsgLeiosNotifyError(cause));
+
+        Segment secondRequest = channel.readOutbound();
+        assertEquals(cause, error.get());
+        assertEquals(LeiosNotifyState.StBusy, agent.getCurrentState());
+        assertInstanceOf(MsgLeiosNotificationRequestNext.class,
+                LeiosNotifyStateBase.deserialize(secondRequest.getPayload()));
+    }
+
+    @Test
+    void listenerExceptionDoesNotStopStreamingLoop() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        agent.setChannel(channel);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        agent.addListener(new LeiosNotifyAgentListener() {
+            @Override
+            public void onBlockTxsOffer(LeiosPoint point) {
+                throw new IllegalStateException("listener failed");
+            }
+
+            @Override
+            public void onNotifyError(Throwable observed) {
+                error.set(observed);
+            }
+        });
+
+        agent.start();
+        channel.readOutbound();
+        agent.receiveResponse(new MsgLeiosBlockTxsOffer(point(14)));
+
+        Segment secondRequest = channel.readOutbound();
+        assertInstanceOf(IllegalStateException.class, error.get());
+        assertEquals(LeiosNotifyState.StBusy, agent.getCurrentState());
+        assertInstanceOf(MsgLeiosNotificationRequestNext.class,
+                LeiosNotifyStateBase.deserialize(secondRequest.getPayload()));
+    }
+
+    @Test
+    void shutdownWaitsForRequestNextWriteBeforeClientDone() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        PendingWriteHandler pendingWrites = new PendingWriteHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(pendingWrites);
+        agent.setChannel(channel);
+
+        agent.start();
+        agent.shutdown();
+
+        assertEquals(1, pendingWrites.writes.size());
+
+        pendingWrites.succeed(0);
+
+        assertEquals(LeiosNotifyState.StBusy, agent.getCurrentState());
+        assertEquals(1, pendingWrites.writes.size());
+
+        agent.receiveResponse(new MsgLeiosBlockTxsOffer(point(15)));
+
+        assertEquals(2, pendingWrites.writes.size());
+        pendingWrites.succeed(1);
+
+        assertTrue(agent.isDone());
+    }
+
+    @Test
+    void startSendsRequestNextAndAutoRequestsAfterNotification() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        agent.setChannel(channel);
+
+        agent.start();
+
+        Segment firstRequest = channel.readOutbound();
+        assertEquals(LeiosProtocolConstants.LEIOS_NOTIFY_PROTOCOL_ID, firstRequest.getProtocol());
+        assertInstanceOf(MsgLeiosNotificationRequestNext.class,
+                LeiosNotifyStateBase.deserialize(firstRequest.getPayload()));
+        assertEquals(LeiosNotifyState.StBusy, agent.getCurrentState());
+
+        agent.receiveResponse(new MsgLeiosBlockTxsOffer(point(4)));
+
+        Segment secondRequest = channel.readOutbound();
+        assertEquals(LeiosProtocolConstants.LEIOS_NOTIFY_PROTOCOL_ID, secondRequest.getProtocol());
+        assertInstanceOf(MsgLeiosNotificationRequestNext.class,
+                LeiosNotifyStateBase.deserialize(secondRequest.getPayload()));
+        assertEquals(LeiosNotifyState.StBusy, agent.getCurrentState());
+    }
+
+    @Test
+    void resetReturnsToIdle() {
+        LeiosNotifyAgent agent = new LeiosNotifyAgent();
+        agent.shutdown();
+        agent.sendRequest(new MsgClientDone());
+
+        agent.reset();
+
+        assertEquals(LeiosNotifyState.StIdle, agent.getCurrentState());
+        assertInstanceOf(MsgLeiosNotificationRequestNext.class, agent.buildNextMessage());
+    }
+
+    private Array rawArray(long tag) {
+        Array array = new Array();
+        array.add(new UnsignedInteger(tag));
+        return array;
+    }
+
+    private LeiosPoint point(int seed) {
+        byte[] hash = new byte[LeiosPoint.EB_HASH_LENGTH];
+        for (int i = 0; i < hash.length; i++) {
+            hash[i] = (byte) (seed + i);
+        }
+        return new LeiosPoint(100 + seed, hash);
+    }
+
+    private static class PendingWriteHandler extends ChannelOutboundHandlerAdapter {
+        private final List<Object> writes = new ArrayList<>();
+        private final List<ChannelPromise> promises = new ArrayList<>();
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            writes.add(msg);
+            promises.add(promise);
+        }
+
+        private void succeed(int index) {
+            promises.get(index).setSuccess();
+        }
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifySerializersTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/leiosnotify/LeiosNotifySerializersTest.java
@@ -1,0 +1,168 @@
+package com.bloxbean.cardano.yaci.core.protocol.leiosnotify;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.serializers.LeiosCborUtil;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgClientDone;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockAnnouncement;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockTxsOffer;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosNotificationRequestNext;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosNotifyError;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosVotes;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.serializers.LeiosNotifySerializers;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LeiosNotifySerializersTest {
+
+    @Test
+    void serializesRequestNextAndDoneTags() {
+        assertEquals("8100", HexUtil.encodeHexString(new MsgLeiosNotificationRequestNext().serialize()));
+        assertEquals("8105", HexUtil.encodeHexString(new MsgClientDone().serialize()));
+    }
+
+    @Test
+    void rejectsRequestNextAndDoneWithExtraFields() {
+        Array requestNext = new Array();
+        requestNext.add(new UnsignedInteger(0));
+        requestNext.add(new UnsignedInteger(1));
+
+        Array done = new Array();
+        done.add(new UnsignedInteger(5));
+        done.add(new UnsignedInteger(1));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> LeiosNotifySerializers.MsgLeiosNotificationRequestNextSerializer.INSTANCE
+                        .deserializeDI(requestNext));
+        assertThrows(IllegalArgumentException.class,
+                () -> LeiosNotifySerializers.MsgClientDoneSerializer.INSTANCE.deserializeDI(done));
+    }
+
+    @Test
+    void deserializesChunkedArraysWithBreakItems() {
+        Array requestNext = new Array();
+        requestNext.add(new UnsignedInteger(0));
+        requestNext.add(SimpleValue.BREAK);
+
+        assertInstanceOf(MsgLeiosNotificationRequestNext.class,
+                LeiosNotifySerializers.MsgLeiosNotificationRequestNextSerializer.INSTANCE
+                        .deserializeDI(requestNext));
+    }
+
+    @Test
+    void serializesAndDeserializesBlockAnnouncementAsOpaqueCbor() {
+        LeiosRawCbor announcement = LeiosCborUtil.toRawCbor(rawArray(7, 8));
+        MsgLeiosBlockAnnouncement message = new MsgLeiosBlockAnnouncement(announcement);
+
+        Message decoded = LeiosNotifyStateBase.deserialize(message.serialize());
+
+        MsgLeiosBlockAnnouncement decodedAnnouncement =
+                assertInstanceOf(MsgLeiosBlockAnnouncement.class, decoded);
+        assertEquals(announcement, decodedAnnouncement.getAnnouncement());
+    }
+
+    @Test
+    void serializesAndDeserializesPrototypeBlockOffer() {
+        LeiosPoint point = point(11);
+        MsgLeiosBlockOffer offer = new MsgLeiosBlockOffer(point, 1234);
+
+        MsgLeiosBlockOffer decoded = LeiosNotifySerializers.MsgLeiosBlockOfferSerializer.INSTANCE
+                .deserializeDI(CborSerializationUtil.deserializeOne(offer.serialize()));
+
+        assertEquals(point, decoded.getPoint());
+        assertEquals(1234, decoded.getEbSize());
+    }
+
+    @Test
+    void serializesAndDeserializesPrototypeBlockTxsOffer() {
+        LeiosPoint point = point(12);
+        MsgLeiosBlockTxsOffer offer = new MsgLeiosBlockTxsOffer(point);
+
+        MsgLeiosBlockTxsOffer decoded = LeiosNotifySerializers.MsgLeiosBlockTxsOfferSerializer.INSTANCE
+                .deserializeDI(CborSerializationUtil.deserializeOne(offer.serialize()));
+
+        assertEquals(point, decoded.getPoint());
+    }
+
+    @Test
+    void serializesAndDeserializesPrototypeVotesAsOpaqueItems() {
+        LeiosRawCbor vote = LeiosCborUtil.toRawCbor(voteArray(15, point(15).getEbHash(), 1));
+        MsgLeiosVotes votes = new MsgLeiosVotes(List.of(vote));
+
+        MsgLeiosVotes decoded = LeiosNotifySerializers.MsgLeiosVotesSerializer.INSTANCE
+                .deserializeDI(CborSerializationUtil.deserializeOne(votes.serialize()));
+
+        assertEquals(List.of(vote), decoded.getVotes());
+    }
+
+    @Test
+    void rejectsPrototypeBlockOfferWithoutEbSize() {
+        Array array = new Array();
+        array.add(new UnsignedInteger(2));
+        array.add(LeiosCborUtil.serializePointArray(point(1)));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            var encoded = CborSerializationUtil.serialize(array, false);
+            var dataItem = CborSerializationUtil.deserializeOne(encoded);
+            LeiosNotifySerializers.MsgLeiosBlockOfferSerializer.INSTANCE.deserializeDI(dataItem);
+        });
+    }
+
+    @Test
+    void trailingTopLevelCborReturnsErrorMessage() {
+        byte[] requestNext = new MsgLeiosNotificationRequestNext().serialize();
+        byte[] cborSequence = new byte[]{requestNext[0], requestNext[1], 0x01};
+
+        Message decoded = LeiosNotifyStateBase.deserialize(cborSequence);
+
+        assertInstanceOf(MsgLeiosNotifyError.class, decoded);
+    }
+
+    @Test
+    void protectsMessagePayloadsFromMutation() {
+        byte[] hash = point(5).getEbHash();
+        LeiosRawCbor vote = LeiosCborUtil.toRawCbor(voteArray(5, hash, 1));
+        MsgLeiosVotes votes = new MsgLeiosVotes(List.of(vote));
+
+        assertThrows(UnsupportedOperationException.class, () -> votes.getVotes().add(vote));
+        assertArrayEquals(vote.getCbor(), votes.getVotes().get(0).getCbor());
+    }
+
+    private Array rawArray(long first, long second) {
+        Array array = new Array();
+        array.add(new UnsignedInteger(first));
+        array.add(new UnsignedInteger(second));
+        return array;
+    }
+
+    private Array voteArray(long slot, byte[] hash, int voterId) {
+        Array array = new Array();
+        array.add(new UnsignedInteger(slot));
+        array.add(new ByteString(hash));
+        array.add(new UnsignedInteger(voterId));
+        array.add(new ByteString(new byte[48]));
+        return array;
+    }
+
+    private LeiosPoint point(int seed) {
+        byte[] hash = new byte[LeiosPoint.EB_HASH_LENGTH];
+        for (int i = 0; i < hash.length; i++) {
+            hash[i] = (byte) (seed + i);
+        }
+        return new LeiosPoint(100 + seed, hash);
+    }
+}

--- a/docs/leios-spec-tracking.md
+++ b/docs/leios-spec-tracking.md
@@ -1,0 +1,30 @@
+# Linear Leios Spec Tracking
+
+Last verified: 2026-07-02
+
+Yaci's experimental Linear Leios support currently implements the Musashi network mini-protocol wire format from
+the cardano-blueprint `leios-prototype` branch at commit `188183b37081fa012fa890236edb7771f96ae92f`.
+
+The implemented scope is limited to node-to-node mini-protocol framing for:
+
+- `leios-notify` on mux protocol id `18`
+- `leios-fetch` on mux protocol id `19`
+
+Endorser block, vote, and transaction-list bodies are kept as opaque CBOR payloads. Block-level
+serialization/deserialization is intentionally outside this implementation.
+
+The source CDDL files for the current implementation are:
+
+- `src/network/node-to-node/leios-notify/messages.cddl`
+- `src/network/node-to-node/leios-fetch/messages.cddl`
+
+This support is Musashi-specific and uses network magic `164`. N2N version `15` is required by the prototype
+handshake, but version `15` alone is not treated as a Leios capability signal. Leios activation must remain
+explicitly tied to Musashi, or to a future handshake/network capability once one exists.
+
+There is no runtime `LeiosProtocolProfile` enum. While the protocol is still moving, Yaci tracks one spec snapshot
+per release. If two live networks later speak different Leios dialects, prefer lenient decoding and explicit
+network/capability flags over threading profile arguments through every serializer.
+
+Future conformance work should vendor the two CDDL files above into test resources with this commit hash and add
+round-trip checks for each supported message shape.

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/LeiosNetworkClient.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/LeiosNetworkClient.java
@@ -1,0 +1,384 @@
+package com.bloxbean.cardano.yaci.helper;
+
+import com.bloxbean.cardano.yaci.core.common.Constants;
+import com.bloxbean.cardano.yaci.core.network.NodeClientConfig;
+import com.bloxbean.cardano.yaci.core.network.TCPNodeClient;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgent;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.HandshakeAgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.N2NVersionData;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.Reason;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.VersionData;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.VersionTable;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
+import com.bloxbean.cardano.yaci.core.protocol.keepalive.KeepAliveAgent;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.LeiosFetchAgent;
+import com.bloxbean.cardano.yaci.core.protocol.leiosfetch.LeiosFetchAgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.LeiosNotifyAgent;
+import com.bloxbean.cardano.yaci.core.protocol.leiosnotify.LeiosNotifyAgentListener;
+import com.bloxbean.cardano.yaci.helper.listener.LeiosDataListener;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+@Slf4j
+public class LeiosNetworkClient implements AutoCloseable {
+    private static final int KEEP_ALIVE_INTERVAL_SECONDS = 10;
+    private static final long GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS = 2_000;
+
+    private final String host;
+    private final int port;
+    private final long networkMagic;
+    private final NodeClientConfig nodeClientConfig;
+    private final HandshakeAgent handshakeAgent;
+    private final KeepAliveAgent keepAliveAgent;
+    private final LeiosNotifyAgent leiosNotifyAgent;
+    private final LeiosFetchAgent leiosFetchAgent;
+    private final TCPNodeClient nodeClient;
+    private final List<LeiosDataListener> dataListeners = new CopyOnWriteArrayList<>();
+    private final AtomicBoolean disconnectNotified = new AtomicBoolean(false);
+    private final AtomicBoolean clientClosing = new AtomicBoolean(false);
+    private final ScheduledExecutorService keepAliveExecutor;
+
+    private volatile AcceptVersion protocolVersion;
+    private volatile boolean leiosActive;
+    private volatile boolean handshakeCompleted;
+    private volatile ScheduledFuture<?> keepAliveFuture;
+
+    public LeiosNetworkClient(String host, int port) {
+        this(host, port, Constants.MUSASHI_PROTOCOL_MAGIC);
+    }
+
+    public LeiosNetworkClient(String host, int port, long networkMagic) {
+        this(host, port, networkMagic, leiosVersionTable(networkMagic));
+    }
+
+    public LeiosNetworkClient(String host, int port, long networkMagic, VersionTable versionTable) {
+        this(host, port, networkMagic, versionTable, NodeClientConfig.defaultConfig());
+    }
+
+    public LeiosNetworkClient(String host, int port, long networkMagic,
+                              VersionTable versionTable, NodeClientConfig nodeClientConfig) {
+        this.host = Objects.requireNonNull(host, "host");
+        this.port = port;
+        this.networkMagic = networkMagic;
+        this.nodeClientConfig = nodeClientConfig != null ? nodeClientConfig : NodeClientConfig.defaultConfig();
+
+        VersionTable effectiveVersionTable = Objects.requireNonNull(versionTable, "versionTable");
+        this.handshakeAgent = new HandshakeAgent(effectiveVersionTable);
+        this.keepAliveAgent = new KeepAliveAgent();
+        this.leiosNotifyAgent = new LeiosNotifyAgent();
+        this.leiosFetchAgent = new LeiosFetchAgent();
+        this.keepAliveExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread thread = new Thread(r, "yaci-leios-keepalive-" + host + ":" + port);
+            thread.setDaemon(true);
+            return thread;
+        });
+        this.nodeClient = new TCPNodeClient(
+                host, port, this.nodeClientConfig, handshakeAgent, keepAliveAgent,
+                leiosNotifyAgent, leiosFetchAgent);
+
+        setupListeners();
+    }
+
+    public void start() {
+        clientClosing.set(false);
+        nodeClient.start();
+    }
+
+    public void shutdown() {
+        clientClosing.set(true);
+        leiosActive = false;
+        stopKeepAliveTimer();
+        leiosNotifyAgent.shutdown();
+        leiosFetchAgent.done();
+        waitForGracefulMiniProtocolShutdown();
+        keepAliveAgent.shutdown();
+        nodeClient.shutdown();
+        keepAliveExecutor.shutdownNow();
+    }
+
+    @Override
+    public void close() {
+        shutdown();
+    }
+
+    public boolean isRunning() {
+        return nodeClient.isRunning();
+    }
+
+    public boolean isLeiosActive() {
+        return leiosActive;
+    }
+
+    public Optional<AcceptVersion> getProtocolVersion() {
+        return Optional.ofNullable(protocolVersion);
+    }
+
+    public long getNetworkMagic() {
+        return networkMagic;
+    }
+
+    LeiosNotifyAgent getLeiosNotifyAgent() {
+        return leiosNotifyAgent;
+    }
+
+    LeiosFetchAgent getLeiosFetchAgent() {
+        return leiosFetchAgent;
+    }
+
+    public void addDataListener(LeiosDataListener listener) {
+        if (listener != null) {
+            dataListeners.add(listener);
+        }
+    }
+
+    public void addNotifyListener(LeiosNotifyAgentListener listener) {
+        if (listener != null) {
+            leiosNotifyAgent.addListener(listener);
+        }
+    }
+
+    public void addFetchListener(LeiosFetchAgentListener listener) {
+        if (listener != null) {
+            leiosFetchAgent.addListener(listener);
+        }
+    }
+
+    public void requestBlock(LeiosPoint point) {
+        ensureActive();
+        leiosFetchAgent.requestBlock(point);
+    }
+
+    public void requestBlockTxs(LeiosPoint point, LeiosTxBitmap bitmap) {
+        ensureActive();
+        if (bitmap.isEmpty()) {
+            throw new IllegalArgumentException("Empty Leios tx bitmap requests are disabled until inbound mux " +
+                    "CBOR byte-fidelity is fixed");
+        }
+        leiosFetchAgent.requestBlockTxs(point, bitmap);
+    }
+
+    public void requestFirstBlockTxs(LeiosPoint point, int txCount) {
+        requestBlockTxs(point, LeiosTxBitmap.firstN(txCount));
+    }
+
+    public void sendKeepAliveMessage(int cookie) {
+        keepAliveAgent.sendKeepAlive(cookie);
+    }
+
+    void handleHandshakeComplete(AcceptVersion acceptVersion) {
+        this.protocolVersion = acceptVersion;
+        this.handshakeCompleted = true;
+        this.clientClosing.set(false);
+        disconnectNotified.set(false);
+        dispatchDataListener(listener -> listener.onHandshake(acceptVersion), "onHandshake");
+
+        if (isLeiosCompatible(acceptVersion)) {
+            leiosActive = true;
+            startKeepAliveTimer();
+            leiosNotifyAgent.start();
+            dispatchDataListener(listener -> listener.onLeiosActivated(acceptVersion), "onLeiosActivated");
+            log.info("Leios mini-protocols activated for {}:{} with {}", host, port, acceptVersion);
+        } else {
+            leiosActive = false;
+            leiosNotifyAgent.stopAutoRequestNext();
+            stopKeepAliveTimer();
+            dispatchDataListener(listener -> listener.onLeiosNotActivated(acceptVersion), "onLeiosNotActivated");
+            log.info("Leios mini-protocols not activated for {}:{} with {}", host, port, acceptVersion);
+        }
+    }
+
+    private void setupListeners() {
+        handshakeAgent.addListener(new HandshakeAgentListener() {
+            @Override
+            public void handshakeOk() {
+                handleHandshakeComplete(handshakeAgent.getProtocolVersion());
+            }
+
+            @Override
+            public void handshakeError(Reason reason) {
+                leiosActive = false;
+                stopKeepAliveTimer();
+                dispatchDataListener(listener -> listener.onHandshakeError(reason), "onHandshakeError");
+            }
+        });
+
+        leiosNotifyAgent.addListener(new LeiosNotifyAgentListener() {
+            @Override
+            public void onBlockAnnouncement(LeiosRawCbor announcement) {
+                dispatchDataListener(listener -> listener.onBlockAnnouncement(announcement),
+                        "onBlockAnnouncement");
+            }
+
+            @Override
+            public void onBlockOffer(LeiosPoint point, long ebSize) {
+                dispatchDataListener(listener -> listener.onBlockOffer(point, ebSize), "onBlockOffer");
+            }
+
+            @Override
+            public void onBlockTxsOffer(LeiosPoint point) {
+                dispatchDataListener(listener -> listener.onBlockTxsOffer(point), "onBlockTxsOffer");
+            }
+
+            @Override
+            public void onVotes(List<LeiosRawCbor> votes) {
+                dispatchDataListener(listener -> listener.onVotes(votes), "onVotes");
+            }
+
+            @Override
+            public void onNotifyError(Throwable error) {
+                dispatchDataListener(listener -> listener.onNotifyError(error), "onNotifyError");
+            }
+
+            @Override
+            public void onDisconnect() {
+                handleDisconnect();
+            }
+        });
+
+        leiosFetchAgent.addListener(new LeiosFetchAgentListener() {
+            @Override
+            public void onBlock(LeiosPoint requestedPoint, LeiosRawCbor endorserBlock) {
+                dispatchDataListener(listener -> listener.onBlock(requestedPoint, endorserBlock), "onBlock");
+            }
+
+            @Override
+            public void onBlockTxs(LeiosPoint requestedPoint, LeiosPoint responsePoint,
+                                   LeiosTxBitmap responseBitmap, LeiosRawCbor txList) {
+                dispatchDataListener(listener ->
+                        listener.onBlockTxs(requestedPoint, responsePoint, responseBitmap, txList), "onBlockTxs");
+            }
+
+            @Override
+            public void onFetchError(Throwable error) {
+                dispatchDataListener(listener -> listener.onFetchError(error), "onFetchError");
+            }
+
+            @Override
+            public void onFetchError(LeiosPoint requestedPoint, Throwable error) {
+                dispatchDataListener(listener -> listener.onFetchError(requestedPoint, error),
+                        "onFetchError(point)");
+            }
+
+            @Override
+            public void onDisconnect() {
+                handleDisconnect();
+            }
+        });
+    }
+
+    void handleDisconnect() {
+        leiosActive = false;
+        stopKeepAliveTimer();
+        leiosNotifyAgent.reset();
+        leiosFetchAgent.reset();
+        if (clientClosing.get()) {
+            return;
+        }
+        if (handshakeCompleted && disconnectNotified.compareAndSet(false, true)) {
+            dispatchDataListener(LeiosDataListener::onDisconnect, "onDisconnect");
+        }
+    }
+
+    private void ensureActive() {
+        if (!leiosActive) {
+            throw new IllegalStateException("Leios mini-protocols are not active");
+        }
+    }
+
+    private static VersionTable leiosVersionTable(long networkMagic) {
+        N2NVersionData versionData = new N2NVersionData(networkMagic, true, 0, false);
+        Map<Long, VersionData> versionTableMap = new HashMap<>();
+        versionTableMap.put(N2NVersionTableConstant.PROTOCOL_V11, versionData);
+        versionTableMap.put(N2NVersionTableConstant.PROTOCOL_V12, versionData);
+        versionTableMap.put(N2NVersionTableConstant.PROTOCOL_V13, versionData);
+        versionTableMap.put(N2NVersionTableConstant.PROTOCOL_V14, versionData);
+        versionTableMap.put(N2NVersionTableConstant.PROTOCOL_V15, versionData);
+        return new VersionTable(versionTableMap);
+    }
+
+    private boolean isLeiosCompatible(AcceptVersion acceptVersion) {
+        if (networkMagic != Constants.MUSASHI_PROTOCOL_MAGIC
+                || acceptVersion == null
+                || N2NVersionTableConstant.isAppLayerVersion(acceptVersion.getVersionNumber())
+                || acceptVersion.getVersionNumber() < N2NVersionTableConstant.PROTOCOL_V15) {
+            return false;
+        }
+
+        VersionData versionData = acceptVersion.getVersionData();
+        return versionData != null && versionData.getNetworkMagic() == Constants.MUSASHI_PROTOCOL_MAGIC;
+    }
+
+    private void startKeepAliveTimer() {
+        if (!keepAliveAgent.isChannelActive() || keepAliveExecutor.isShutdown()) {
+            return;
+        }
+        ScheduledFuture<?> current = keepAliveFuture;
+        if (current != null && !current.isDone()) {
+            return;
+        }
+
+        keepAliveFuture = keepAliveExecutor.scheduleAtFixedRate(() -> {
+            if (!leiosActive || clientClosing.get() || !keepAliveAgent.isChannelActive()) {
+                return;
+            }
+            try {
+                keepAliveAgent.sendKeepAlive(ThreadLocalRandom.current().nextInt(KeepAliveAgent.MAX_NUM + 1));
+            } catch (Exception e) {
+                log.warn("Leios keep-alive send failed", e);
+            }
+        }, 0, KEEP_ALIVE_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private void stopKeepAliveTimer() {
+        ScheduledFuture<?> current = keepAliveFuture;
+        if (current != null) {
+            current.cancel(false);
+            keepAliveFuture = null;
+        }
+    }
+
+    private void waitForGracefulMiniProtocolShutdown() {
+        if (!handshakeCompleted) {
+            return;
+        }
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS);
+        while (System.nanoTime() < deadline) {
+            if (leiosNotifyAgent.isDone() && leiosFetchAgent.isDone()) {
+                return;
+            }
+            try {
+                TimeUnit.MILLISECONDS.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private void dispatchDataListener(Consumer<LeiosDataListener> action, String callbackName) {
+        for (LeiosDataListener listener : dataListeners) {
+            try {
+                action.accept(listener);
+            } catch (Exception e) {
+                log.warn("Leios data listener {} failed", callbackName, e);
+            }
+        }
+    }
+}

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/listener/LeiosDataListener.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/listener/LeiosDataListener.java
@@ -1,0 +1,55 @@
+package com.bloxbean.cardano.yaci.helper.listener;
+
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.Reason;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+
+import java.util.List;
+
+public interface LeiosDataListener {
+    default void onHandshake(AcceptVersion acceptVersion) {
+    }
+
+    default void onLeiosActivated(AcceptVersion acceptVersion) {
+    }
+
+    default void onLeiosNotActivated(AcceptVersion acceptVersion) {
+    }
+
+    default void onHandshakeError(Reason reason) {
+    }
+
+    default void onBlockAnnouncement(LeiosRawCbor announcement) {
+    }
+
+    default void onBlockOffer(LeiosPoint point, long ebSize) {
+    }
+
+    default void onBlockTxsOffer(LeiosPoint point) {
+    }
+
+    default void onVotes(List<LeiosRawCbor> votes) {
+    }
+
+    default void onBlock(LeiosPoint requestedPoint, LeiosRawCbor endorserBlock) {
+    }
+
+    default void onBlockTxs(LeiosPoint requestedPoint, LeiosPoint responsePoint,
+                            LeiosTxBitmap responseBitmap, LeiosRawCbor txList) {
+    }
+
+    default void onNotifyError(Throwable error) {
+    }
+
+    default void onFetchError(Throwable error) {
+    }
+
+    default void onFetchError(LeiosPoint requestedPoint, Throwable error) {
+        onFetchError(error);
+    }
+
+    default void onDisconnect() {
+    }
+}

--- a/helper/src/test/java/com/bloxbean/cardano/yaci/helper/LeiosMusashiSmokeTest.java
+++ b/helper/src/test/java/com/bloxbean/cardano/yaci/helper/LeiosMusashiSmokeTest.java
@@ -1,0 +1,314 @@
+package com.bloxbean.cardano.yaci.helper;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yaci.helper.listener.LeiosDataListener;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+@EnabledIfEnvironmentVariable(named = "YACI_MUSASHI_SMOKE", matches = "true")
+class LeiosMusashiSmokeTest {
+    private static final String DEFAULT_HOST = "leios-node.play.dev.cardano.org";
+    private static final int DEFAULT_PORT = 3001;
+    private static final int DEFAULT_HANDSHAKE_TIMEOUT_SECONDS = 30;
+    private static final int DEFAULT_NOTIFICATION_WAIT_SECONDS = 90;
+    private static final int DEFAULT_PROGRESS_LOG_SECONDS = 60;
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+    private static final BigInteger WORD16_MAX = BigInteger.valueOf(0xFFFF);
+
+    @Test
+    void connectsToMusashiAndActivatesLeiosMiniProtocols() throws InterruptedException {
+        String host = env("YACI_MUSASHI_HOST", DEFAULT_HOST);
+        int port = intEnv("YACI_MUSASHI_PORT", DEFAULT_PORT);
+        int handshakeTimeoutSeconds = intEnv("YACI_MUSASHI_HANDSHAKE_TIMEOUT_SECONDS",
+                DEFAULT_HANDSHAKE_TIMEOUT_SECONDS);
+        int notificationWaitSeconds = intEnv("YACI_MUSASHI_NOTIFICATION_WAIT_SECONDS",
+                DEFAULT_NOTIFICATION_WAIT_SECONDS);
+        int progressLogSeconds = intEnv("YACI_MUSASHI_PROGRESS_LOG_SECONDS", DEFAULT_PROGRESS_LOG_SECONDS);
+        boolean runFullWindow = booleanEnv("YACI_MUSASHI_RUN_FULL_WINDOW", false);
+        boolean fetchFromVote = booleanEnv("YACI_MUSASHI_FETCH_FROM_VOTE", false);
+
+        CountDownLatch handshakeLatch = new CountDownLatch(1);
+        CountDownLatch firstNotificationLatch = new CountDownLatch(1);
+        CountDownLatch fetchLatch = new CountDownLatch(1);
+        AtomicReference<AcceptVersion> acceptedVersion = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean blockOfferFetchRequested = new AtomicBoolean(false);
+        AtomicBoolean voteFetchRequested = new AtomicBoolean(false);
+        AtomicInteger announcements = new AtomicInteger();
+        AtomicInteger blockOffers = new AtomicInteger();
+        AtomicInteger blockTxsOffers = new AtomicInteger();
+        AtomicInteger voteMessages = new AtomicInteger();
+        AtomicInteger decodedVotes = new AtomicInteger();
+        AtomicInteger voteFetchRequests = new AtomicInteger();
+        AtomicInteger voteFetchErrors = new AtomicInteger();
+        AtomicInteger fetchedBlocks = new AtomicInteger();
+
+        LeiosNetworkClient client = new LeiosNetworkClient(host, port);
+        client.addDataListener(new LeiosDataListener() {
+            @Override
+            public void onHandshake(AcceptVersion acceptVersion) {
+                acceptedVersion.set(acceptVersion);
+                handshakeLatch.countDown();
+                log.info("Musashi handshake accepted: {}", acceptVersion);
+            }
+
+            @Override
+            public void onLeiosActivated(AcceptVersion acceptVersion) {
+                log.info("Leios mini-protocols activated: {}", acceptVersion);
+            }
+
+            @Override
+            public void onLeiosNotActivated(AcceptVersion acceptVersion) {
+                failure.compareAndSet(null,
+                        new IllegalStateException("Handshake did not activate Leios: " + acceptVersion));
+                handshakeLatch.countDown();
+            }
+
+            @Override
+            public void onBlockAnnouncement(LeiosRawCbor announcement) {
+                announcements.incrementAndGet();
+                firstNotificationLatch.countDown();
+                log.info("Leios block announcement received: {} bytes", announcement.getCbor().length);
+            }
+
+            @Override
+            public void onBlockOffer(LeiosPoint point, long ebSize) {
+                blockOffers.incrementAndGet();
+                firstNotificationLatch.countDown();
+                log.info("Leios block offer received: point={}, ebSize={}", formatPoint(point), ebSize);
+                if (blockOfferFetchRequested.compareAndSet(false, true)) {
+                    client.requestBlock(point);
+                }
+            }
+
+            @Override
+            public void onBlockTxsOffer(LeiosPoint point) {
+                blockTxsOffers.incrementAndGet();
+                firstNotificationLatch.countDown();
+                log.info("Leios block txs offer received: point={}", formatPoint(point));
+            }
+
+            @Override
+            public void onVotes(List<LeiosRawCbor> votes) {
+                voteMessages.incrementAndGet();
+                firstNotificationLatch.countDown();
+                log.info("Leios votes received: count={}", votes.size());
+                for (LeiosRawCbor rawVote : votes) {
+                    LeiosVote vote = decodeVote(rawVote);
+                    decodedVotes.incrementAndGet();
+                    log.info("Leios vote decoded: point={}, voterId={}, signatureBytes={}",
+                            formatPoint(vote.point()), vote.voterId(), vote.signatureBytes());
+                    if (fetchFromVote && voteFetchRequested.compareAndSet(false, true)) {
+                        voteFetchRequests.incrementAndGet();
+                        log.info("Requesting EB body from vote point: {}", formatPoint(vote.point()));
+                        client.requestBlock(vote.point());
+                    }
+                }
+            }
+
+            @Override
+            public void onBlock(LeiosPoint requestedPoint, LeiosRawCbor endorserBlock) {
+                fetchedBlocks.incrementAndGet();
+                fetchLatch.countDown();
+                log.info("Leios block fetched: point={}, bytes={}", formatPoint(requestedPoint),
+                        endorserBlock.getCbor().length);
+            }
+
+            @Override
+            public void onNotifyError(Throwable error) {
+                failure.compareAndSet(null, error);
+                handshakeLatch.countDown();
+                firstNotificationLatch.countDown();
+                fetchLatch.countDown();
+            }
+
+            @Override
+            public void onFetchError(Throwable error) {
+                if (voteFetchRequested.get() && !blockOfferFetchRequested.get()) {
+                    voteFetchErrors.incrementAndGet();
+                    log.warn("Diagnostic vote-point fetch failed", error);
+                } else {
+                    failure.compareAndSet(null, error);
+                }
+                firstNotificationLatch.countDown();
+                fetchLatch.countDown();
+            }
+
+            @Override
+            public void onDisconnect() {
+                if (voteFetchRequested.get() && !blockOfferFetchRequested.get() && fetchedBlocks.get() == 0) {
+                    log.warn("Disconnected after diagnostic vote-point fetch request");
+                } else {
+                    failure.compareAndSet(null, new IllegalStateException("Disconnected from Musashi relay"));
+                }
+                handshakeLatch.countDown();
+                firstNotificationLatch.countDown();
+                fetchLatch.countDown();
+            }
+        });
+
+        try {
+            log.info("Connecting to Musashi Leios testnet at {}:{}", host, port);
+            client.start();
+
+            assertTrue(handshakeLatch.await(handshakeTimeoutSeconds, TimeUnit.SECONDS),
+                    "Timed out waiting for Musashi handshake");
+            assertNull(failure.get(), () -> "Musashi smoke test failed: " + failure.get());
+            assertTrue(client.isLeiosActive(), () -> "Leios mini-protocols were not active after handshake: "
+                    + acceptedVersion.get());
+            assertTrue(acceptedVersion.get() != null && acceptedVersion.get().getVersionNumber() >= 15,
+                    () -> "Expected Leios-capable protocol version, got " + acceptedVersion.get());
+
+            boolean notificationReceived = waitForNotifications(firstNotificationLatch, failure, client,
+                    notificationWaitSeconds, progressLogSeconds, runFullWindow, acceptedVersion, announcements,
+                    blockOffers, blockTxsOffers, voteMessages, decodedVotes, voteFetchRequests, voteFetchErrors,
+                    fetchedBlocks);
+            if (!notificationReceived) {
+                log.warn("No Leios notify messages received within {} seconds; public testnet load may be idle",
+                        notificationWaitSeconds);
+            }
+
+            if (blockOfferFetchRequested.get() && fetchedBlocks.get() == 0) {
+                assertTrue(fetchLatch.await(Math.min(notificationWaitSeconds, 60), TimeUnit.SECONDS),
+                        "Leios block offer was received, but leios-fetch did not return a block body");
+            }
+
+            assertNull(failure.get(), () -> "Musashi smoke test failed: " + failure.get());
+            log.info("Musashi smoke summary: version={}, announcements={}, blockOffers={}, blockTxsOffers={}, " +
+                            "voteMessages={}, decodedVotes={}, voteFetchRequests={}, voteFetchErrors={}, " +
+                            "fetchedBlocks={}", acceptedVersion.get(), announcements.get(), blockOffers.get(),
+                    blockTxsOffers.get(), voteMessages.get(), decodedVotes.get(), voteFetchRequests.get(),
+                    voteFetchErrors.get(), fetchedBlocks.get());
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    private static boolean waitForNotifications(CountDownLatch firstNotificationLatch,
+                                                AtomicReference<Throwable> failure,
+                                                LeiosNetworkClient client,
+                                                int notificationWaitSeconds,
+                                                int progressLogSeconds,
+                                                boolean runFullWindow,
+                                                AtomicReference<AcceptVersion> acceptedVersion,
+                                                AtomicInteger announcements,
+                                                AtomicInteger blockOffers,
+                                                AtomicInteger blockTxsOffers,
+                                                AtomicInteger voteMessages,
+                                                AtomicInteger decodedVotes,
+                                                AtomicInteger voteFetchRequests,
+                                                AtomicInteger voteFetchErrors,
+                                                AtomicInteger fetchedBlocks) throws InterruptedException {
+        boolean notificationReceived = false;
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(notificationWaitSeconds);
+        long startedAt = System.nanoTime();
+
+        while (System.nanoTime() < deadline) {
+            long remainingSeconds = Math.max(1, TimeUnit.NANOSECONDS.toSeconds(deadline - System.nanoTime()));
+            long waitSeconds = Math.max(1, Math.min(progressLogSeconds, remainingSeconds));
+
+            if (!notificationReceived) {
+                notificationReceived = firstNotificationLatch.await(waitSeconds, TimeUnit.SECONDS);
+            } else {
+                TimeUnit.SECONDS.sleep(waitSeconds);
+            }
+
+            long elapsedSeconds = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startedAt);
+            log.info("Musashi smoke progress: elapsed={}s, active={}, version={}, announcements={}, " +
+                            "blockOffers={}, blockTxsOffers={}, voteMessages={}, decodedVotes={}, " +
+                            "voteFetchRequests={}, voteFetchErrors={}, fetchedBlocks={}",
+                    elapsedSeconds, client.isLeiosActive(), acceptedVersion.get(), announcements.get(),
+                    blockOffers.get(), blockTxsOffers.get(), voteMessages.get(), decodedVotes.get(),
+                    voteFetchRequests.get(), voteFetchErrors.get(), fetchedBlocks.get());
+
+            if (failure.get() != null || (notificationReceived && !runFullWindow)) {
+                break;
+            }
+        }
+
+        return notificationReceived;
+    }
+
+    private static String formatPoint(LeiosPoint point) {
+        return point.getSlot() + "@" + HexUtil.encodeHexString(point.getEbHash());
+    }
+
+    private static LeiosVote decodeVote(LeiosRawCbor rawVote) {
+        DataItem dataItem = CborSerializationUtil.deserializeOne(rawVote.getCbor());
+        if (!(dataItem instanceof Array array)) {
+            throw new IllegalArgumentException("Leios vote must be a CBOR array");
+        }
+
+        List<DataItem> items = array.getDataItems();
+        if (items.size() != 4) {
+            throw new IllegalArgumentException("Leios vote must have 4 fields");
+        }
+
+        long slot = toLong((UnsignedInteger) items.get(0), "vote slot");
+        byte[] ebHash = ((ByteString) items.get(1)).getBytes();
+        int voterId = toWord16((UnsignedInteger) items.get(2));
+        int signatureBytes = ((ByteString) items.get(3)).getBytes().length;
+        return new LeiosVote(new LeiosPoint(slot, ebHash), voterId, signatureBytes);
+    }
+
+    private static long toLong(UnsignedInteger value, String name) {
+        BigInteger bigint = value.getValue();
+        if (bigint.signum() < 0 || bigint.compareTo(LONG_MAX) > 0) {
+            throw new IllegalArgumentException(name + " must fit in signed long");
+        }
+        return bigint.longValue();
+    }
+
+    private static int toWord16(UnsignedInteger value) {
+        BigInteger bigint = value.getValue();
+        if (bigint.signum() < 0 || bigint.compareTo(WORD16_MAX) > 0) {
+            throw new IllegalArgumentException("voter_id must fit in word16");
+        }
+        return bigint.intValue();
+    }
+
+    private static String env(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private static int intEnv(String name, int defaultValue) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return Integer.parseInt(value);
+    }
+
+    private static boolean booleanEnv(String name, boolean defaultValue) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    private record LeiosVote(LeiosPoint point, int voterId, int signatureBytes) {
+    }
+}

--- a/helper/src/test/java/com/bloxbean/cardano/yaci/helper/LeiosNetworkClientTest.java
+++ b/helper/src/test/java/com/bloxbean/cardano/yaci/helper/LeiosNetworkClientTest.java
@@ -1,0 +1,215 @@
+package com.bloxbean.cardano.yaci.helper;
+
+import com.bloxbean.cardano.yaci.core.common.Constants;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.N2NVersionData;
+import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosPoint;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosRawCbor;
+import com.bloxbean.cardano.yaci.core.protocol.leios.LeiosTxBitmap;
+import com.bloxbean.cardano.yaci.helper.listener.LeiosDataListener;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LeiosNetworkClientTest {
+
+    @Test
+    void activatesLeiosForCompatibleMusashiHandshake() {
+        LeiosNetworkClient client = new LeiosNetworkClient("localhost", 3001);
+        AtomicReference<AcceptVersion> activated = new AtomicReference<>();
+        client.addDataListener(new LeiosDataListener() {
+            @Override
+            public void onLeiosActivated(AcceptVersion acceptVersion) {
+                activated.set(acceptVersion);
+            }
+        });
+
+        AcceptVersion acceptVersion = musashiV15();
+        client.handleHandshakeComplete(acceptVersion);
+
+        assertTrue(client.isLeiosActive());
+        assertTrue(client.getLeiosNotifyAgent().isAutoRequestNext());
+        assertEquals(acceptVersion, activated.get());
+        assertEquals(acceptVersion, client.getProtocolVersion().orElseThrow());
+    }
+
+    @Test
+    void doesNotActivateLeiosForIncompatibleHandshake() {
+        LeiosNetworkClient client = new LeiosNetworkClient("localhost", 3001);
+        AtomicReference<AcceptVersion> notActivated = new AtomicReference<>();
+        client.addDataListener(new LeiosDataListener() {
+            @Override
+            public void onLeiosNotActivated(AcceptVersion acceptVersion) {
+                notActivated.set(acceptVersion);
+            }
+        });
+
+        AcceptVersion acceptVersion = new AcceptVersion(
+                N2NVersionTableConstant.PROTOCOL_V14,
+                new N2NVersionData(Constants.MUSASHI_PROTOCOL_MAGIC, true, 0, false));
+        client.handleHandshakeComplete(acceptVersion);
+
+        assertFalse(client.isLeiosActive());
+        assertFalse(client.getLeiosNotifyAgent().isAutoRequestNext());
+        assertEquals(acceptVersion, notActivated.get());
+    }
+
+    @Test
+    void doesNotActivateLeiosForNonMusashiV15Handshake() {
+        LeiosNetworkClient client = new LeiosNetworkClient("localhost", 3001, 42);
+        AtomicReference<AcceptVersion> notActivated = new AtomicReference<>();
+        client.addDataListener(new LeiosDataListener() {
+            @Override
+            public void onLeiosNotActivated(AcceptVersion acceptVersion) {
+                notActivated.set(acceptVersion);
+            }
+        });
+
+        AcceptVersion acceptVersion = new AcceptVersion(
+                N2NVersionTableConstant.PROTOCOL_V15,
+                new N2NVersionData(42, true, 0, false));
+        client.handleHandshakeComplete(acceptVersion);
+
+        assertFalse(client.isLeiosActive());
+        assertEquals(acceptVersion, notActivated.get());
+    }
+
+    @Test
+    void requestMethodsAreGatedUntilLeiosIsActive() {
+        LeiosNetworkClient client = new LeiosNetworkClient("localhost", 3001);
+
+        assertThrows(IllegalStateException.class, () -> client.requestBlock(point(1)));
+
+        client.handleHandshakeComplete(musashiV15());
+        client.requestBlockTxs(point(2), LeiosTxBitmap.firstN(1));
+
+        assertEquals(1, client.getLeiosFetchAgent().getQueueSize());
+    }
+
+    @Test
+    void rejectsEmptyTxBitmapRequestsUntilMuxByteFidelityIsFixed() {
+        LeiosNetworkClient client = new LeiosNetworkClient("localhost", 3001);
+
+        client.handleHandshakeComplete(musashiV15());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> client.requestBlockTxs(point(6), LeiosTxBitmap.empty()));
+        assertThrows(IllegalArgumentException.class,
+                () -> client.requestFirstBlockTxs(point(7), 0));
+    }
+
+    @Test
+    void disconnectClearsActivationAndIsReportedOnce() {
+        LeiosNetworkClient client = new LeiosNetworkClient("localhost", 3001);
+        AtomicInteger disconnects = new AtomicInteger();
+        client.addDataListener(new LeiosDataListener() {
+            @Override
+            public void onDisconnect() {
+                disconnects.incrementAndGet();
+            }
+        });
+
+        client.handleDisconnect();
+        assertEquals(0, disconnects.get());
+
+        client.handleHandshakeComplete(musashiV15());
+        client.requestBlockTxs(point(4), LeiosTxBitmap.firstN(1));
+        assertTrue(client.isLeiosActive());
+        assertTrue(client.getLeiosNotifyAgent().isAutoRequestNext());
+        assertEquals(1, client.getLeiosFetchAgent().getQueueSize());
+
+        client.getLeiosNotifyAgent().disconnected();
+        client.getLeiosFetchAgent().disconnected();
+
+        assertFalse(client.isLeiosActive());
+        assertFalse(client.getLeiosNotifyAgent().isAutoRequestNext());
+        assertEquals(0, client.getLeiosFetchAgent().getQueueSize());
+        assertEquals(1, disconnects.get());
+        assertThrows(IllegalStateException.class, () -> client.requestBlock(point(5)));
+    }
+
+    @Test
+    void forwardsNotifyAndFetchCallbacksToDataListener() {
+        LeiosNetworkClient client = new LeiosNetworkClient("localhost", 3001);
+        AtomicReference<LeiosPoint> blockOffer = new AtomicReference<>();
+        AtomicReference<LeiosRawCbor> block = new AtomicReference<>();
+        AtomicInteger fetchErrors = new AtomicInteger();
+        client.addDataListener(new LeiosDataListener() {
+            @Override
+            public void onBlockOffer(LeiosPoint point, long ebSize) {
+                blockOffer.set(point);
+            }
+
+            @Override
+            public void onBlock(LeiosPoint requestedPoint, LeiosRawCbor endorserBlock) {
+                block.set(endorserBlock);
+            }
+
+            @Override
+            public void onFetchError(Throwable error) {
+                fetchErrors.incrementAndGet();
+            }
+        });
+
+        LeiosPoint point = point(3);
+        LeiosRawCbor rawCbor = LeiosRawCbor.of(new byte[]{0x01});
+
+        client.getLeiosNotifyAgent().sendRequest(client.getLeiosNotifyAgent().buildNextMessage());
+        client.getLeiosNotifyAgent().receiveResponse(
+                new com.bloxbean.cardano.yaci.core.protocol.leiosnotify.messages.MsgLeiosBlockOffer(point, 1));
+
+        client.getLeiosFetchAgent().requestBlock(point);
+        client.getLeiosFetchAgent().sendRequest(client.getLeiosFetchAgent().buildNextMessage());
+        client.getLeiosFetchAgent().receiveResponse(
+                new com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosBlock(rawCbor));
+        client.getLeiosFetchAgent().receiveResponse(
+                new com.bloxbean.cardano.yaci.core.protocol.leiosfetch.messages.MsgLeiosFetchError(
+                        new IllegalArgumentException("bad")));
+
+        assertEquals(point, blockOffer.get());
+        assertEquals(rawCbor, block.get());
+        assertEquals(1, fetchErrors.get());
+    }
+
+    @Test
+    void wiresMusashiAgentsInternallyWithoutPublicRawAgentGetters() {
+        LeiosNetworkClient client = new LeiosNetworkClient("localhost", 3001);
+
+        assertEquals(18, client.getLeiosNotifyAgent().getProtocolId());
+        assertEquals(19, client.getLeiosFetchAgent().getProtocolId());
+        assertInstanceOf(com.bloxbean.cardano.yaci.core.protocol.leiosnotify.LeiosNotifyAgent.class,
+                client.getLeiosNotifyAgent());
+        assertFalse(hasPublicMethod("getLeiosNotifyAgent"));
+        assertFalse(hasPublicMethod("getLeiosFetchAgent"));
+    }
+
+    private AcceptVersion musashiV15() {
+        return new AcceptVersion(
+                N2NVersionTableConstant.PROTOCOL_V15,
+                new N2NVersionData(Constants.MUSASHI_PROTOCOL_MAGIC, true, 0, false));
+    }
+
+    private LeiosPoint point(int seed) {
+        byte[] hash = new byte[LeiosPoint.EB_HASH_LENGTH];
+        for (int i = 0; i < hash.length; i++) {
+            hash[i] = (byte) (seed + i);
+        }
+        return new LeiosPoint(100 + seed, hash);
+    }
+
+    private boolean hasPublicMethod(String methodName) {
+        return Arrays.stream(LeiosNetworkClient.class.getDeclaredMethods())
+                .anyMatch(method -> method.getName().equals(methodName)
+                        && Modifier.isPublic(method.getModifiers()));
+    }
+}


### PR DESCRIPTION
## What

Opens the tracking branch for implementing the two Linear Leios (CIP-0164)
**node-to-node mini-protocols** — **`LeiosNotify`** (protocol **18**) and
**`LeiosFetch`** (protocol **19**) — for the **Musashi** prototype testnet
(network magic **164**, Dijkstra era / PV12).

This first commit lands the design of record, **ADR 0007**
(`adr/0007-linear-leios-musashi-network-mini-protocols.md`). Implementation lands
in follow-up commits on this branch.

Closes #166

## Approach: transport-only

The PR series is scoped to the **network / state-machine / message level only**.
Every Leios payload (Endorser Block bodies, transactions, votes, certificates,
announcement headers) is carried as **opaque CBOR** (`LeiosRawCbor` / `byte[]`).
Block-level serialization/deserialization, BLS verification, `Era`/`Block`
changes, and Yaci-Store integration are **deferred to a follow-up PR**.

Rationale: the blueprint marks the heavy Leios structures as not-yet-final
(`endorser_block`, `announcement_header`, `bitmaps`, `tx`, vote fields are
`any`/`TODO`/`REVIEW`). The mini-protocol **framing** is stable enough to build;
the message **contents** are still moving. Cutting at that boundary keeps all
spec-churn behind an opaque-bytes wall.

## Two profiles (pinned to exact cardano-blueprint commits)

- **`MUSASHI_PROTOTYPE`** (default) = `leios-prototype` @ `188183b` — matches what
  the testnet speaks today (`BlockOffer` carries `eb_size`; notify tag 4 = inline
  votes; `BlockTxs` echoes `point,bitmaps`; `bitmaps = {word16 => word64}`
  indefinite map; `point = [slot, eb_hash]`).
- **`BLUEPRINT_CURRENT`** = `main` @ `e773b95` — the fuller shape (adds votes 4/5
  and range 6/7/8), kept inactive until a peer supports it.

## Scope

**In:** state machines, agencies, message envelopes (tag + arity), point /
`(slot, voter_id)` / range / `eb_size` / bitmap-map parsing, profile-aware
serializers, handshake gating (attach agents only on a Leios-capable N2N version),
a small `LeiosNetworkClient`.

**Out (follow-up):** decoding EB bodies / txs / votes / certs / announcement
headers / bitmap interiors; BLS; Dijkstra `Era`/`Block`; Yaci-Store schema.

## Plan (tracked in #166)

1. Network skeleton & fixtures — shared models, id constants 18/19, CDDL fixtures.
2. LeiosNotify — state, messages, serializers, agent, listener.
3. LeiosFetch — state, messages, serializers, agent, listener, bitmap helper.
4. Handshake & smoke client — Musashi version-table helper, `LeiosNetworkClient`,
   default-disabled integration test.
5. Blueprint-drift follow-up — `BLUEPRINT_CURRENT` profile once a peer supports it.

## Notes for reviewers

- Protocol ids **18/19** are within Yaci's valid mux range and don't collide with
  the app-layer squatters (100/101/102).
- No changes to ChainSync / BlockFetch / PeerSharing; new agents attach only on a
  Leios-capable handshake, so existing behavior is unchanged.
- This PR currently contains **only the ADR**; code review of the implementation
  will follow as commits land on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
