### PR TITLE
feat(txsubmission): allow listeners to filter tx body requests

### DIFF
--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionListener.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionListener.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.ReplyTxIds;
 import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.ReplyTxs;
 import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.RequestTxIds;
 import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.RequestTxs;
+import com.bloxbean.cardano.yaci.core.protocol.txsubmission.messges.TxId;
 
 public interface TxSubmissionListener extends AgentListener {
     // Client-side methods (for handling requests from server)
@@ -15,6 +16,10 @@ public interface TxSubmissionListener extends AgentListener {
     // Server-side methods (for handling replies from client)
     default void handleReplyTxIds(ReplyTxIds replyTxIds) {
         // Default empty implementation for backward compatibility
+    }
+
+    default boolean shouldRequestTx(TxId txId, int size) {
+        return true;
     }
     
     default void handleReplyTxs(ReplyTxs replyTxs) {

--- a/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgent.java
+++ b/core/src/main/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgent.java
@@ -135,18 +135,25 @@ public class TxSubmissionServerAgent extends Agent<TxSubmissionListener> {
             return;
         }
 
-        // Add transaction IDs to FIFO queue
+        // Notify listeners first so they can plan which announced ids should be fetched.
+        getAgentListeners().forEach(listener -> listener.handleReplyTxIds(replyTxIds));
+
+        // Add transaction IDs accepted by listeners to FIFO queue.
         replyTxIds.getTxIdAndSizeMap().forEach((txId, size) -> {
             String txIdStr = txId.toString();
-            if (!seenTxIds.contains(txIdStr)) {
+            if (seenTxIds.contains(txIdStr)) {
+                return;
+            }
+            seenTxIds.add(txIdStr);
+            boolean shouldRequest = getAgentListeners().stream()
+                    .allMatch(listener -> listener.shouldRequestTx(txId, size));
+            if (shouldRequest) {
                 outstandingTxIds.offer(txId);
-                seenTxIds.add(txIdStr);
                 log.debug("Added tx ID to queue: {} (size: {} bytes)", txId, size);
+            } else {
+                log.debug("Skipped tx ID by listener policy: {} (size: {} bytes)", txId, size);
             }
         });
-
-        // Notify listeners
-        getAgentListeners().forEach(listener -> listener.handleReplyTxIds(replyTxIds));
 
         // Request the actual transaction bodies
         if (!outstandingTxIds.isEmpty()) {

--- a/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgentTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/yaci/core/protocol/txsubmission/TxSubmissionServerAgentTest.java
@@ -201,6 +201,50 @@ class TxSubmissionServerAgentTest {
     }
 
     @Test
+    void testListenerCanFilterRequestedTxBodies() {
+        agent.receiveResponse(new Init());
+        agent.buildNextMessage();
+
+        ReplyTxIds replyTxIds = new ReplyTxIds();
+        TxId txId1 = new TxId(com.bloxbean.cardano.yaci.core.protocol.localstate.api.Era.Conway, "tx1".getBytes());
+        TxId txId2 = new TxId(com.bloxbean.cardano.yaci.core.protocol.localstate.api.Era.Conway, "tx2".getBytes());
+        TxId txId3 = new TxId(com.bloxbean.cardano.yaci.core.protocol.localstate.api.Era.Conway, "tx3".getBytes());
+        replyTxIds.addTxId(txId1, 100);
+        replyTxIds.addTxId(txId2, 200);
+        replyTxIds.addTxId(txId3, 300);
+
+        agent.addListener(new TxSubmissionListener() {
+            @Override
+            public void handleRequestTxs(RequestTxs requestTxs) {}
+
+            @Override
+            public void handleRequestTxIdsNonBlocking(RequestTxIds requestTxIds) {}
+
+            @Override
+            public void handleRequestTxIdsBlocking(RequestTxIds requestTxIds) {}
+
+            @Override
+            public boolean shouldRequestTx(TxId txId, int size) {
+                return !txId.equals(txId2);
+            }
+        });
+
+        agent.receiveResponse(replyTxIds);
+
+        var message = agent.buildNextMessage();
+        assertNotNull(message);
+        assertInstanceOf(RequestTxs.class, message);
+
+        RequestTxs requestTxs = (RequestTxs) message;
+        assertEquals(2, requestTxs.getTxIds().size());
+        assertTrue(requestTxs.getTxIds().contains(txId1));
+        assertFalse(requestTxs.getTxIds().contains(txId2));
+        assertTrue(requestTxs.getTxIds().contains(txId3));
+        assertEquals(3, agent.getReceivedTxIdCount());
+        assertEquals(2, agent.getOutstandingTxCount());
+    }
+
+    @Test
     void testCannotRequestInWrongState() {
         // In Init state, server doesn't have agency
         assertFalse(agent.hasAgency());


### PR DESCRIPTION
 ## Summary
  - Add `TxSubmissionListener.shouldRequestTx(TxId, int)` with a default `true` implementation.
  - Let `TxSubmissionServerAgent` notify listeners of announced tx IDs before queueing body requests.
  - Queue only tx IDs accepted by listener policy, while still marking all announced IDs as seen.
  - Add regression coverage for listener-filtered body requests.

  ## Why
  Yano tx diffusion needs to plan inbound tx body requests before Yaci asks peers for bodies. Without this hook, skipped tx IDs can still be requested as bodies and later appear as ignored bodies in Yano metrics.
