### PR TITLE
  Fix mux CBOR framing and add property tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,10 @@ gradle-app.setting
 # Cache of project
 .gradletasknamecache
 
+# jqwik property-test generated examples/failure database
+**/.jqwik-database
+**/.jqwik-database/
+
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,6 +4,8 @@ dependencies {
     api libs.slf4j.api
 
     implementation libs.cardano.client.core
+
+    testImplementation libs.jqwik
 }
 
 publishing {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/handlers/MiniProtoStreamingByteToMessageDecoder.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/handlers/MiniProtoStreamingByteToMessageDecoder.java
@@ -1,12 +1,9 @@
 package com.bloxbean.cardano.yaci.core.network.handlers;
 
-import co.nstant.in.cbor.CborDecoder;
-import co.nstant.in.cbor.model.DataItem;
-import co.nstant.in.cbor.model.MajorType;
-import com.bloxbean.cardano.client.crypto.bip32.util.BytesUtil;
 import com.bloxbean.cardano.yaci.core.protocol.Agent;
 import com.bloxbean.cardano.yaci.core.protocol.Segment;
-import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.CborByteScanner;
+import com.bloxbean.cardano.yaci.core.util.CborByteScanner.CborSlice;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ReplayingDecoder;
@@ -17,9 +14,18 @@ import java.util.*;
 @Slf4j
 public class MiniProtoStreamingByteToMessageDecoder
         extends ReplayingDecoder<Segment> {
+    private static final int UNLIMITED_INCOMPLETE_BUFFER = -1;
+
     private final Map<Integer, ProtocolChannel> protocolChannelMap;
+    private final int maxIncompleteBufferSize;
+    private boolean poisoned;
 
     public MiniProtoStreamingByteToMessageDecoder(Agent... agents) {
+        this(UNLIMITED_INCOMPLETE_BUFFER, agents);
+    }
+
+    public MiniProtoStreamingByteToMessageDecoder(int maxIncompleteBufferSize, Agent... agents) {
+        this.maxIncompleteBufferSize = maxIncompleteBufferSize;
         protocolChannelMap = new HashMap<>();
         protocolChannelMap.put(0, new ProtocolChannel()); //For handshake channel
         for (Agent agent: agents) {
@@ -30,6 +36,11 @@ public class MiniProtoStreamingByteToMessageDecoder
     @Override
     protected void decode(ChannelHandlerContext ctx,
                           ByteBuf in, List<Object> out) {
+        if (poisoned) {
+            in.skipBytes(actualReadableBytes());
+            return;
+        }
+
         try {
             int timestamp = (int) in.readUnsignedInt();
 
@@ -51,75 +62,28 @@ public class MiniProtoStreamingByteToMessageDecoder
 
             ProtocolChannel protocolChannel = getProtocolChannel(protocol);
             if (protocolChannel == null) {
-                protocolChannel = new ProtocolChannel();
-                protocolChannelMap.put(protocol, protocolChannel);
+                log.warn("Received segment for unregistered mini-protocol {}. Closing channel.", protocol);
+                poisoned = true;
+                ctx.close();
+                return;
             }
-            byte[] bytes = protocolChannel != null? protocolChannel.getBytes(): new byte[0];
+            protocolChannel.append(payload);
 
-            bytes = BytesUtil.merge(bytes, payload);
             try {
-                while (true && bytes.length != 0) {
-                    //TODO -- Remove later after testing
-//                    DataItem di = CborDecoder.decode(bytes).get(0);
-//                    byte[] segmentBytes = CborSerializationUtil.serialize(di);
+                int consumedLength = emitCompleteMessages(timestamp, protocol, protocolChannel, out);
+                if (consumedLength > 0)
+                    protocolChannel.discardBytes(consumedLength);
 
-
-                    List<DataItem> diList = CborDecoder.decode(bytes);
-                    //To handle. When multiple dataitems and non array data items which are part of message
-                    //Exp. Local State Query : Current Protocol Param's maxCollateralInputs always comes as a separate
-                    //DataItem.
-                    //Check till any non-array DataItem, otherwise break and the next array DI will be handled in next
-                    //iteration.
-                    byte[] segmentBytes;
-                    List<DataItem> finalDIs = null;
-                    if (diList.size() > 1) {
-                        //ArrayList with initialSize is used instead of LinkedList to save time in .size() call later.
-                        //This is critical for BlockFetch usecase
-                        finalDIs = new ArrayList<>(3);
-
-                        int i = 0;
-                        //check for array
-                        for (DataItem di: diList) {
-                            if (i == 0) {
-                                finalDIs.add(diList.get(0));
-                                i++;
-                                continue;
-                            }
-
-                            if (di.getMajorType() == MajorType.ARRAY)
-                                break;
-                            else {
-                                finalDIs.add(di);
-                            }
-                        }
-                    }
-
-                    if (finalDIs != null && finalDIs.size() > 1) //These items are considered part of the same message.
-                        segmentBytes = CborSerializationUtil.serialize(finalDIs.toArray(new DataItem[0]), false);
-                    else
-                        segmentBytes = CborSerializationUtil.serialize(diList.get(0), false);
-
-                    Segment segment = Segment.builder()
-                            .timestamp(timestamp)
-                            .protocol((short) protocol)
-                            .payload(segmentBytes)
-                            .build();
-
-                    int len = segmentBytes.length;
-
-                    out.add(segment);
-
-                    if (bytes.length > len) {
-                        bytes = Arrays.copyOfRange(bytes, len, bytes.length);
-                    } else
-                        bytes = new byte[0];
-                }
-                protocolChannel.setBytes(bytes);
+                validateIncompleteBuffer(protocol, protocolChannel);
                 in.markReaderIndex();
                 return;
 
-            } catch (Exception e) {
-                protocolChannel.setBytes(bytes);
+            } catch (RuntimeException | StackOverflowError e) {
+                log.warn("Invalid CBOR payload for mini-protocol {}. Closing channel. {}", protocol, e.toString());
+                log.debug("Invalid CBOR payload for mini-protocol " + protocol, e);
+                poisoned = true;
+                protocolChannel.clear();
+                ctx.close();
                 return;
             }
         } catch (Exception e) {
@@ -130,6 +94,61 @@ public class MiniProtoStreamingByteToMessageDecoder
     private ProtocolChannel getProtocolChannel(int protocol) {
         ProtocolChannel protocolChannel = protocolChannelMap.get(protocol);
         return protocolChannel;
+    }
+
+    private int emitCompleteMessages(int timestamp, int protocol, ProtocolChannel protocolChannel, List<Object> out) {
+        byte[] bytes = protocolChannel.getBytes();
+        List<CborSlice> frames = protocolChannel.scanCompleteFrames();
+        if (frames.isEmpty())
+            return 0;
+
+        int consumedLength = 0;
+        int frameIndex = 0;
+        while (frameIndex < frames.size()) {
+            int messageStart = frames.get(frameIndex).startOffset();
+            int messageEnd = frames.get(frameIndex).endOffset();
+            frameIndex++;
+
+            while (frameIndex < frames.size() && !isMessageStart(frames.get(frameIndex))) {
+                messageEnd = frames.get(frameIndex).endOffset();
+                frameIndex++;
+            }
+
+            if (messageEnd < bytes.length && !startsWithMessage(bytes, messageEnd))
+                break;
+
+            out.add(Segment.builder()
+                    .timestamp(timestamp)
+                    .protocol(protocol)
+                    .payload(Arrays.copyOfRange(bytes, messageStart, messageEnd))
+                    .build());
+            consumedLength = messageEnd;
+        }
+
+        return consumedLength;
+    }
+
+    private void validateIncompleteBuffer(int protocol, ProtocolChannel protocolChannel) {
+        if (maxIncompleteBufferSize < 0)
+            return;
+
+        int bufferedBytes = protocolChannel.getBytes().length;
+        if (bufferedBytes > maxIncompleteBufferSize) {
+            throw new IllegalArgumentException("Accumulated incomplete mini-protocol buffer for protocol "
+                    + protocol + " exceeded " + maxIncompleteBufferSize + " bytes");
+        }
+    }
+
+    private boolean startsWithMessage(byte[] bytes, int offset) {
+        try {
+            return CborByteScanner.untaggedMajorType(bytes, offset) == CborByteScanner.MAJOR_TYPE_ARRAY;
+        } catch (CborByteScanner.IncompleteCborException e) {
+            return false;
+        }
+    }
+
+    private boolean isMessageStart(CborSlice frame) {
+        return frame.untaggedMajorType() == CborByteScanner.MAJOR_TYPE_ARRAY;
     }
 
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/network/handlers/ProtocolChannel.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/network/handlers/ProtocolChannel.java
@@ -1,12 +1,64 @@
 package com.bloxbean.cardano.yaci.core.network.handlers;
 
+import com.bloxbean.cardano.client.crypto.bip32.util.BytesUtil;
+import com.bloxbean.cardano.yaci.core.util.CborByteScanner;
+import com.bloxbean.cardano.yaci.core.util.CborByteScanner.CborSlice;
 import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Data
 public class ProtocolChannel {
     private byte[] bytes;
+    private int scanOffset;
+    private List<CborSlice> completeFrames;
 
     public ProtocolChannel() {
         this.bytes = new byte[0];
+        this.completeFrames = new ArrayList<>();
+    }
+
+    public void append(byte[] payload) {
+        bytes = BytesUtil.merge(bytes, payload);
+    }
+
+    public List<CborSlice> scanCompleteFrames() {
+        List<CborSlice> newFrames = CborByteScanner.completeTopLevelItems(bytes, scanOffset);
+        if (!newFrames.isEmpty()) {
+            completeFrames.addAll(newFrames);
+            scanOffset = newFrames.get(newFrames.size() - 1).endOffset();
+        }
+
+        return completeFrames;
+    }
+
+    public void discardBytes(int consumedLength) {
+        if (consumedLength <= 0)
+            return;
+
+        bytes = Arrays.copyOfRange(bytes, consumedLength, bytes.length);
+        scanOffset = Math.max(0, scanOffset - consumedLength);
+
+        List<CborSlice> shiftedFrames = new ArrayList<>();
+        for (CborSlice frame : completeFrames) {
+            if (frame.endOffset() <= consumedLength)
+                continue;
+            if (frame.startOffset() < consumedLength)
+                continue;
+
+            shiftedFrames.add(new CborSlice(frame.startOffset() - consumedLength,
+                    frame.endOffset() - consumedLength,
+                    frame.majorType(),
+                    frame.untaggedMajorType()));
+        }
+        completeFrames = shiftedFrames;
+    }
+
+    public void clear() {
+        bytes = new byte[0];
+        scanOffset = 0;
+        completeFrames.clear();
     }
 }

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/Agent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/Agent.java
@@ -8,6 +8,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 @Slf4j
 public abstract class Agent<T extends AgentListener> {
@@ -74,9 +77,18 @@ public abstract class Agent<T extends AgentListener> {
     }
 
     protected void writeMessage(Message message, Runnable onSuccess) {
+        writeMessage(message, onSuccess, null);
+    }
+
+    protected void writeMessage(Message message, Runnable onSuccess, Consumer<Throwable> onFailure) {
+        AtomicBoolean completed = new AtomicBoolean(false);
         Channel ch = this.channel; // volatile read, captured once
         if (ch == null || !ch.isActive()) {
-            log.warn("Cannot write message: channel is null or inactive");
+            IllegalStateException failure = new IllegalStateException("Cannot write message: channel is null or inactive");
+            if (onFailure != null)
+                notifyWriteFailure(onFailure, failure);
+            else
+                log.warn(failure.getMessage());
             return;
         }
 
@@ -88,7 +100,7 @@ public abstract class Agent<T extends AgentListener> {
             protocolWithFlag |= 0x8000; // Server response flag
             if (log.isDebugEnabled()) {
                 log.debug("Server mode: adding response flag - protocol {} -> {} (0x{})",
-                         this.getProtocolId(), protocolWithFlag, Integer.toHexString(protocolWithFlag));
+                        this.getProtocolId(), protocolWithFlag, Integer.toHexString(protocolWithFlag));
             }
         }
 
@@ -96,24 +108,47 @@ public abstract class Agent<T extends AgentListener> {
         int baseProtocolId = protocolWithFlag & 0x7FFF;
         if (baseProtocolId < 0 || baseProtocolId > 199) {
             log.error("🚨 Suspicious protocol ID: {} (0x{}) (base: {} 0x{})",
-                     protocolWithFlag, Integer.toHexString(protocolWithFlag),
-                     baseProtocolId, Integer.toHexString(baseProtocolId));
+                    protocolWithFlag, Integer.toHexString(protocolWithFlag),
+                    baseProtocolId, Integer.toHexString(baseProtocolId));
         }
 
         byte[] payload = message.serialize();
 
-        // Handle large payloads with automatic segmentation
-        if (payload.length > 65535) {
-            log.info("Large payload detected ({} bytes) - using mux-level segmentation", payload.length);
-            writeSegmentedMessage(ch, protocolWithFlag, payload, onSuccess);
-            return;
-        }
+        Consumer<Throwable> failureHandler = onFailure != null ? onFailure
+                : throwable -> closeChannelAfterWriteFailure(ch, throwable);
+        Consumer<Throwable> closeAfterSegmentFailure = onFailure != null
+                ? throwable -> closeChannelAfterWriteFailure(ch, throwable)
+                : throwable -> {
+                };
+        Runnable onSuccessOnce = () -> {
+            if (completed.compareAndSet(false, true) && onSuccess != null)
+                onSuccess.run();
+        };
+        Consumer<Throwable> onFailureOnce = throwable -> {
+            if (completed.compareAndSet(false, true))
+                notifyWriteFailure(failureHandler, throwable);
+        };
 
-        // Normal single segment message
-        writeSingleSegment(ch, protocolWithFlag, payload, onSuccess);
+        try {
+            // Handle large payloads with automatic segmentation
+            if (payload.length > 65535) {
+                log.info("Large payload detected ({} bytes) - using mux-level segmentation", payload.length);
+                writeSegmentedMessage(ch, protocolWithFlag, payload, onSuccessOnce, onFailureOnce,
+                        closeAfterSegmentFailure);
+                return;
+            }
+
+            // Normal single segment message
+            writeSingleSegment(ch, protocolWithFlag, payload, onSuccessOnce, onFailureOnce);
+        } catch (Throwable e) {
+            onFailureOnce.accept(e);
+            if (payload.length > 65535)
+                closeAfterSegmentFailure.accept(e);
+        }
     }
 
-    private void writeSingleSegment(Channel ch, int protocolWithFlag, byte[] payload, Runnable onSuccess) {
+    private void writeSingleSegment(Channel ch, int protocolWithFlag, byte[] payload,
+                                    Runnable onSuccess, Consumer<Throwable> onFailure) {
         int elapseTime = calculateElapsedTime();
 
         Segment segment = Segment.builder()
@@ -126,22 +161,32 @@ public abstract class Agent<T extends AgentListener> {
         synchronized (ch) {
             ch.writeAndFlush(segment).addListener(future -> {
                 if (future.isSuccess()) {
-                    if (onSuccess != null) onSuccess.run();
+                    if (onSuccess != null)
+                        onSuccess.run();
                 } else {
                     log.error("Failed to send message for protocol {}", getProtocolId(), future.cause());
+                    if (onFailure != null)
+                        onFailure.accept(writeFailureCause(future.cause()));
                 }
             });
         }
     }
 
-    private void writeSegmentedMessage(Channel ch, int protocolWithFlag, byte[] payload, Runnable onSuccess) {
+    private void writeSegmentedMessage(Channel ch, int protocolWithFlag, byte[] payload,
+                                       Runnable onSuccess, Consumer<Throwable> onFailure,
+                                       Consumer<Throwable> afterFailure) {
         final int MAX_SEGMENT_SIZE = 65535;
         final int totalSegments = (payload.length + MAX_SEGMENT_SIZE - 1) / MAX_SEGMENT_SIZE;
+        AtomicBoolean failed = new AtomicBoolean(false);
+        AtomicInteger successfulSegments = new AtomicInteger(0);
 
         log.info("Segmenting large message: {} bytes into {} segments", payload.length, totalSegments);
 
         synchronized (ch) {
             for (int i = 0; i < totalSegments; i++) {
+                if (failed.get())
+                    break;
+
                 int offset = i * MAX_SEGMENT_SIZE;
                 int segmentSize = Math.min(MAX_SEGMENT_SIZE, payload.length - offset);
 
@@ -156,24 +201,47 @@ public abstract class Agent<T extends AgentListener> {
                         .payload(segmentPayload)
                         .build();
 
-                final boolean isLastSegment = (i == totalSegments - 1);
                 final int segmentIndex = i;
 
                 log.debug("Sending segment {}/{} - {} bytes", segmentIndex + 1, totalSegments, segmentSize);
 
                 ch.writeAndFlush(segment).addListener(future -> {
                     if (future.isSuccess()) {
-                        if (isLastSegment && onSuccess != null) {
+                        int completed = successfulSegments.incrementAndGet();
+                        if (completed == totalSegments && !failed.get() && onSuccess != null) {
                             onSuccess.run();
                         }
                         log.debug("Segment {}/{} sent successfully", segmentIndex + 1, totalSegments);
                     } else {
                         log.error("Failed to send segment {}/{} for protocol {}",
                                  segmentIndex + 1, totalSegments, getProtocolId(), future.cause());
+                        if (failed.compareAndSet(false, true) && onFailure != null) {
+                            Throwable cause = writeFailureCause(future.cause());
+                            onFailure.accept(cause);
+                            afterFailure.accept(cause);
+                        }
                     }
                 });
             }
         }
+    }
+
+    private void notifyWriteFailure(Consumer<Throwable> failureHandler, Throwable throwable) {
+        try {
+            failureHandler.accept(throwable);
+        } catch (Throwable callbackError) {
+            log.error("Write failure callback threw for protocol {}", getProtocolId(), callbackError);
+        }
+    }
+
+    private Throwable writeFailureCause(Throwable cause) {
+        return cause != null ? cause : new IllegalStateException("Netty write failed without a cause");
+    }
+
+    private void closeChannelAfterWriteFailure(Channel ch, Throwable cause) {
+        log.warn("Closing channel after failed write for protocol {}", getProtocolId(), cause);
+        if (ch != null && ch.isOpen())
+            ch.close();
     }
 
     private int calculateElapsedTime() {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/util/CborByteScanner.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/util/CborByteScanner.java
@@ -1,0 +1,424 @@
+package com.bloxbean.cardano.yaci.core.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Byte-level CBOR scanner for finding data item boundaries without decoding and re-encoding values.
+ *
+ * <p>Use this class when the exact original bytes matter. Examples include network framing, block
+ * hashing, datum/redeemer hashing, and any opaque payload that must be passed through unchanged.
+ * The scanner walks the CBOR structure just far enough to answer "where does this data item end?"
+ * It does not build {@code DataItem} objects, sort map keys, canonicalize integers, or otherwise
+ * rewrite the input.
+ *
+ * <p>CBOR starts every data item with an initial byte. The high 3 bits are the major type and the
+ * low 5 bits are the additional information:
+ *
+ * <pre>
+ * 0x82 0x01 0x02
+ * ^^^^
+ * 0x82 = major type 4 (array), additional info 2 (two elements)
+ *
+ * This is the CBOR array [1, 2]. The whole item occupies bytes 0..3, so endOffset(..., 0) returns 3.
+ * </pre>
+ *
+ * <p>Nested items are included in the returned boundary:
+ *
+ * <pre>
+ * 0x82 0xbf 0xff 0x9f 0x01 0xff
+ *      ^^^^^^^^^    ^^^^^^^^^^^^^^
+ *      empty map    indefinite array [1]
+ *
+ * This is [ {}, [1] ] where both nested values use indefinite-length encodings. The scanner returns
+ * the offset after the final 0xff break byte. Those break bytes are part of the original wire bytes
+ * and are preserved by callers that slice using the returned offsets.
+ * </pre>
+ *
+ * <p>For a stream containing multiple top-level items:
+ *
+ * <pre>
+ * 0x82 0x01 0x02 0x18 0x00
+ * ^^^^^^^^^^^^^^ ^^^^^^^^^
+ * array [1, 2]   integer 0 encoded in two bytes
+ * </pre>
+ *
+ * {@link #completeTopLevelItems(byte[])} returns two slices, one for each top-level data item.
+ * The integer slice remains {@code 0x18 0x00}; it is not normalized to canonical {@code 0x00}.
+ *
+ * <p>This class is intentionally generic CBOR plumbing. It does not know Cardano CDDL, transaction
+ * layout, or mini-protocol message grouping rules.
+ */
+public final class CborByteScanner {
+    public static final int MAJOR_TYPE_UNSIGNED_INTEGER = 0;
+    public static final int MAJOR_TYPE_NEGATIVE_INTEGER = 1;
+    public static final int MAJOR_TYPE_BYTE_STRING = 2;
+    public static final int MAJOR_TYPE_TEXT_STRING = 3;
+    public static final int MAJOR_TYPE_ARRAY = 4;
+    public static final int MAJOR_TYPE_MAP = 5;
+    public static final int MAJOR_TYPE_TAG = 6;
+    public static final int MAJOR_TYPE_SIMPLE = 7;
+
+    // Cardano values are nowhere near this depth in normal traffic. The limit is intentionally
+    // generous, but finite, so malformed inputs cannot recurse until the JVM stack fails.
+    private static final int MAX_NESTING_DEPTH = 1024;
+    private static final long INDEFINITE_LENGTH = -1L;
+
+    private CborByteScanner() {
+    }
+
+    /**
+     * Returns the offset immediately after the complete CBOR data item starting at {@code offset}.
+     *
+     * <p>For example, for {@code 82 01 02}, {@code endOffset(bytes, 0)} returns {@code 3}.
+     * For {@code bf ff} (an empty indefinite-length map), it returns {@code 2}, preserving the
+     * break byte in the item boundary.
+     *
+     * @param bytes source bytes containing at least one CBOR data item
+     * @param offset start offset of the data item
+     * @return offset immediately after the complete data item
+     * @throws IncompleteCborException if the buffer ends before the item is complete
+     * @throws IllegalArgumentException if the item is malformed CBOR
+     */
+    public static int endOffset(byte[] bytes, int offset) {
+        return skipItem(bytes, offset);
+    }
+
+    /**
+     * Returns the offset immediately after the first CBOR data item in {@code bytes}.
+     *
+     * @param bytes source bytes containing at least one CBOR data item
+     * @return offset immediately after the first complete data item
+     * @throws IncompleteCborException if the buffer ends before the item is complete
+     * @throws IllegalArgumentException if the item is malformed CBOR
+     */
+    public static int endOffset(byte[] bytes) {
+        return endOffset(bytes, 0);
+    }
+
+    /**
+     * Scans consecutive complete top-level CBOR data items from the start of {@code bytes}.
+     *
+     * <p>This method is useful for streaming buffers. If the final top-level item is incomplete,
+     * scanning stops before it and the already-complete slices are returned. For example,
+     * {@code 82 01 02 43 aa} returns one slice for {@code 82 01 02} and leaves the incomplete
+     * byte string {@code 43 aa} for the caller's buffer.
+     *
+     * @param bytes source bytes containing zero or more top-level CBOR items
+     * @return complete top-level slices in source order
+     * @throws IllegalArgumentException if a malformed complete item is encountered
+     */
+    public static List<CborSlice> completeTopLevelItems(byte[] bytes) {
+        return completeTopLevelItems(bytes, 0);
+    }
+
+    /**
+     * Scans consecutive complete top-level CBOR data items from {@code offset}.
+     *
+     * <p>The returned slice offsets are still relative to the original {@code bytes} array, not
+     * to {@code offset}. This lets streaming callers cache completed slices and resume scanning
+     * only from the first not-yet-complete top-level item after more bytes arrive.
+     *
+     * @param bytes source bytes containing zero or more top-level CBOR items
+     * @param offset start offset for scanning
+     * @return complete top-level slices in source order
+     * @throws IllegalArgumentException if a malformed complete item is encountered
+     */
+    public static List<CborSlice> completeTopLevelItems(byte[] bytes, int offset) {
+        if (offset < 0 || offset > bytes.length)
+            throw new IllegalArgumentException("Invalid CBOR scan offset: " + offset);
+
+        List<CborSlice> slices = new ArrayList<>(3);
+        while (offset < bytes.length) {
+            int itemStart = offset;
+            try {
+                int itemEnd = endOffset(bytes, itemStart);
+                slices.add(new CborSlice(itemStart, itemEnd, majorType(bytes[itemStart]),
+                        untaggedMajorType(bytes, itemStart)));
+                offset = itemEnd;
+            } catch (IncompleteCborException e) {
+                break;
+            }
+        }
+
+        return slices;
+    }
+
+    /**
+     * Returns the CBOR major type encoded in an initial byte.
+     *
+     * <p>The major type is the high 3 bits. For example, {@code 0x82} has major type 4,
+     * which means array.
+     *
+     * @param initialByte first byte of a CBOR data item
+     * @return major type number, from 0 to 7
+     */
+    public static int majorType(byte initialByte) {
+        return (initialByte & 0xff) >> 5;
+    }
+
+    /**
+     * Returns the major type after skipping any leading CBOR tags.
+     *
+     * <p>For example, {@code c0 82 01 02} is a tag-0 item whose content is the array
+     * {@code [1, 2]}. {@link #majorType(byte)} returns {@link #MAJOR_TYPE_TAG} for the
+     * first byte, while this method returns {@link #MAJOR_TYPE_ARRAY}.
+     *
+     * @param bytes source bytes containing at least one CBOR data item
+     * @param offset start offset of the data item
+     * @return major type of the first non-tag item
+     * @throws IncompleteCborException if the buffer ends before the untagged item starts
+     * @throws IllegalArgumentException if a tag has malformed additional information
+     */
+    public static int untaggedMajorType(byte[] bytes, int offset) {
+        int cursor = offset;
+        int depth = 0;
+        while (true) {
+            requireAvailable(bytes, cursor, 1);
+            if (isBreak(bytes[cursor]))
+                throw new IllegalArgumentException("CBOR break is only valid inside an indefinite-length item");
+
+            int initialByte = bytes[cursor] & 0xff;
+            int majorType = initialByte >> 5;
+            if (majorType != MAJOR_TYPE_TAG)
+                return majorType;
+
+            if (++depth > MAX_NESTING_DEPTH)
+                throw new IllegalArgumentException("CBOR nesting exceeds maximum depth: " + MAX_NESTING_DEPTH);
+
+            cursor = skipArgument(bytes, cursor + 1, initialByte & 0x1f);
+        }
+    }
+
+    /**
+     * A byte slice for one complete CBOR data item.
+     *
+     * @param startOffset inclusive start offset in the original source byte array
+     * @param endOffset exclusive end offset in the original source byte array
+     * @param majorType CBOR major type of the top-level item
+     * @param untaggedMajorType major type after skipping leading tags, same as {@code majorType} for untagged items
+     */
+    public record CborSlice(int startOffset, int endOffset, int majorType, int untaggedMajorType) {
+        public int length() {
+            return endOffset - startOffset;
+        }
+
+        public byte[] copyFrom(byte[] source) {
+            return Arrays.copyOfRange(source, startOffset, endOffset);
+        }
+    }
+
+    /**
+     * Indicates that the current byte buffer ends before a complete CBOR item could be scanned.
+     *
+     * <p>Streaming callers usually keep the buffered bytes and try again after more bytes arrive.
+     */
+    public static class IncompleteCborException extends RuntimeException {
+        public IncompleteCborException() {
+            super("Incomplete CBOR data item", null, false, false);
+        }
+    }
+
+    private static int skipItem(byte[] bytes, int offset) {
+        return skipItem(bytes, offset, 0);
+    }
+
+    private static int skipItem(byte[] bytes, int offset, int depth) {
+        if (depth > MAX_NESTING_DEPTH)
+            throw new IllegalArgumentException("CBOR nesting exceeds maximum depth: " + MAX_NESTING_DEPTH);
+
+        requireAvailable(bytes, offset, 1);
+        if (isBreak(bytes[offset]))
+            throw new IllegalArgumentException("CBOR break is only valid inside an indefinite-length item");
+
+        int initialByte = bytes[offset] & 0xff;
+        int majorType = initialByte >> 5;
+        int additionalInfo = initialByte & 0x1f;
+        int cursor = offset + 1;
+
+        return switch (majorType) {
+            case MAJOR_TYPE_UNSIGNED_INTEGER, MAJOR_TYPE_NEGATIVE_INTEGER ->
+                    skipArgument(bytes, cursor, additionalInfo);
+            case MAJOR_TYPE_BYTE_STRING, MAJOR_TYPE_TEXT_STRING ->
+                    skipByteOrTextString(bytes, cursor, majorType, additionalInfo);
+            case MAJOR_TYPE_ARRAY -> skipArray(bytes, cursor, additionalInfo, depth);
+            case MAJOR_TYPE_MAP -> skipMap(bytes, cursor, additionalInfo, depth);
+            case MAJOR_TYPE_TAG -> {
+                int nextOffset = skipArgument(bytes, cursor, additionalInfo);
+                yield skipItem(bytes, nextOffset, depth + 1);
+            }
+            case MAJOR_TYPE_SIMPLE -> skipSimpleValue(bytes, cursor, additionalInfo);
+            default -> throw new IllegalArgumentException("Unsupported CBOR major type: " + majorType);
+        };
+    }
+
+    private static int skipByteOrTextString(byte[] bytes, int cursor, int majorType, int additionalInfo) {
+        LengthArgument lengthArgument = readLength(bytes, cursor, additionalInfo);
+        if (lengthArgument.length() == INDEFINITE_LENGTH)
+            return skipIndefiniteByteOrTextString(bytes, lengthArgument.nextOffset(), majorType);
+
+        return addLength(lengthArgument.nextOffset(), lengthArgument.length(), bytes.length);
+    }
+
+    private static int skipArray(byte[] bytes, int cursor, int additionalInfo, int depth) {
+        LengthArgument lengthArgument = readLength(bytes, cursor, additionalInfo);
+        cursor = lengthArgument.nextOffset();
+        if (lengthArgument.length() == INDEFINITE_LENGTH) {
+            while (true) {
+                requireAvailable(bytes, cursor, 1);
+                if (isBreak(bytes[cursor]))
+                    return cursor + 1;
+                cursor = skipItem(bytes, cursor, depth + 1);
+            }
+        }
+
+        for (long i = 0; i < lengthArgument.length(); i++) {
+            cursor = skipItem(bytes, cursor, depth + 1);
+        }
+        return cursor;
+    }
+
+    private static int skipMap(byte[] bytes, int cursor, int additionalInfo, int depth) {
+        LengthArgument lengthArgument = readLength(bytes, cursor, additionalInfo);
+        cursor = lengthArgument.nextOffset();
+        if (lengthArgument.length() == INDEFINITE_LENGTH) {
+            while (true) {
+                requireAvailable(bytes, cursor, 1);
+                if (isBreak(bytes[cursor]))
+                    return cursor + 1;
+
+                cursor = skipItem(bytes, cursor, depth + 1);
+                requireAvailable(bytes, cursor, 1);
+                if (isBreak(bytes[cursor]))
+                    throw new IllegalArgumentException("Indefinite CBOR map ended after a key without a value");
+                cursor = skipItem(bytes, cursor, depth + 1);
+            }
+        }
+
+        for (long i = 0; i < lengthArgument.length(); i++) {
+            cursor = skipItem(bytes, cursor, depth + 1);
+            cursor = skipItem(bytes, cursor, depth + 1);
+        }
+        return cursor;
+    }
+
+    private static int skipIndefiniteByteOrTextString(byte[] bytes, int cursor, int expectedMajorType) {
+        while (true) {
+            requireAvailable(bytes, cursor, 1);
+            if (isBreak(bytes[cursor]))
+                return cursor + 1;
+
+            int initialByte = bytes[cursor] & 0xff;
+            int majorType = initialByte >> 5;
+            int additionalInfo = initialByte & 0x1f;
+            if (majorType != expectedMajorType)
+                throw new IllegalArgumentException("Invalid chunk major type for indefinite CBOR string");
+
+            LengthArgument chunkLength = readLength(bytes, cursor + 1, additionalInfo);
+            if (chunkLength.length() == INDEFINITE_LENGTH)
+                throw new IllegalArgumentException("Nested indefinite CBOR string chunks are not allowed");
+            cursor = addLength(chunkLength.nextOffset(), chunkLength.length(), bytes.length);
+        }
+    }
+
+    private static int skipSimpleValue(byte[] bytes, int cursor, int additionalInfo) {
+        return switch (additionalInfo) {
+            case 24 -> addLength(cursor, 1, bytes.length);
+            case 25 -> addLength(cursor, 2, bytes.length);
+            case 26 -> addLength(cursor, 4, bytes.length);
+            case 27 -> addLength(cursor, 8, bytes.length);
+            case 28, 29, 30, 31 -> throw new IllegalArgumentException("Reserved CBOR simple value additional info");
+            default -> cursor;
+        };
+    }
+
+    private static LengthArgument readLength(byte[] bytes, int cursor, int additionalInfo) {
+        if (additionalInfo == 31)
+            return new LengthArgument(INDEFINITE_LENGTH, cursor);
+
+        return readUnsignedLongArgument(bytes, cursor, additionalInfo);
+    }
+
+    private static int skipArgument(byte[] bytes, int cursor, int additionalInfo) {
+        if (additionalInfo < 24)
+            return cursor;
+
+        return switch (additionalInfo) {
+            case 24 -> addFixedWidth(cursor, 1, bytes.length);
+            case 25 -> addFixedWidth(cursor, 2, bytes.length);
+            case 26 -> addFixedWidth(cursor, 4, bytes.length);
+            case 27 -> addFixedWidth(cursor, 8, bytes.length);
+            case 28, 29, 30 -> throw new IllegalArgumentException("Reserved CBOR additional info");
+            default -> throw new IllegalArgumentException("Indefinite length is not valid here");
+        };
+    }
+
+    private static LengthArgument readUnsignedLongArgument(byte[] bytes, int cursor, int additionalInfo) {
+        if (additionalInfo < 24)
+            return new LengthArgument(additionalInfo, cursor);
+
+        return switch (additionalInfo) {
+            case 24 -> {
+                requireAvailable(bytes, cursor, 1);
+                yield new LengthArgument(bytes[cursor] & 0xffL, cursor + 1);
+            }
+            case 25 -> {
+                requireAvailable(bytes, cursor, 2);
+                long value = ((bytes[cursor] & 0xffL) << 8) | (bytes[cursor + 1] & 0xffL);
+                yield new LengthArgument(value, cursor + 2);
+            }
+            case 26 -> {
+                requireAvailable(bytes, cursor, 4);
+                long value = ((bytes[cursor] & 0xffL) << 24)
+                        | ((bytes[cursor + 1] & 0xffL) << 16)
+                        | ((bytes[cursor + 2] & 0xffL) << 8)
+                        | (bytes[cursor + 3] & 0xffL);
+                yield new LengthArgument(value, cursor + 4);
+            }
+            case 27 -> {
+                requireAvailable(bytes, cursor, 8);
+                long value = 0;
+                for (int i = 0; i < 8; i++) {
+                    value = (value << 8) | (bytes[cursor + i] & 0xffL);
+                }
+                // Lengths and collection counts above Long.MAX_VALUE are valid CBOR numerically,
+                // but cannot be represented safely by this Java scanner. Treat them as invalid
+                // protocol input instead of wrapping negative and accepting malformed streams.
+                if (value < 0)
+                    throw new IllegalArgumentException("CBOR length exceeds Java signed long range");
+                yield new LengthArgument(value, cursor + 8);
+            }
+            case 28, 29, 30 -> throw new IllegalArgumentException("Reserved CBOR additional info");
+            default -> throw new IllegalArgumentException("Indefinite length is not valid here");
+        };
+    }
+
+    private static int addLength(int cursor, long length, int bufferLength) {
+        if (length < 0)
+            throw new IllegalArgumentException("Negative CBOR length");
+        if (length > Integer.MAX_VALUE)
+            throw new IllegalArgumentException("CBOR length exceeds maximum supported Java byte array size");
+        if (cursor > bufferLength - (int) length)
+            throw new IncompleteCborException();
+        return cursor + (int) length;
+    }
+
+    private static int addFixedWidth(int cursor, int length, int bufferLength) {
+        if (cursor > bufferLength - length)
+            throw new IncompleteCborException();
+        return cursor + length;
+    }
+
+    private static void requireAvailable(byte[] bytes, int cursor, int neededBytes) {
+        if (cursor < 0 || neededBytes < 0 || cursor > bytes.length - neededBytes)
+            throw new IncompleteCborException();
+    }
+
+    private static boolean isBreak(byte value) {
+        return (value & 0xff) == 0xff;
+    }
+
+    private record LengthArgument(long length, int nextOffset) {
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/handlers/MiniProtoStreamingByteToMessageDecoderPropertyTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/handlers/MiniProtoStreamingByteToMessageDecoderPropertyTest.java
@@ -1,0 +1,512 @@
+package com.bloxbean.cardano.yaci.core.network.handlers;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.AgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.Segment;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Property tests for the mux-level CBOR framing path.
+ *
+ * <p>The production decoder does not understand Cardano blocks, transactions, or any
+ * protocol-specific CDDL at this layer. Its narrow responsibility is to buffer mux payload
+ * bytes per mini-protocol, identify complete CBOR message boundaries, and emit the exact
+ * original bytes without decode/re-encode normalization.
+ *
+ * <p>These tests generate valid CBOR messages, split their byte stream into arbitrary mux
+ * segment payloads, feed those segments through the Netty decoder, and assert that the
+ * emitted {@link Segment} payloads are byte-for-byte identical to the generated messages.
+ * This catches boundary bugs that fixed example tests can miss, especially around nested
+ * CBOR, indefinite-length items, tag-wrapped arrays, and interleaved protocol buffers.
+ */
+class MiniProtoStreamingByteToMessageDecoderPropertyTest {
+    private static final int PROTOCOL_A = 7;
+    private static final int PROTOCOL_B = 9;
+
+    /**
+     * A single mini-protocol stream may be split at arbitrary mux segment boundaries.
+     *
+     * <p>The invariant is stronger than "the decoder parsed something": after arbitrary
+     * chunking, every emitted payload must exactly match the original generated message
+     * bytes. This protects non-canonical but valid CBOR encodings and hash-sensitive
+     * opaque payloads from accidental re-encoding or off-by-one slicing.
+     */
+    @Property(tries = 200)
+    void emitsExactMessageBytesForAnyMuxSegmentation(@ForAll long seed,
+                                                     @ForAll @IntRange(min = 1, max = 50) int messageCount,
+                                                     @ForAll @IntRange(min = 1, max = 256) int maxChunkSize) {
+        Random random = new Random(seed);
+        List<byte[]> messages = randomMuxMessages(random, messageCount);
+        List<byte[]> chunks = splitStream(concat(messages), random, maxChunkSize);
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new MiniProtoStreamingByteToMessageDecoder(new TestAgent(PROTOCOL_A)));
+
+        List<Segment> emitted = writeChunks(channel, PROTOCOL_A, chunks);
+
+        assertTrue(channel.isActive(), "seed=" + seed);
+        assertPayloads(messages, emitted, seed);
+    }
+
+    /**
+     * Mux carries several mini-protocols over the same connection.
+     *
+     * <p>Each protocol id must have its own accumulation buffer. A partial message on one
+     * protocol must not block, consume, or contaminate message boundaries for another
+     * protocol. This property interleaves chunks from two protocol streams and verifies
+     * that each stream is reconstructed independently.
+     */
+    @Property(tries = 200)
+    void keepsIndependentBuffersForInterleavedProtocols(@ForAll long seed,
+                                                       @ForAll @IntRange(min = 1, max = 30) int protocolAMessageCount,
+                                                       @ForAll @IntRange(min = 1, max = 30) int protocolBMessageCount,
+                                                       @ForAll @IntRange(min = 1, max = 128) int maxChunkSize) {
+        Random random = new Random(seed);
+        List<byte[]> protocolAMessages = randomMuxMessages(random, protocolAMessageCount);
+        List<byte[]> protocolBMessages = randomMuxMessages(random, protocolBMessageCount);
+        List<byte[]> protocolAChunks = splitStream(concat(protocolAMessages), random, maxChunkSize);
+        List<byte[]> protocolBChunks = splitStream(concat(protocolBMessages), random, maxChunkSize);
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new MiniProtoStreamingByteToMessageDecoder(new TestAgent(PROTOCOL_A), new TestAgent(PROTOCOL_B)));
+
+        List<Segment> emitted = new ArrayList<>();
+        int a = 0;
+        int b = 0;
+        while (a < protocolAChunks.size() || b < protocolBChunks.size()) {
+            boolean writeA = b >= protocolBChunks.size() || (a < protocolAChunks.size() && random.nextBoolean());
+            if (writeA) {
+                channel.writeInbound(muxSegment(PROTOCOL_A, protocolAChunks.get(a++)));
+            } else {
+                channel.writeInbound(muxSegment(PROTOCOL_B, protocolBChunks.get(b++)));
+            }
+            drain(channel, emitted);
+        }
+
+        assertTrue(channel.isActive(), "seed=" + seed);
+        assertPayloads(protocolAMessages, payloadsForProtocol(emitted, PROTOCOL_A), seed);
+        assertPayloads(protocolBMessages, payloadsForProtocol(emitted, PROTOCOL_B), seed);
+    }
+
+    /**
+     * Structurally malformed CBOR should poison the mux decoder for the connection.
+     *
+     * <p>This property is intentionally small in scope. It does not try to prove DoS or
+     * resource-limit policy. It only protects the reject path invariant: after a valid
+     * message prefix, a malformed CBOR fragment must close the channel and must not emit
+     * any extra payload bytes after the stream is known to be invalid.
+     */
+    @Property(tries = 100)
+    void malformedCborClosesChannelWithoutEmittingGarbage(@ForAll long seed,
+                                                          @ForAll @IntRange(min = 1, max = 128) int maxChunkSize) {
+        Random random = new Random(seed);
+        byte[] validMessage = randomMuxMessage(random);
+        byte[] malformed = randomMalformedCbor(random);
+        List<byte[]> malformedChunks = splitStream(malformed, random, maxChunkSize);
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new MiniProtoStreamingByteToMessageDecoder(new TestAgent(PROTOCOL_A)));
+
+        List<Segment> emitted = withDecoderLoggingDisabled(() -> {
+            List<Segment> segments = writeChunks(channel, PROTOCOL_A, List.of(validMessage));
+            segments.addAll(writeChunksUntilInactive(channel, PROTOCOL_A, malformedChunks));
+            channel.runPendingTasks();
+            return segments;
+        });
+
+        assertFalse(channel.isActive(), "seed=" + seed);
+        assertEquals(1, emitted.size(), "seed=" + seed);
+        assertArrayEquals(validMessage, emitted.get(0).getPayload(), "seed=" + seed);
+    }
+
+    /**
+     * Generates mux message payloads shaped like normal Cardano mini-protocol messages:
+     * a top-level CBOR array, sometimes wrapped in a tag. The array can contain arbitrary
+     * nested valid CBOR values.
+     */
+    private List<byte[]> randomMuxMessages(Random random, int messageCount) {
+        List<byte[]> messages = new ArrayList<>(messageCount);
+        for (int i = 0; i < messageCount; i++) {
+            messages.add(randomMuxMessage(random));
+        }
+        return messages;
+    }
+
+    private byte[] randomMuxMessage(Random random) {
+        byte[] array = random.nextBoolean()
+                ? randomArray(random, 0)
+                : randomIndefiniteArray(random, 0);
+
+        if (random.nextInt(4) == 0) {
+            return concat(encodeUnsigned(6, 1_000 + random.nextInt(10_000)), array);
+        } else {
+            return array;
+        }
+    }
+
+    /**
+     * Generates valid CBOR values for message contents. It intentionally includes nested
+     * arrays/maps, indefinite-length containers, indefinite byte/text strings, and tags
+     * because those are the cases where boundary scanning is easy to get wrong.
+     */
+    private byte[] randomCbor(Random random, int depth) {
+        int choice = depth > 3 ? random.nextInt(5) : random.nextInt(12);
+        return switch (choice) {
+            case 0 -> encodeUnsigned(0, randomIntegerArgument(random));
+            case 1 -> encodeUnsigned(1, randomIntegerArgument(random));
+            case 2 -> randomByteString(random);
+            case 3 -> randomTextString(random);
+            case 4 -> randomSimple(random);
+            case 5 -> randomArray(random, depth);
+            case 6 -> randomMap(random, depth);
+            case 7 -> randomIndefiniteArray(random, depth);
+            case 8 -> randomIndefiniteMap(random, depth);
+            case 9 -> concat(encodeUnsigned(6, 1_000 + random.nextInt(10_000)), randomCbor(random, depth + 1));
+            case 10 -> randomIndefiniteByteString(random);
+            default -> randomIndefiniteTextString(random);
+        };
+    }
+
+    private long randomIntegerArgument(Random random) {
+        return switch (random.nextInt(5)) {
+            case 0 -> random.nextInt(24);
+            case 1 -> random.nextInt(256);
+            case 2 -> random.nextInt(65_536);
+            case 3 -> random.nextLong(1L << 32);
+            default -> random.nextLong(Long.MAX_VALUE);
+        };
+    }
+
+    private byte[] randomByteString(Random random) {
+        byte[] data = new byte[random.nextInt(32)];
+        random.nextBytes(data);
+        return concat(encodeUnsigned(2, data.length), data);
+    }
+
+    private byte[] randomTextString(Random random) {
+        byte[] data = randomAsciiBytes(random);
+        return concat(encodeUnsigned(3, data.length), data);
+    }
+
+    private byte[] randomSimple(Random random) {
+        return switch (random.nextInt(8)) {
+            case 0 -> bytes(0xf4);
+            case 1 -> bytes(0xf5);
+            case 2 -> bytes(0xf6);
+            case 3 -> bytes(0xf7);
+            case 4 -> bytes(0xf8, 32 + random.nextInt(224));
+            case 5 -> concat(bytes(0xf9), randomBytes(random, 2));
+            case 6 -> concat(bytes(0xfa), randomBytes(random, 4));
+            default -> concat(bytes(0xfb), randomBytes(random, 8));
+        };
+    }
+
+    private byte[] randomArray(Random random, int depth) {
+        int length = random.nextInt(5);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.writeBytes(encodeUnsigned(4, length));
+        for (int i = 0; i < length; i++) {
+            out.writeBytes(randomCbor(random, depth + 1));
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] randomMap(Random random, int depth) {
+        int length = random.nextInt(5);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.writeBytes(encodeUnsigned(5, length));
+        for (int i = 0; i < length; i++) {
+            out.writeBytes(randomCbor(random, depth + 1));
+            out.writeBytes(randomCbor(random, depth + 1));
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] randomIndefiniteArray(Random random, int depth) {
+        int length = random.nextInt(5);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(0x9f);
+        for (int i = 0; i < length; i++) {
+            out.writeBytes(randomCbor(random, depth + 1));
+        }
+        out.write(0xff);
+        return out.toByteArray();
+    }
+
+    private byte[] randomIndefiniteMap(Random random, int depth) {
+        int length = random.nextInt(5);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(0xbf);
+        for (int i = 0; i < length; i++) {
+            out.writeBytes(randomCbor(random, depth + 1));
+            out.writeBytes(randomCbor(random, depth + 1));
+        }
+        out.write(0xff);
+        return out.toByteArray();
+    }
+
+    private byte[] randomIndefiniteByteString(Random random) {
+        int chunks = random.nextInt(5);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(0x5f);
+        for (int i = 0; i < chunks; i++) {
+            out.writeBytes(randomByteString(random));
+        }
+        out.write(0xff);
+        return out.toByteArray();
+    }
+
+    private byte[] randomIndefiniteTextString(Random random) {
+        int chunks = random.nextInt(5);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(0x7f);
+        for (int i = 0; i < chunks; i++) {
+            out.writeBytes(randomTextString(random));
+        }
+        out.write(0xff);
+        return out.toByteArray();
+    }
+
+    private byte[] randomAsciiBytes(Random random) {
+        byte[] data = new byte[random.nextInt(32)];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) ('a' + random.nextInt(26));
+        }
+        return data;
+    }
+
+    private byte[] randomMalformedCbor(Random random) {
+        return switch (random.nextInt(6)) {
+            case 0 -> bytes(0xff); // Top-level break byte.
+            case 1 -> bytes(0x82, 0x01, 0xff); // Break byte inside a definite array.
+            case 2 -> bytes(0xbf, 0x01, 0xff); // Indefinite map ends after key without value.
+            case 3 -> bytes(0x5f, 0x5f, 0x40, 0xff, 0xff); // Nested indefinite byte-string chunk.
+            case 4 -> bytes(0x5f, 0x01, 0xff); // Indefinite byte string contains a non-byte-string chunk.
+            default -> bytes(0xfc); // Reserved simple-value additional information.
+        };
+    }
+
+    private byte[] randomBytes(Random random, int length) {
+        byte[] bytes = new byte[length];
+        random.nextBytes(bytes);
+        return bytes;
+    }
+
+    /**
+     * Splits a byte stream into arbitrary mux payload chunks. The decoder must behave the
+     * same whether a CBOR message arrives in one segment, byte-by-byte, or across several
+     * uneven segments.
+     */
+    private List<byte[]> splitStream(byte[] bytes, Random random, int maxChunkSize) {
+        List<byte[]> chunks = new ArrayList<>();
+        int offset = 0;
+        while (offset < bytes.length) {
+            int maxSize = Math.min(maxChunkSize, bytes.length - offset);
+            int chunkSize = 1 + random.nextInt(maxSize);
+            chunks.add(Arrays.copyOfRange(bytes, offset, offset + chunkSize));
+            offset += chunkSize;
+        }
+        return chunks;
+    }
+
+    private List<Segment> writeChunks(EmbeddedChannel channel, int protocol, List<byte[]> chunks) {
+        List<Segment> emitted = new ArrayList<>();
+        for (byte[] chunk : chunks) {
+            channel.writeInbound(muxSegment(protocol, chunk));
+            drain(channel, emitted);
+        }
+        return emitted;
+    }
+
+    private List<Segment> writeChunksUntilInactive(EmbeddedChannel channel, int protocol, List<byte[]> chunks) {
+        List<Segment> emitted = new ArrayList<>();
+        for (byte[] chunk : chunks) {
+            if (!channel.isActive())
+                break;
+
+            channel.writeInbound(muxSegment(protocol, chunk));
+            drain(channel, emitted);
+        }
+        return emitted;
+    }
+
+    private List<Segment> withDecoderLoggingDisabled(SegmentSupplier supplier) {
+        LoggingControl loggingControl = disableDecoderLogging();
+        try {
+            return supplier.get();
+        } finally {
+            if (loggingControl != null)
+                loggingControl.restore();
+        }
+    }
+
+    private LoggingControl disableDecoderLogging() {
+        try {
+            Class<?> loggerClass = Class.forName("org.apache.log4j.Logger");
+            Class<?> levelClass = Class.forName("org.apache.log4j.Level");
+            Method getLogger = loggerClass.getMethod("getLogger", Class.class);
+            Method getLevel = loggerClass.getMethod("getLevel");
+            Method setLevel = loggerClass.getMethod("setLevel", levelClass);
+            Object logger = getLogger.invoke(null, MiniProtoStreamingByteToMessageDecoder.class);
+            Object previousLevel = getLevel.invoke(logger);
+            Object offLevel = levelClass.getField("OFF").get(null);
+
+            setLevel.invoke(logger, offLevel);
+            return () -> {
+                try {
+                    setLevel.invoke(logger, new Object[]{previousLevel});
+                } catch (ReflectiveOperationException e) {
+                    // Best-effort test log suppression only.
+                }
+            };
+        } catch (ReflectiveOperationException e) {
+            return null;
+        }
+    }
+
+    private void drain(EmbeddedChannel channel, List<Segment> emitted) {
+        Segment segment;
+        while ((segment = channel.readInbound()) != null) {
+            emitted.add(segment);
+        }
+    }
+
+    private List<Segment> payloadsForProtocol(List<Segment> emitted, int protocol) {
+        return emitted.stream()
+                .filter(segment -> segment.getProtocol() == protocol)
+                .toList();
+    }
+
+    private void assertPayloads(List<byte[]> expected, List<Segment> actual, long seed) {
+        assertEquals(expected.size(), actual.size(), "seed=" + seed);
+        for (int i = 0; i < expected.size(); i++) {
+            assertArrayEquals(expected.get(i), actual.get(i).getPayload(), "seed=" + seed + ", message=" + i);
+        }
+    }
+
+    private ByteBuf muxSegment(int protocol, byte[] payload) {
+        ByteBuf byteBuf = Unpooled.buffer();
+        byteBuf.writeInt(0);
+        byteBuf.writeShort(protocol);
+        byteBuf.writeShort(payload.length);
+        byteBuf.writeBytes(payload);
+        return byteBuf;
+    }
+
+    private byte[] encodeUnsigned(int majorType, long argument) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int prefix = majorType << 5;
+        if (argument < 24) {
+            out.write(prefix | (int) argument);
+        } else if (argument <= 0xff) {
+            out.write(prefix | 24);
+            out.write((int) argument);
+        } else if (argument <= 0xffff) {
+            out.write(prefix | 25);
+            out.write((int) (argument >>> 8));
+            out.write((int) argument);
+        } else if (argument <= 0xffffffffL) {
+            out.write(prefix | 26);
+            for (int i = 3; i >= 0; i--) {
+                out.write((int) (argument >>> (8 * i)));
+            }
+        } else {
+            out.write(prefix | 27);
+            for (int i = 7; i >= 0; i--) {
+                out.write((int) (argument >>> (8 * i)));
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] concat(List<byte[]> chunks) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] chunk : chunks) {
+            out.writeBytes(chunk);
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] concat(byte[]... chunks) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] chunk : chunks) {
+            out.writeBytes(chunk);
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] bytes(int... values) {
+        byte[] bytes = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            bytes[i] = (byte) values[i];
+        }
+        return bytes;
+    }
+
+    private interface SegmentSupplier {
+        List<Segment> get();
+    }
+
+    private interface LoggingControl {
+        void restore();
+    }
+
+    private static class TestAgent extends Agent<AgentListener> {
+        private final int protocolId;
+
+        private TestAgent(int protocolId) {
+            super(true);
+            this.protocolId = protocolId;
+            this.currentState = TestState.INSTANCE;
+        }
+
+        @Override
+        public int getProtocolId() {
+            return protocolId;
+        }
+
+        @Override
+        public Message buildNextMessage() {
+            return null;
+        }
+
+        @Override
+        public void processResponse(Message message) {
+        }
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+    }
+
+    private enum TestState implements State {
+        INSTANCE;
+
+        @Override
+        public State nextState(Message message) {
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return true;
+        }
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/network/handlers/MiniProtoStreamingByteToMessageDecoderTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/network/handlers/MiniProtoStreamingByteToMessageDecoderTest.java
@@ -1,0 +1,270 @@
+package com.bloxbean.cardano.yaci.core.network.handlers;
+
+import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.AgentListener;
+import com.bloxbean.cardano.yaci.core.protocol.Message;
+import com.bloxbean.cardano.yaci.core.protocol.Segment;
+import com.bloxbean.cardano.yaci.core.protocol.State;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MiniProtoStreamingByteToMessageDecoderTest {
+
+    @Test
+    void preservesEmptyIndefiniteMapBreakByte() {
+        byte[] payload = bytes(0xbf, 0xff);
+        EmbeddedChannel channel = channelForProtocol(19);
+
+        assertTrue(channel.writeInbound(muxSegment(19, payload)));
+
+        Segment segment = channel.readInbound();
+        assertArrayEquals(payload, segment.getPayload());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void preservesNonCanonicalCborBytes() {
+        byte[] payload = bytes(0x18, 0x00);
+        EmbeddedChannel channel = channelForProtocol(42);
+
+        assertTrue(channel.writeInbound(muxSegment(42, payload)));
+
+        Segment segment = channel.readInbound();
+        assertArrayEquals(payload, segment.getPayload());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void splitsMultipleArrayMessagesFromOneMuxSegment() {
+        EmbeddedChannel channel = channelForProtocol(7);
+
+        assertTrue(channel.writeInbound(muxSegment(7, bytes(0x81, 0x01, 0x82, 0x02, 0x03))));
+
+        Segment first = channel.readInbound();
+        Segment second = channel.readInbound();
+        assertArrayEquals(bytes(0x81, 0x01), first.getPayload());
+        assertArrayEquals(bytes(0x82, 0x02, 0x03), second.getPayload());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void groupsArrayWithFollowingNonArrayItemsUntilNextArray() {
+        EmbeddedChannel channel = channelForProtocol(7);
+
+        assertTrue(channel.writeInbound(muxSegment(7, bytes(0x81, 0x01, 0x02, 0x41, 0xaa, 0x81, 0x03))));
+
+        Segment first = channel.readInbound();
+        Segment second = channel.readInbound();
+        assertArrayEquals(bytes(0x81, 0x01, 0x02, 0x41, 0xaa), first.getPayload());
+        assertArrayEquals(bytes(0x81, 0x03), second.getPayload());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void waitsForGroupedTrailingNonArrayItemAcrossMuxSegments() {
+        EmbeddedChannel channel = channelForProtocol(7);
+
+        assertFalse(channel.writeInbound(muxSegment(7, bytes(0x81, 0x01, 0x42))));
+        assertTrue(channel.writeInbound(muxSegment(7, bytes(0xaa, 0xbb))));
+
+        Segment segment = channel.readInbound();
+        assertArrayEquals(bytes(0x81, 0x01, 0x42, 0xaa, 0xbb), segment.getPayload());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void waitsForSingleMessageSplitAcrossMuxSegments() {
+        EmbeddedChannel channel = channelForProtocol(7);
+
+        assertFalse(channel.writeInbound(muxSegment(7, bytes(0x82, 0x01))));
+        assertTrue(channel.writeInbound(muxSegment(7, bytes(0x02))));
+
+        Segment segment = channel.readInbound();
+        assertArrayEquals(bytes(0x82, 0x01, 0x02), segment.getPayload());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void splitsTaggedArrayMessagesFromOneMuxSegment() {
+        EmbeddedChannel channel = channelForProtocol(7);
+
+        assertTrue(channel.writeInbound(muxSegment(7, bytes(0xc0, 0x81, 0x01, 0xc0, 0x81, 0x02))));
+
+        Segment first = channel.readInbound();
+        Segment second = channel.readInbound();
+        assertArrayEquals(bytes(0xc0, 0x81, 0x01), first.getPayload());
+        assertArrayEquals(bytes(0xc0, 0x81, 0x02), second.getPayload());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void waitsForTaggedArrayMessageStartSplitAcrossMuxSegments() {
+        EmbeddedChannel channel = channelForProtocol(7);
+
+        assertFalse(channel.writeInbound(muxSegment(7, bytes(0x81, 0x01, 0xc0))));
+        assertTrue(channel.writeInbound(muxSegment(7, bytes(0x81, 0x02))));
+
+        Segment first = channel.readInbound();
+        Segment second = channel.readInbound();
+        assertArrayEquals(bytes(0x81, 0x01), first.getPayload());
+        assertArrayEquals(bytes(0xc0, 0x81, 0x02), second.getPayload());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void closesChannelOnMalformedCborPayload() {
+        EmbeddedChannel channel = channelForProtocol(7);
+
+        assertFalse(channel.writeInbound(muxSegment(7, bytes(0xff))));
+        channel.runPendingTasks();
+
+        assertFalse(channel.isActive());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void discardsRemainingMuxSegmentsAfterMalformedCborPayload() {
+        EmbeddedChannel channel = channelForProtocol(7);
+
+        assertFalse(channel.writeInbound(muxSegments(7, bytes(0xff), bytes(0x81, 0x01))));
+        channel.runPendingTasks();
+
+        assertFalse(channel.isActive());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void closesChannelOnUnsupportedOversizedDeclaredLength() {
+        EmbeddedChannel channel = channelForProtocol(7);
+
+        assertFalse(channel.writeInbound(muxSegment(7, bytes(0x5a, 0xff, 0xff, 0xff, 0xff))));
+        channel.runPendingTasks();
+
+        assertFalse(channel.isActive());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void closesChannelWhenIncompletePayloadExceedsConfiguredAccumulationCap() {
+        EmbeddedChannel channel = new EmbeddedChannel(new MiniProtoStreamingByteToMessageDecoder(1024, new TestAgent(7)));
+        byte[] hugeByteStringHeader = bytes(0x5a, 0x7f, 0xff, 0xff, 0xff);
+        byte[] continuation = new byte[65535];
+
+        assertFalse(channel.writeInbound(muxSegment(7, hugeByteStringHeader)));
+        for (int i = 0; i < 200 && channel.isActive(); i++) {
+            channel.writeInbound(muxSegment(7, continuation));
+        }
+        channel.runPendingTasks();
+
+        assertFalse(channel.isActive());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void closesChannelOnUnregisteredProtocol() {
+        EmbeddedChannel channel = new EmbeddedChannel(new MiniProtoStreamingByteToMessageDecoder());
+
+        assertFalse(channel.writeInbound(muxSegment(7, bytes(0x81, 0x01))));
+        channel.runPendingTasks();
+
+        assertFalse(channel.isActive());
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    void defaultDecoderDoesNotApplyOldEightMbHardCap() {
+        EmbeddedChannel channel = channelForProtocol(7);
+        byte[] hugeByteStringHeader = bytes(0x5a, 0x7f, 0xff, 0xff, 0xff);
+        byte[] continuation = new byte[65535];
+
+        assertFalse(channel.writeInbound(muxSegment(7, hugeByteStringHeader)));
+        for (int i = 0; i < 130; i++) {
+            assertFalse(channel.writeInbound(muxSegment(7, continuation)));
+        }
+
+        assertTrue(channel.isActive());
+        assertNull(channel.readInbound());
+    }
+
+    private EmbeddedChannel channelForProtocol(int protocol) {
+        return new EmbeddedChannel(new MiniProtoStreamingByteToMessageDecoder(new TestAgent(protocol)));
+    }
+
+    private ByteBuf muxSegment(int protocol, byte[] payload) {
+        ByteBuf byteBuf = Unpooled.buffer();
+        byteBuf.writeInt(0);
+        byteBuf.writeShort(protocol);
+        byteBuf.writeShort(payload.length);
+        byteBuf.writeBytes(payload);
+        return byteBuf;
+    }
+
+    private ByteBuf muxSegments(int protocol, byte[]... payloads) {
+        ByteBuf byteBuf = Unpooled.buffer();
+        for (byte[] payload : payloads) {
+            byteBuf.writeInt(0);
+            byteBuf.writeShort(protocol);
+            byteBuf.writeShort(payload.length);
+            byteBuf.writeBytes(payload);
+        }
+        return byteBuf;
+    }
+
+    private byte[] bytes(int... values) {
+        byte[] bytes = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            bytes[i] = (byte) values[i];
+        }
+        return bytes;
+    }
+
+    private static class TestAgent extends Agent<AgentListener> {
+        private final int protocolId;
+
+        private TestAgent(int protocolId) {
+            super(true);
+            this.protocolId = protocolId;
+            this.currentState = TestState.INSTANCE;
+        }
+
+        @Override
+        public int getProtocolId() {
+            return protocolId;
+        }
+
+        @Override
+        public Message buildNextMessage() {
+            return null;
+        }
+
+        @Override
+        public void processResponse(Message message) {
+        }
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+    }
+
+    private enum TestState implements State {
+        INSTANCE;
+
+        @Override
+        public State nextState(Message message) {
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return true;
+        }
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/AgentWriteMessageTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/AgentWriteMessageTest.java
@@ -1,0 +1,297 @@
+package com.bloxbean.cardano.yaci.core.protocol;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentWriteMessageTest {
+
+    @Test
+    void writeMessageFailureCallbackIsInvokedWhenChannelIsInactive() {
+        TestAgent agent = new TestAgent();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        agent.write(new TestMessage(new byte[]{1}), () -> {
+        }, failure::set);
+
+        assertNotNull(failure.get());
+        assertTrue(failure.get().getMessage().contains("channel is null or inactive"));
+    }
+
+    @Test
+    void writeMessageFailureCallbackIsInvokedWhenNettyWriteFails() {
+        RuntimeException writeFailure = new RuntimeException("write failed");
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                promise.setFailure(writeFailure);
+            }
+        });
+        TestAgent agent = new TestAgent();
+        agent.setChannel(channel);
+        AtomicBoolean success = new AtomicBoolean(false);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        agent.write(new TestMessage(new byte[]{1}), () -> success.set(true), failure::set);
+
+        assertFalse(success.get());
+        assertSame(writeFailure, failure.get());
+    }
+
+    @Test
+    void writeMessageRethrowsWhenSerializationFails() {
+        RuntimeException serializeFailure = new RuntimeException("serialize failed");
+        EmbeddedChannel channel = new EmbeddedChannel();
+        TestAgent agent = new TestAgent();
+        agent.setChannel(channel);
+        AtomicBoolean success = new AtomicBoolean(false);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> agent.write(new FailingMessage(serializeFailure), () -> success.set(true), failure::set));
+
+        assertSame(serializeFailure, exception);
+        assertFalse(success.get());
+        assertNull(failure.get());
+        assertTrue(channel.isActive());
+    }
+
+    @Test
+    void writeMessageRethrowsWhenSerializationThrowsError() {
+        AssertionError serializeFailure = new AssertionError("serialize overflow");
+        EmbeddedChannel channel = new EmbeddedChannel();
+        TestAgent agent = new TestAgent();
+        agent.setChannel(channel);
+        AtomicBoolean success = new AtomicBoolean(false);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        AssertionError exception = assertThrows(AssertionError.class,
+                () -> agent.write(new FailingErrorMessage(serializeFailure), () -> success.set(true), failure::set));
+
+        assertSame(serializeFailure, exception);
+        assertFalse(success.get());
+        assertNull(failure.get());
+        assertTrue(channel.isActive());
+    }
+
+    @Test
+    void writeMessageFailureCallbackIsInvokedWhenNettyWriteThrowsSynchronously() {
+        RuntimeException writeFailure = new RuntimeException("write threw");
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                throw writeFailure;
+            }
+        });
+        TestAgent agent = new TestAgent();
+        agent.setChannel(channel);
+        AtomicBoolean success = new AtomicBoolean(false);
+        AtomicInteger failures = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        agent.write(new TestMessage(new byte[]{1}), () -> success.set(true), throwable -> {
+            failures.incrementAndGet();
+            failure.set(throwable);
+        });
+
+        assertFalse(success.get());
+        assertEquals(1, failures.get());
+        assertNotNull(failure.get());
+    }
+
+    @Test
+    void segmentedWriteFailureInvokesFailureCallbackExactlyOnce() {
+        RuntimeException writeFailure = new RuntimeException("segment failed");
+        AtomicInteger writes = new AtomicInteger();
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                if (writes.incrementAndGet() == 2)
+                    promise.setFailure(writeFailure);
+                else
+                    promise.setSuccess();
+            }
+        });
+        TestAgent agent = new TestAgent();
+        agent.setChannel(channel);
+        AtomicBoolean success = new AtomicBoolean(false);
+        AtomicInteger failures = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        agent.write(new TestMessage(new byte[131071]), () -> success.set(true), throwable -> {
+            failures.incrementAndGet();
+            failure.set(throwable);
+        });
+
+        assertFalse(success.get());
+        assertEquals(1, failures.get());
+        assertSame(writeFailure, failure.get());
+        assertFalse(channel.isActive());
+    }
+
+    @Test
+    void legacyWriteMessageClosesChannelOnWriteFailure() {
+        RuntimeException writeFailure = new RuntimeException("write failed");
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                promise.setFailure(writeFailure);
+            }
+        });
+        TestAgent agent = new TestAgent();
+        agent.setChannel(channel);
+        AtomicBoolean success = new AtomicBoolean(false);
+
+        agent.writeLegacy(new TestMessage(new byte[]{1}), () -> success.set(true));
+        channel.runPendingTasks();
+
+        assertFalse(success.get());
+        assertFalse(channel.isActive());
+    }
+
+    @Test
+    void legacyWriteMessageClosesOriginalFailedChannelAfterReconnect() {
+        RuntimeException writeFailure = new RuntimeException("late write failed");
+        AtomicReference<ChannelPromise> pendingWrite = new AtomicReference<>();
+        EmbeddedChannel failedChannel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                pendingWrite.set(promise);
+            }
+        });
+        EmbeddedChannel reconnectedChannel = new EmbeddedChannel();
+        TestAgent agent = new TestAgent();
+        agent.setChannel(failedChannel);
+
+        agent.writeLegacy(new TestMessage(new byte[]{1}), () -> {
+        });
+        assertNotNull(pendingWrite.get());
+
+        agent.setChannel(reconnectedChannel);
+        pendingWrite.get().setFailure(writeFailure);
+        failedChannel.runPendingTasks();
+        reconnectedChannel.runPendingTasks();
+
+        assertFalse(failedChannel.isActive());
+        assertTrue(reconnectedChannel.isActive());
+    }
+
+    @Test
+    void legacyWriteMessageRethrowsSerializationFailureWithoutClosingChannel() {
+        RuntimeException serializeFailure = new RuntimeException("serialize failed");
+        EmbeddedChannel channel = new EmbeddedChannel();
+        TestAgent agent = new TestAgent();
+        agent.setChannel(channel);
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> agent.writeLegacy(new FailingMessage(serializeFailure), () -> {
+                }));
+
+        assertSame(serializeFailure, exception);
+        assertTrue(channel.isActive());
+    }
+
+    @Test
+    void throwingFailureCallbackDoesNotEscapeNettyWriteFailurePath() {
+        RuntimeException writeFailure = new RuntimeException("write failed");
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                promise.setFailure(writeFailure);
+            }
+        });
+        TestAgent agent = new TestAgent();
+        agent.setChannel(channel);
+
+        agent.write(new TestMessage(new byte[]{1}), () -> {
+        }, throwable -> {
+            throw new IllegalStateException("callback failed");
+        });
+
+        assertTrue(channel.isActive());
+    }
+
+    private static class TestAgent extends Agent<AgentListener> {
+        private TestAgent() {
+            super(true);
+            this.currentState = TestState.INSTANCE;
+        }
+
+        @Override
+        public int getProtocolId() {
+            return 42;
+        }
+
+        @Override
+        public Message buildNextMessage() {
+            return null;
+        }
+
+        @Override
+        public void processResponse(Message message) {
+        }
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+
+        private void write(Message message, Runnable onSuccess, Consumer<Throwable> onFailure) {
+            writeMessage(message, onSuccess, onFailure);
+        }
+
+        private void writeLegacy(Message message, Runnable onSuccess) {
+            writeMessage(message, onSuccess);
+        }
+    }
+
+    private enum TestState implements State {
+        INSTANCE;
+
+        @Override
+        public State nextState(Message message) {
+            return this;
+        }
+
+        @Override
+        public boolean hasAgency(boolean isClient) {
+            return true;
+        }
+    }
+
+    private record TestMessage(byte[] payload) implements Message {
+        @Override
+        public byte[] serialize() {
+            return payload;
+        }
+    }
+
+    private record FailingMessage(RuntimeException failure) implements Message {
+        @Override
+        public byte[] serialize() {
+            throw failure;
+        }
+    }
+
+    private record FailingErrorMessage(Error failure) implements Message {
+        @Override
+        public byte[] serialize() {
+            throw failure;
+        }
+    }
+}

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/util/CborByteScannerTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/util/CborByteScannerTest.java
@@ -1,0 +1,292 @@
+package com.bloxbean.cardano.yaci.core.util;
+
+import co.nstant.in.cbor.CborDecoder;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CborByteScannerTest {
+
+    @Test
+    void endOffsetIncludesBreakForEmptyIndefiniteMap() {
+        byte[] bytes = bytes(0xbf, 0xff);
+
+        assertEquals(2, CborByteScanner.endOffset(bytes));
+    }
+
+    @Test
+    void endOffsetIncludesNestedIndefiniteItems() {
+        byte[] bytes = bytes(0x82, 0xbf, 0xff, 0x9f, 0x01, 0xff);
+
+        assertEquals(6, CborByteScanner.endOffset(bytes));
+    }
+
+    @Test
+    void completeTopLevelItemsPreservesOriginalBytes() {
+        byte[] bytes = bytes(0x82, 0x01, 0x02, 0x18, 0x00);
+
+        List<CborByteScanner.CborSlice> slices = CborByteScanner.completeTopLevelItems(bytes);
+
+        assertEquals(2, slices.size());
+        assertEquals(CborByteScanner.MAJOR_TYPE_ARRAY, slices.get(0).majorType());
+        assertEquals(CborByteScanner.MAJOR_TYPE_UNSIGNED_INTEGER, slices.get(1).majorType());
+        assertArrayEquals(bytes(0x82, 0x01, 0x02), slices.get(0).copyFrom(bytes));
+        assertArrayEquals(bytes(0x18, 0x00), slices.get(1).copyFrom(bytes));
+    }
+
+    @Test
+    void completeTopLevelItemsStopsBeforeIncompleteTrailingItem() {
+        byte[] bytes = bytes(0x82, 0x01, 0x02, 0x43, 0xaa);
+
+        List<CborByteScanner.CborSlice> slices = CborByteScanner.completeTopLevelItems(bytes);
+
+        assertEquals(1, slices.size());
+        assertArrayEquals(bytes(0x82, 0x01, 0x02), slices.get(0).copyFrom(bytes));
+    }
+
+    @Test
+    void endOffsetFailsForIncompleteItem() {
+        var exception = assertThrows(CborByteScanner.IncompleteCborException.class,
+                () -> CborByteScanner.endOffset(bytes(0x82, 0x01)));
+
+        assertEquals(0, exception.getStackTrace().length);
+    }
+
+    @Test
+    void endOffsetAcceptsUint64ArgumentsWithHighBitSetForIntegerValues() {
+        assertEquals(9, CborByteScanner.endOffset(bytes(
+                0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff)));
+        assertEquals(9, CborByteScanner.endOffset(bytes(
+                0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff)));
+    }
+
+    @Test
+    void endOffsetAcceptsUint64ArgumentsWithHighBitSetForTags() {
+        assertEquals(10, CborByteScanner.endOffset(bytes(
+                0xdb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01)));
+    }
+
+    @Test
+    void endOffsetRejectsLengthTooLargeForJavaByteArray() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CborByteScanner.endOffset(bytes(0x5a, 0xff, 0xff, 0xff, 0xff)));
+    }
+
+    @Test
+    void endOffsetRejectsExcessiveNestingBeforeStackOverflow() {
+        byte[] bytes = new byte[1100];
+        for (int i = 0; i < bytes.length - 1; i++) {
+            bytes[i] = (byte) 0x81;
+        }
+        bytes[bytes.length - 1] = 0x00;
+
+        assertThrows(IllegalArgumentException.class, () -> CborByteScanner.endOffset(bytes));
+    }
+
+    @Test
+    void completeTopLevelItemsReportsTaggedArrayContentMajorType() {
+        byte[] bytes = bytes(0xc0, 0x81, 0x01);
+
+        List<CborByteScanner.CborSlice> slices = CborByteScanner.completeTopLevelItems(bytes);
+
+        assertEquals(1, slices.size());
+        assertEquals(CborByteScanner.MAJOR_TYPE_TAG, slices.get(0).majorType());
+        assertEquals(CborByteScanner.MAJOR_TYPE_ARRAY, slices.get(0).untaggedMajorType());
+    }
+
+    @Test
+    void completeTopLevelItemsCanResumeFromOffset() {
+        byte[] bytes = bytes(0x81, 0x01, 0x82, 0x02, 0x03);
+
+        List<CborByteScanner.CborSlice> slices = CborByteScanner.completeTopLevelItems(bytes, 2);
+
+        assertEquals(1, slices.size());
+        assertEquals(2, slices.get(0).startOffset());
+        assertEquals(5, slices.get(0).endOffset());
+    }
+
+    @Test
+    void endOffsetRejectsTopLevelBreak() {
+        assertThrows(IllegalArgumentException.class, () -> CborByteScanner.endOffset(bytes(0xff)));
+    }
+
+    @Test
+    void endOffsetRejectsNestedIndefiniteStringChunks() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CborByteScanner.endOffset(bytes(0x5f, 0x5f, 0x40, 0xff, 0xff)));
+    }
+
+    @Test
+    void endOffsetRejectsContainerCountAboveJavaSignedLongRange() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CborByteScanner.endOffset(bytes(0x9b, 0x80, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x00)));
+    }
+
+    @Test
+    void generatedValidCborMatchesCborJavaBoundaries() throws Exception {
+        Random random = new Random(0x5eed);
+        List<byte[]> sequence = new ArrayList<>();
+        ByteArrayOutputStream concatenated = new ByteArrayOutputStream();
+
+        for (int i = 0; i < 5_000; i++) {
+            byte[] value = randomCbor(random, 0);
+            CborDecoder.decode(value);
+            assertEquals(value.length, CborByteScanner.endOffset(value), "case " + i);
+
+            sequence.add(value);
+            concatenated.write(value);
+        }
+
+        byte[] bytes = concatenated.toByteArray();
+        List<CborByteScanner.CborSlice> slices = CborByteScanner.completeTopLevelItems(bytes);
+
+        assertEquals(sequence.size(), slices.size());
+        for (int i = 0; i < sequence.size(); i++) {
+            assertArrayEquals(sequence.get(i), slices.get(i).copyFrom(bytes), "slice " + i);
+        }
+    }
+
+    private byte[] bytes(int... values) {
+        byte[] bytes = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            bytes[i] = (byte) values[i];
+        }
+        return bytes;
+    }
+
+    private byte[] randomCbor(Random random, int depth) {
+        int choice = depth > 3 ? random.nextInt(5) : random.nextInt(10);
+        return switch (choice) {
+            case 0 -> encodeUnsigned(0, randomArgument(random));
+            case 1 -> encodeUnsigned(1, randomArgument(random));
+            case 2 -> randomByteString(random);
+            case 3 -> randomTextString(random);
+            case 4 -> randomSimple(random);
+            case 5 -> randomArray(random, depth);
+            case 6 -> randomMap(random, depth);
+            case 7 -> randomIndefiniteArray(random, depth);
+            case 8 -> concat(encodeUnsigned(6, 1_000 + random.nextInt(10_000)), randomCbor(random, depth + 1));
+            default -> randomIndefiniteByteString(random);
+        };
+    }
+
+    private long randomArgument(Random random) {
+        return switch (random.nextInt(5)) {
+            case 0 -> random.nextInt(24);
+            case 1 -> random.nextInt(256);
+            case 2 -> random.nextInt(65_536);
+            case 3 -> random.nextLong(1L << 32);
+            default -> random.nextLong(Long.MAX_VALUE);
+        };
+    }
+
+    private byte[] randomByteString(Random random) {
+        byte[] data = new byte[random.nextInt(16)];
+        random.nextBytes(data);
+        return concat(encodeUnsigned(2, data.length), data);
+    }
+
+    private byte[] randomTextString(Random random) {
+        int length = random.nextInt(16);
+        byte[] data = new byte[length];
+        for (int i = 0; i < length; i++) {
+            data[i] = (byte) ('a' + random.nextInt(26));
+        }
+        return concat(encodeUnsigned(3, data.length), data);
+    }
+
+    private byte[] randomSimple(Random random) {
+        return switch (random.nextInt(5)) {
+            case 0 -> bytes(0xf4);
+            case 1 -> bytes(0xf5);
+            case 2 -> bytes(0xf6);
+            case 3 -> bytes(0xf7);
+            default -> bytes(0xf8, 32 + random.nextInt(224));
+        };
+    }
+
+    private byte[] randomArray(Random random, int depth) {
+        int length = random.nextInt(4);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.writeBytes(encodeUnsigned(4, length));
+        for (int i = 0; i < length; i++) {
+            out.writeBytes(randomCbor(random, depth + 1));
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] randomMap(Random random, int depth) {
+        int length = random.nextInt(4);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.writeBytes(encodeUnsigned(5, length));
+        for (int i = 0; i < length; i++) {
+            out.writeBytes(randomCbor(random, depth + 1));
+            out.writeBytes(randomCbor(random, depth + 1));
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] randomIndefiniteArray(Random random, int depth) {
+        int length = random.nextInt(4);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(0x9f);
+        for (int i = 0; i < length; i++) {
+            out.writeBytes(randomCbor(random, depth + 1));
+        }
+        out.write(0xff);
+        return out.toByteArray();
+    }
+
+    private byte[] randomIndefiniteByteString(Random random) {
+        int chunks = random.nextInt(4);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(0x5f);
+        for (int i = 0; i < chunks; i++) {
+            out.writeBytes(randomByteString(random));
+        }
+        out.write(0xff);
+        return out.toByteArray();
+    }
+
+    private byte[] encodeUnsigned(int majorType, long argument) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int prefix = majorType << 5;
+        if (argument < 24) {
+            out.write(prefix | (int) argument);
+        } else if (argument <= 0xff) {
+            out.write(prefix | 24);
+            out.write((int) argument);
+        } else if (argument <= 0xffff) {
+            out.write(prefix | 25);
+            out.write((int) (argument >>> 8));
+            out.write((int) argument);
+        } else if (argument <= 0xffffffffL) {
+            out.write(prefix | 26);
+            for (int i = 3; i >= 0; i--) {
+                out.write((int) (argument >>> (8 * i)));
+            }
+        } else {
+            out.write(prefix | 27);
+            for (int i = 7; i >= 0; i--) {
+                out.write((int) (argument >>> (8 * i)));
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] concat(byte[]... chunks) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] chunk : chunks) {
+            out.writeBytes(chunk);
+        }
+        return out.toByteArray();
+    }
+}

