### PR TITLE
feat(helper): app-chain sync (103) on the shared peer connection

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.bloxbean.cardano
 artifactId = yaci
-version = 0.5.0-pre12-SNAPSHOT
+version = 0.5.0-pre12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.bloxbean.cardano
 artifactId = yaci
-version = 0.5.0-pre11
+version = 0.5.0-pre12-SNAPSHOT

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/AppProtocolManager.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/AppProtocolManager.java
@@ -76,6 +76,18 @@ public class AppProtocolManager {
         this.appChainSyncEnabled = true;
     }
 
+    /**
+     * Adopt an EXISTING app-chain sync agent (listeners and all) — used when a
+     * manager is replaced (e.g. {@code PeerClient.enableAppMsg(config)}) so
+     * references and listeners registered through {@link #getAppChainSyncAgent()}
+     * before the replacement stay valid.
+     */
+    void adoptAppChainSyncAgent(AppChainSyncClientAgent agent) {
+        if (agent == null) return;
+        this.appChainSyncAgent = agent;
+        this.appChainSyncEnabled = true;
+    }
+
     public boolean isAppChainSyncEnabled() {
         return appChainSyncEnabled;
     }
@@ -141,16 +153,27 @@ public class AppProtocolManager {
     public void onHandshakeComplete(AcceptVersion acceptVersion) {
         if (acceptVersion == null) return;
         if (!appMsgEnabled && !appChainSyncEnabled) return;  // caller didn't enable anything
-        if (!N2NVersionTableConstant.isAppLayerVersion(acceptVersion.getVersionNumber())) {
+        // Assign (not just set) on EVERY handshake: a reconnection that
+        // renegotiates a non-app-layer version must clear the gate.
+        appLayerNegotiated =
+                N2NVersionTableConstant.isAppLayerVersion(acceptVersion.getVersionNumber());
+        if (!appLayerNegotiated) {
             log.info("Peer negotiated V{} — app-layer protocols not activated",
                     acceptVersion.getVersionNumber());
             return;
         }
-        appLayerNegotiated = true;
         if (appMsgEnabled)
             activateAppMsgSubmission();
         // AppChainSync (103) needs no activation: it is request-driven and
         // only sends when the caller invokes requestRange().
+    }
+
+    /**
+     * Connection dropped: the app-layer gate closes until the NEXT handshake
+     * completes with an app-layer version. Called by the connection owner.
+     */
+    public void onDisconnected() {
+        appLayerNegotiated = false;
     }
 
     private void activateAppMsgSubmission() {

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/AppProtocolManager.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/AppProtocolManager.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yaci.helper;
 
 import com.bloxbean.cardano.yaci.core.protocol.Agent;
+import com.bloxbean.cardano.yaci.core.protocol.appchainsync.AppChainSyncClientAgent;
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.AppMsgSubmissionAgent;
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.AppMsgSubmissionConfig;
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.AppMsgSubmissionListener;
@@ -8,13 +9,18 @@ import com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion;
 import com.bloxbean.cardano.yaci.core.protocol.handshake.util.N2NVersionTableConstant;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Manages app-layer protocols (Protocol 100+) for a peer connection.
- * Callers signal intent via {@link #enableAppMsg()}; the agent is added to a
- * connection only when enabled and activated only when the peer negotiates V100.
+ * Callers signal intent via {@link #enableAppMsg()} and/or
+ * {@link #enableAppChainSync()}; an agent is added to a connection only when
+ * its protocol is enabled, and app-layer traffic flows only when the peer
+ * negotiates an app-layer handshake version (V100+). The app-chain sync
+ * client (protocol 103) is fully request-driven, so enabling it just rides
+ * the agent on the connection — callers gate their requests on
+ * {@link #isAppLayerNegotiated()}.
  */
 @Slf4j
 public class AppProtocolManager {
@@ -22,6 +28,9 @@ public class AppProtocolManager {
     private final AppMsgSubmissionAgent appMsgAgent;
     private boolean appMsgEnabled = false;
     private boolean listenersSetup = false;
+    private AppChainSyncClientAgent appChainSyncAgent;
+    private boolean appChainSyncEnabled = false;
+    private volatile boolean appLayerNegotiated = false;
 
     public AppProtocolManager() {
         this(AppMsgSubmissionConfig.createDefault());
@@ -57,13 +66,44 @@ public class AppProtocolManager {
     }
 
     /**
+     * Signal intent to use the AppChainSync protocol (103, finalized app-block
+     * range fetch). The agent rides the connection when enabled; it sends
+     * nothing until {@link AppChainSyncClientAgent#requestRange} is called.
+     */
+    public void enableAppChainSync() {
+        if (appChainSyncAgent == null)
+            appChainSyncAgent = new AppChainSyncClientAgent();
+        this.appChainSyncEnabled = true;
+    }
+
+    public boolean isAppChainSyncEnabled() {
+        return appChainSyncEnabled;
+    }
+
+    /** Null until {@link #enableAppChainSync()} is called. */
+    public AppChainSyncClientAgent getAppChainSyncAgent() {
+        return appChainSyncAgent;
+    }
+
+    /**
+     * True once the handshake completed with an app-layer version (V100+).
+     * Callers should gate app-chain sync requests on this.
+     */
+    public boolean isAppLayerNegotiated() {
+        return appLayerNegotiated;
+    }
+
+    /**
      * Get app agents to include in the connection agent list.
-     * Returns an empty list unless app messaging is explicitly enabled.
+     * Returns an empty list unless at least one app protocol is enabled.
      */
     public List<Agent<?>> getAgents() {
-        if (!appMsgEnabled)
-            return Collections.emptyList();
-        return List.of(appMsgAgent);
+        List<Agent<?>> agents = new ArrayList<>(2);
+        if (appMsgEnabled)
+            agents.add(appMsgAgent);
+        if (appChainSyncEnabled)
+            agents.add(appChainSyncAgent);
+        return agents;
     }
 
     /**
@@ -94,19 +134,23 @@ public class AppProtocolManager {
 
     /**
      * Enable app protocols if the negotiated version supports them AND
-     * the caller has signalled intent via {@link #enableAppMsg()}.
-     * Called after handshake completes.
+     * the caller has signalled intent via {@link #enableAppMsg()} /
+     * {@link #enableAppChainSync()}. Called after handshake completes.
      * @param acceptVersion the negotiated version from handshake
      */
     public void onHandshakeComplete(AcceptVersion acceptVersion) {
-        if (!appMsgEnabled) return;  // caller didn't enable it
         if (acceptVersion == null) return;
+        if (!appMsgEnabled && !appChainSyncEnabled) return;  // caller didn't enable anything
         if (!N2NVersionTableConstant.isAppLayerVersion(acceptVersion.getVersionNumber())) {
             log.info("Peer negotiated V{} — app-layer protocols not activated",
                     acceptVersion.getVersionNumber());
             return;
         }
-        activateAppMsgSubmission();
+        appLayerNegotiated = true;
+        if (appMsgEnabled)
+            activateAppMsgSubmission();
+        // AppChainSync (103) needs no activation: it is request-driven and
+        // only sends when the caller invokes requestRange().
     }
 
     private void activateAppMsgSubmission() {

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
@@ -183,10 +183,10 @@ public class N2NPeerFetcher implements Fetcher<Block> {
     }
 
     private void validateAppProtocolConfiguration() {
-        if (appProtocolManager.isAppMsgEnabled()
+        if ((appProtocolManager.isAppMsgEnabled() || appProtocolManager.isAppChainSyncEnabled())
                 && !N2NVersionTableConstant.hasAppLayerVersion(versionTable)) {
             throw new IllegalStateException(
-                    "App message protocol requires a version table with app-layer V100 support");
+                    "App-layer protocols require a version table with app-layer V100 support");
         }
 //        n2nClient = new TCPNodeClient(host, port, nodeClientConfig, handshakeAgent, keepAliveAgent,
 //                chainSyncAgent, blockFetchAgent, txSubmissionAgent);
@@ -600,6 +600,15 @@ public class N2NPeerFetcher implements Fetcher<Block> {
 
         this.versionTable = N2NVersionTableConstant.withAppLayer(versionTable);
         appProtocolManager.enableAppMsg();
+    }
+
+    /** Enable the app-chain sync protocol (103). Must be called before start(). */
+    public void enableAppChainSync() {
+        if (n2nClient != null)
+            throw new IllegalStateException("App chain sync protocol must be enabled before start()");
+
+        this.versionTable = N2NVersionTableConstant.withAppLayer(versionTable);
+        appProtocolManager.enableAppChainSync();
     }
 
     /**

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/N2NPeerFetcher.java
@@ -255,6 +255,8 @@ public class N2NPeerFetcher implements Fetcher<Block> {
                 log.info("ChainSync agent disconnected - resetting handshake flag");
                 // Notify agent about connection loss for reconnection preparation
                 chainSyncAgent.onConnectionLost();
+                // App-layer gate closes until the next handshake renegotiates it
+                appProtocolManager.onDisconnected();
                 // Reset firstTimeHandshake to false so that on reconnection
                 // we know it's a reconnection and not the first connection
                 firstTimeHandshake = false;

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
@@ -236,13 +236,15 @@ public class PeerClient {
             throw new IllegalStateException("App message protocol must be enabled before connect()");
 
         // Replacing the manager must not silently drop an already-enabled
-        // app-chain sync protocol (call-order independence).
-        boolean appChainSyncEnabled = appProtocolManager.isAppChainSyncEnabled();
+        // app-chain sync protocol — the AGENT INSTANCE is carried over, so
+        // listeners/references obtained via getAppChainSyncAgent() before this
+        // call stay valid (true call-order independence).
+        var existingSyncAgent = appProtocolManager.isAppChainSyncEnabled()
+                ? appProtocolManager.getAppChainSyncAgent() : null;
         this.appProtocolManager = new AppProtocolManager(appMsgConfig);
         this.versionTable = N2NVersionTableConstant.withAppLayer(versionTable);
         appProtocolManager.enableAppMsg();
-        if (appChainSyncEnabled)
-            appProtocolManager.enableAppChainSync();
+        appProtocolManager.adoptAppChainSyncAgent(existingSyncAgent);
     }
 
     /**

--- a/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
+++ b/helper/src/main/java/com/bloxbean/cardano/yaci/helper/PeerClient.java
@@ -235,9 +235,29 @@ public class PeerClient {
         if (n2NPeerFetcher != null)
             throw new IllegalStateException("App message protocol must be enabled before connect()");
 
+        // Replacing the manager must not silently drop an already-enabled
+        // app-chain sync protocol (call-order independence).
+        boolean appChainSyncEnabled = appProtocolManager.isAppChainSyncEnabled();
         this.appProtocolManager = new AppProtocolManager(appMsgConfig);
         this.versionTable = N2NVersionTableConstant.withAppLayer(versionTable);
         appProtocolManager.enableAppMsg();
+        if (appChainSyncEnabled)
+            appProtocolManager.enableAppChainSync();
+    }
+
+    /**
+     * Enable the app-chain sync protocol (103, finalized app-block range
+     * fetch). Must be called before connect(). The agent is request-driven:
+     * nothing is sent until {@code getAppProtocolManager()
+     * .getAppChainSyncAgent().requestRange(...)} is invoked, and callers
+     * should gate requests on the manager's {@code isAppLayerNegotiated()}.
+     */
+    public void enableAppChainSync() {
+        if (n2NPeerFetcher != null)
+            throw new IllegalStateException("App chain sync protocol must be enabled before connect()");
+
+        this.versionTable = N2NVersionTableConstant.withAppLayer(versionTable);
+        appProtocolManager.enableAppChainSync();
     }
 
     /**

--- a/helper/src/test/java/com/bloxbean/cardano/yaci/helper/AppProtocolManagerTest.java
+++ b/helper/src/test/java/com/bloxbean/cardano/yaci/helper/AppProtocolManagerTest.java
@@ -138,6 +138,33 @@ class AppProtocolManagerTest {
     }
 
     @Test
+    void renegotiatingNonAppLayerVersionClearsTheGate() {
+        // Reconnection that downgrades below V100 must close the gate
+        AppProtocolManager manager = new AppProtocolManager();
+        manager.enableAppChainSync();
+
+        manager.onHandshakeComplete(acceptVersion(100));
+        assertThat(manager.isAppLayerNegotiated()).isTrue();
+
+        manager.onHandshakeComplete(acceptVersion(11));
+        assertThat(manager.isAppLayerNegotiated()).isFalse();
+    }
+
+    @Test
+    void disconnectClosesTheGateUntilNextHandshake() {
+        AppProtocolManager manager = new AppProtocolManager();
+        manager.enableAppChainSync();
+        manager.onHandshakeComplete(acceptVersion(100));
+        assertThat(manager.isAppLayerNegotiated()).isTrue();
+
+        manager.onDisconnected();
+        assertThat(manager.isAppLayerNegotiated()).isFalse();
+
+        manager.onHandshakeComplete(acceptVersion(100));
+        assertThat(manager.isAppLayerNegotiated()).isTrue();
+    }
+
+    @Test
     void enableAppMsgWithConfigPreservesEnabledAppChainSync() {
         // enableAppMsg(config) replaces the manager — an earlier
         // enableAppChainSync() must survive (call-order independence)
@@ -150,6 +177,21 @@ class AppProtocolManagerTest {
         assertThat(peerClient.getAppProtocolManager().isAppMsgEnabled()).isTrue();
         assertThat(peerClient.getAppProtocolManager().isAppChainSyncEnabled()).isTrue();
         assertThat(peerClient.getAppProtocolManager().getAgents()).hasSize(2);
+    }
+
+    @Test
+    void enableAppMsgWithConfigPreservesSyncAgentIdentity() {
+        // Listeners/references obtained BEFORE the manager replacement must
+        // stay valid — the agent INSTANCE is adopted, not recreated.
+        PeerClient peerClient = new PeerClient("localhost", 1, 42, Point.ORIGIN);
+        peerClient.enableAppChainSync();
+        var agentBefore = peerClient.getAppProtocolManager().getAppChainSyncAgent();
+
+        peerClient.enableAppMsg(
+                com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.AppMsgSubmissionConfig.createDefault());
+
+        assertThat(peerClient.getAppProtocolManager().getAppChainSyncAgent())
+                .isSameAs(agentBefore);
     }
 
     @Test

--- a/helper/src/test/java/com/bloxbean/cardano/yaci/helper/AppProtocolManagerTest.java
+++ b/helper/src/test/java/com/bloxbean/cardano/yaci/helper/AppProtocolManagerTest.java
@@ -61,4 +61,109 @@ class AppProtocolManagerTest {
 
         assertThat(fetcher.getAppProtocolManager().isAppMsgEnabled()).isTrue();
     }
+
+    @Test
+    void appChainSyncAgentIsNullUntilEnabled() {
+        AppProtocolManager manager = new AppProtocolManager();
+
+        assertThat(manager.isAppChainSyncEnabled()).isFalse();
+        assertThat(manager.getAppChainSyncAgent()).isNull();
+        assertThat(manager.getAgents()).isEmpty();
+    }
+
+    @Test
+    void enableAppChainSyncExposesSyncAgent() {
+        AppProtocolManager manager = new AppProtocolManager();
+
+        manager.enableAppChainSync();
+
+        assertThat(manager.isAppChainSyncEnabled()).isTrue();
+        assertThat(manager.getAppChainSyncAgent()).isNotNull();
+        assertThat(manager.getAppChainSyncAgent().getProtocolId()).isEqualTo(103);
+        assertThat(manager.getAgents()).containsExactly(manager.getAppChainSyncAgent());
+    }
+
+    @Test
+    void bothProtocolsEnabledRideTheSameConnection() {
+        AppProtocolManager manager = new AppProtocolManager();
+
+        manager.enableAppMsg();
+        manager.enableAppChainSync();
+
+        assertThat(manager.getAgents()).containsExactly(
+                manager.getAppMsgSubmissionAgent(),
+                manager.getAppChainSyncAgent());
+    }
+
+    @Test
+    void enabledAppChainSyncRequiresAppLayerVersionTable() {
+        AppProtocolManager manager = new AppProtocolManager();
+        manager.enableAppChainSync();
+
+        assertThatThrownBy(() -> new N2NPeerFetcher(
+                "localhost",
+                1,
+                Point.ORIGIN,
+                N2NVersionTableConstant.v11AndAbove(42),
+                manager))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("V100");
+    }
+
+    @Test
+    void enableAppChainSyncOnFetcherAddsAppLayerVersion() {
+        N2NPeerFetcher fetcher = new N2NPeerFetcher(
+                "localhost",
+                1,
+                Point.ORIGIN,
+                N2NVersionTableConstant.v11AndAbove(42));
+
+        fetcher.enableAppChainSync();
+
+        assertThat(fetcher.getAppProtocolManager().isAppChainSyncEnabled()).isTrue();
+    }
+
+    @Test
+    void appLayerNegotiatedOnlyAfterV100Handshake() {
+        AppProtocolManager manager = new AppProtocolManager();
+        manager.enableAppChainSync();
+
+        assertThat(manager.isAppLayerNegotiated()).isFalse();
+
+        manager.onHandshakeComplete(acceptVersion(11));
+        assertThat(manager.isAppLayerNegotiated()).isFalse();
+
+        manager.onHandshakeComplete(acceptVersion(100));
+        assertThat(manager.isAppLayerNegotiated()).isTrue();
+    }
+
+    @Test
+    void enableAppMsgWithConfigPreservesEnabledAppChainSync() {
+        // enableAppMsg(config) replaces the manager — an earlier
+        // enableAppChainSync() must survive (call-order independence)
+        PeerClient peerClient = new PeerClient("localhost", 1, 42, Point.ORIGIN);
+
+        peerClient.enableAppChainSync();
+        peerClient.enableAppMsg(
+                com.bloxbean.cardano.yaci.core.protocol.appmsg.n2n.AppMsgSubmissionConfig.createDefault());
+
+        assertThat(peerClient.getAppProtocolManager().isAppMsgEnabled()).isTrue();
+        assertThat(peerClient.getAppProtocolManager().isAppChainSyncEnabled()).isTrue();
+        assertThat(peerClient.getAppProtocolManager().getAgents()).hasSize(2);
+    }
+
+    @Test
+    void handshakeWithNothingEnabledDoesNotMarkNegotiated() {
+        AppProtocolManager manager = new AppProtocolManager();
+
+        manager.onHandshakeComplete(acceptVersion(100));
+
+        assertThat(manager.isAppLayerNegotiated()).isFalse();
+    }
+
+    private static com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion acceptVersion(long version) {
+        return new com.bloxbean.cardano.yaci.core.protocol.handshake.messages.AcceptVersion(
+                version, N2NVersionTableConstant.v11AndAbove(42).getVersionDataMap()
+                        .values().iterator().next());
+    }
 }


### PR DESCRIPTION
## What

`AppProtocolManager` gains the **AppChainSync client agent (protocol 103)** alongside appmsg (100), so a single N2N connection can carry L1 mini-protocols + app-message diffusion + app-block catch-up:

- `enableAppChainSync()` on `AppProtocolManager`, `PeerClient` and `N2NPeerFetcher` — symmetric with `enableAppMsg`, pre-connect only, upgrades the handshake table to app-layer versions
- `getAgents()` contributes both agents when enabled; the 103 agent is request-driven (nothing is sent until `requestRange`), so no handshake activation is needed
- `isAppLayerNegotiated()` lets callers gate catch-up requests on the negotiated version
- `PeerClient.enableAppMsg(config)` no longer drops an already-enabled app-chain sync when it replaces the manager (call-order independence)
- the V100 version-table guard now covers either enabled app protocol

## Why

Downstream (Yano) unifies the app-chain transport with the L1 peer session — **one TCP connection per peer pair** instead of a dedicated app dial next to the L1 session. The appmsg (100) seam already existed; catch-up (103) was the missing piece.

## Testing

- 12 unit tests in `AppProtocolManagerTest`: enable combinations, agent exposure, version-table guards, negotiation flag, call-order preservation
- Consumed downstream by Yano's shared-transport devnet gate (12/12): single connection, diffusion, 103 catch-up, fallback recovery — all over one session

🤖 Generated with [Claude Code](https://claude.com/claude-code)