--- a/docs/mux-cbor-byte-scanning.md
+++ b/docs/mux-cbor-byte-scanning.md
@@ -1,0 +1,505 @@
+# Mux CBOR Byte Scanning
+
+This note explains how Yaci splits inbound mux payload bytes into mini-protocol messages.
+It is intentionally focused on the narrow framing problem handled by:
+
+- `MiniProtoStreamingByteToMessageDecoder`
+- `ProtocolChannel`
+- `CborByteScanner`
+
+It does not describe block, transaction, datum, redeemer, or Leios payload decoding. Those
+are handled later by protocol-specific serializers.
+
+## Why This Exists
+
+Cardano mini-protocol messages are CBOR encoded and carried inside mux segments. The mux
+layer gives Yaci bytes for a protocol id, but it does not guarantee that one read equals
+one complete mini-protocol message.
+
+A TCP read or Netty decode pass can contain:
+
+```text
+partial CBOR message
+```
+
+or:
+
+```text
+one complete CBOR message + part of the next message
+```
+
+or:
+
+```text
+multiple complete CBOR messages
+```
+
+The mux decoder therefore needs to answer one question:
+
+```text
+Do we have a complete CBOR item boundary, and which original bytes belong to it?
+```
+
+The important phrase is "original bytes". The mux layer must not decode a CBOR value into
+a Java object and then encode it again just to find a boundary. Re-encoding can change the
+bytes. For example:
+
+```text
+18 00
+```
+
+is a valid non-canonical encoding of integer `0`. A CBOR library may re-encode it as:
+
+```text
+00
+```
+
+That is a different byte sequence. For opaque payloads and hash-sensitive Cardano data,
+that is not acceptable.
+
+Another important example is an empty indefinite-length map:
+
+```text
+BF FF
+```
+
+`BF` starts an indefinite-length map. `FF` is the break byte that closes it. If a library
+drops or rewrites the break byte while re-encoding, the mini-protocol stream can become
+desynchronized.
+
+The current decoder avoids that class of bug by scanning CBOR structure and slicing the
+original byte array.
+
+## Mux Segment Shape
+
+The decoder first reads the mux segment header:
+
+```text
++-------------+-------------+-------------+----------------+
+| timestamp   | protocol id | payload len | payload bytes  |
+| 4 bytes     | 2 bytes     | 2 bytes     | payload len    |
++-------------+-------------+-------------+----------------+
+```
+
+The `protocol id` selects the mini-protocol. Yaci keeps a separate `ProtocolChannel`
+buffer per registered protocol because each mini-protocol stream has independent CBOR
+boundaries.
+
+Simplified flow:
+
+```text
+read mux segment
+  -> find protocol channel
+  -> append payload bytes to that protocol buffer
+  -> scan complete top-level CBOR items
+  -> emit complete mini-protocol message bytes
+  -> keep incomplete residue buffered
+```
+
+Segments for unregistered protocols are rejected. This avoids keeping unbounded buffers
+for protocol ids that no agent owns.
+
+## CBOR Item Basics
+
+Every CBOR data item starts with an initial byte:
+
+```text
+high 3 bits: major type
+low  5 bits: additional information
+```
+
+For example:
+
+```text
+82 01 02
+```
+
+`0x82` in binary is:
+
+```text
+1000_0010
+```
+
+The high 3 bits are `100`, which is major type `4`: array.
+
+The low 5 bits are `00010`, which is additional information `2`: two elements.
+
+So:
+
+```text
+82 01 02
+```
+
+means:
+
+```text
+array of 2 elements
+  element 1: 01
+  element 2: 02
+```
+
+and the complete item occupies 3 bytes.
+
+The major types used by the scanner are:
+
+```text
+0 unsigned integer
+1 negative integer
+2 byte string
+3 text string
+4 array
+5 map
+6 tag
+7 simple value / float / break
+```
+
+The additional information field either contains the value/length directly or says how
+many following bytes contain it:
+
+```text
+0..23   value or length is stored directly in the low 5 bits
+24      next 1 byte stores the value or length
+25      next 2 bytes store the value or length
+26      next 4 bytes store the value or length
+27      next 8 bytes store the value or length
+31      indefinite length, valid for byte/text strings, arrays, and maps
+```
+
+## How Arrays Are Scanned
+
+For arrays, the length is the number of child CBOR items. Knowing the child count is not
+enough to know the byte size of the array. Each child can have a different encoded size.
+
+Example:
+
+```text
+83 01 42 AA BB 82 02 03
+```
+
+Structural view:
+
+```text
+83              array of 3 elements
+
+01              element 1: unsigned integer 1
+
+42 AA BB        element 2: byte string of length 2
+                  AA BB
+
+82 02 03        element 3: array of 2 elements
+                  02
+                  03
+```
+
+The scanner handles this recursively:
+
+```text
+scan item at offset 0
+  initial byte 83 -> array, 3 elements
+  scan child 1 -> integer, 1 byte
+  scan child 2 -> byte string, header plus 2 bytes
+  scan child 3 -> array, recursively scan its 2 children
+  return offset after child 3
+```
+
+In pseudocode:
+
+```java
+scanItem(offset):
+    read initial byte
+    majorType = high 3 bits
+    additionalInfo = low 5 bits
+
+    if integer/simple:
+        skip the encoded argument bytes
+
+    if byte string/text string:
+        read length
+        skip length bytes
+
+    if array:
+        read element count
+        repeat element count times:
+            offset = scanItem(offset)
+
+    if map:
+        read pair count
+        repeat pair count times:
+            offset = scanItem(offset) // key
+            offset = scanItem(offset) // value
+
+    if tag:
+        read tag number
+        offset = scanItem(offset) // tagged item
+
+    return offset
+```
+
+## How Maps Are Scanned
+
+For maps, the length is the number of key/value pairs. The scanner therefore scans two
+CBOR child items for every pair.
+
+Example:
+
+```text
+A2 01 41 AA 02 82 03 04
+```
+
+Structural view:
+
+```text
+A2              map of 2 pairs
+
+01              key 1: unsigned integer 1
+41 AA           value 1: byte string of length 1
+
+02              key 2: unsigned integer 2
+82 03 04        value 2: array of 2 elements
+```
+
+The scanner does not care what the keys or values mean. It only needs to know where each
+child item ends.
+
+## Indefinite-Length Items
+
+CBOR arrays, maps, byte strings, and text strings can use indefinite-length encoding. In
+that case, there is no fixed element count or byte length in the first item header. The
+scanner keeps scanning chunks or child items until it sees the break byte:
+
+```text
+FF
+```
+
+Example indefinite array:
+
+```text
+9F 01 02 03 FF
+```
+
+Structural view:
+
+```text
+9F      start indefinite-length array
+01      child item
+02      child item
+03      child item
+FF      break, end of array
+```
+
+Example empty indefinite map:
+
+```text
+BF FF
+```
+
+Structural view:
+
+```text
+BF      start indefinite-length map
+FF      break, end of map
+```
+
+The break byte is part of the original CBOR encoding. It must be preserved in the emitted
+payload slice.
+
+## Mini-Protocol Message Boundary Rule
+
+Most Cardano mini-protocol messages are encoded as top-level CBOR arrays. For example:
+
+```text
+82 04 58 ...
+```
+
+can be read structurally as:
+
+```text
+array of 2 items
+  message tag 4
+  byte string payload
+```
+
+Yaci uses this convention when several complete top-level CBOR items are present in the
+same protocol buffer:
+
+```text
+an untagged top-level array starts a mini-protocol message
+following non-array top-level items are grouped with that message
+the next untagged top-level array starts the next message
+```
+
+"Untagged" means tags are skipped before checking the major type. So a tag-wrapped array
+is still treated as a message start:
+
+```text
+C0 81 01
+```
+
+Structural view:
+
+```text
+C0      CBOR tag 0
+81 01   tagged value: array of 1 element
+```
+
+The scanner reports this as a top-level item whose outer major type is tag, but whose
+untagged major type is array. The mux decoder can therefore split:
+
+```text
+C0 81 01 C0 81 02
+```
+
+into:
+
+```text
+C0 81 01
+C0 81 02
+```
+
+The grouping rule exists for compatibility with payloads that appear as multiple
+top-level CBOR items in a protocol buffer. Example:
+
+```text
+81 01 02 41 AA 81 03
+```
+
+Top-level CBOR items:
+
+```text
+81 01       array [1]
+02          integer 2
+41 AA       byte string h'AA'
+81 03       array [3]
+```
+
+Yaci emits:
+
+```text
+message 1: 81 01 02 41 AA
+message 2: 81 03
+```
+
+The non-array items after the first array are grouped with the first message until the
+next array starts.
+
+If the decoder cannot yet prove the trailing grouped item is complete, it waits for more
+mux payload bytes instead of emitting early.
+
+Example split across mux segments:
+
+```text
+segment 1 payload: 81 01 42
+segment 2 payload: AA BB
+```
+
+After segment 1:
+
+```text
+81 01       complete array [1]
+42          byte string header: length 2, but bytes are missing
+```
+
+The decoder waits.
+
+After segment 2:
+
+```text
+81 01 42 AA BB
+```
+
+The decoder emits the original five bytes as one protocol payload.
+
+## What Happens To Incomplete CBOR
+
+Incomplete CBOR is not an error by itself. It usually means the value was split across
+mux segments.
+
+Example:
+
+```text
+82 01
+```
+
+The first byte says "array of 2 elements", but only one child item is present. The scanner
+returns "incomplete", and the protocol buffer keeps the bytes.
+
+When the next mux segment arrives:
+
+```text
+02
+```
+
+the buffer becomes:
+
+```text
+82 01 02
+```
+
+and the message can be emitted.
+
+## What Happens To Malformed CBOR
+
+Malformed CBOR is treated differently from incomplete CBOR. For example, a top-level break
+byte is invalid:
+
+```text
+FF
+```
+
+`FF` is only valid inside an indefinite-length item. If it appears as a top-level item, the
+decoder treats the peer stream as invalid, clears the protocol buffer, marks the decoder
+as poisoned, and closes the channel.
+
+This is intentionally strict. Once a mux stream is structurally invalid, guessing future
+message boundaries is unsafe.
+
+## Buffer Size Policy
+
+The default mux decoder does not impose a hard maximum on incomplete CBOR accumulation.
+This is deliberate. LocalStateQuery can return very large results, including ledger-state
+sized responses, and those responses may be much larger than a small fixed cap.
+
+This does not mean every declared CBOR size is accepted. If a CBOR item declares a length
+that cannot be represented safely by Java byte-array indexing, the scanner treats that as
+invalid protocol input. The removed limit was the small fixed accumulation cap, not the
+basic Java safety checks.
+
+The decoder does support an optional `maxIncompleteBufferSize` constructor for constrained
+or test-specific use cases. The default production path leaves it unlimited and relies on:
+
+- registered protocol ids only
+- CBOR structural validation
+- channel close on malformed CBOR
+- normal process and deployment memory limits
+
+Do not add a small global cap here without validating LocalStateQuery and other large
+response paths.
+
+## Narrow Scope
+
+The mux scanner only provides CBOR item boundaries and original byte slices. It does not:
+
+- validate Cardano CDDL
+- check mini-protocol state-machine rules
+- parse blocks, transactions, datums, redeemers, or Leios endorser blocks
+- canonicalize CBOR
+- sort map keys
+- convert CBOR into Java model objects
+
+Those concerns belong to the protocol-specific serializers and model parsers after the
+mux layer has emitted a complete payload.
+
+## Debugging Checklist
+
+When debugging a mux payload in hex:
+
+1. Read the mux header and identify the protocol id.
+2. Append the payload to that protocol's existing buffer.
+3. Look at the first CBOR byte.
+4. Split the first byte into major type and additional information.
+5. For arrays, recursively scan the declared number of child items.
+6. For maps, recursively scan key and value for each pair.
+7. For byte/text strings, skip exactly the declared payload length.
+8. For indefinite items, scan until the `FF` break byte.
+9. Emit only when the full CBOR item or grouped mini-protocol payload is complete.
+10. Slice and pass through the original bytes; do not decode and re-encode at mux level.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ lombok="org.projectlombok:lombok:1.18.44"
 junit-jupiter-api="org.junit.jupiter:junit-jupiter-api:5.13.4"
 junit-jupiter-engine="org.junit.jupiter:junit-jupiter-engine:5.13.4"
 junit-platform-launcher="org.junit.platform:junit-platform-launcher:1.13.4"
+jqwik="net.jqwik:jqwik:1.10.1"
 harmcrest-library="org.hamcrest:hamcrest-library:2.2"
 
 mockito-core="org.mockito:mockito-core:5.23.0"


### PR DESCRIPTION
 This PR fixes mux-level CBOR framing so inbound mini-protocol payloads are split by scanning CBOR byte boundaries instead of decode/re-encoding through cbor-java.

###   Key changes:

  - Adds CborByteScanner for byte-preserving CBOR item boundary detection.
  - Updates MiniProtoStreamingByteToMessageDecoder to emit original payload bytes unchanged.
  - Preserves indefinite-length CBOR encodings such as BF FF.
  - Removes the small default incomplete-buffer cap so large LocalStateQuery responses are not rejected.
  - Rejects unregistered mux protocol ids.
  - Improves write failure handling in Agent.
  - Adds jqwik property tests for mux segmentation, protocol interleaving, float/simple values, and malformed CBOR close behavior.
  - Adds mux CBOR scanning documentation.

  **Validation:**

  - ./gradlew :core:test
  - focused mux property tests
  - preprod sync completed successfully
